### PR TITLE
fix(ui, repo): resolve typescript svg import error

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,6 @@
 	"css.validate": false,
 	"editor.quickSuggestions": {
 		"strings": true
-	}
+  },
+  "typescript.tsdk": "node_modules/typescript/lib"
 }

--- a/packages/ui/icons/index.ts
+++ b/packages/ui/icons/index.ts
@@ -9,7 +9,6 @@ import SearchIcon from "./search.svg";
 import NextIcon from "./nextarrow.svg";
 import UrlIcon from "./url.svg";
 import CanvasIcon from "./canvas.svg";
-import blockIcon from "./block.svg";
 import LinkIcon from "./link.svg";
 import AutocompleteIcon from "./autocomplete.svg";
 import BlockIcon from "./block.svg";
@@ -29,7 +28,6 @@ export {
 	NextIcon,
 	UrlIcon,
 	CanvasIcon,
-	blockIcon,
 	LinkIcon,
 	AutocompleteIcon,
 	BlockIcon,

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -4,5 +4,5 @@
 		"outDir": "dist"
 	},
 	"exclude": ["node_modules", "dist"],
-	"include": ["shadcn", "icons", "hooks", "components"]
+	"include": ["shadcn", "icons", "hooks", "components", "types.d.ts"]
 }

--- a/packages/ui/tsconfig.lint.json
+++ b/packages/ui/tsconfig.lint.json
@@ -4,5 +4,5 @@
 		"outDir": "dist"
 	},
 	"exclude": ["node_modules", "dist"],
-	"include": ["shadcn", "icons", "hooks", "components"]
+	"include": ["shadcn", "icons", "hooks", "components", "types.d.ts"]
 }

--- a/packages/ui/types.d.ts
+++ b/packages/ui/types.d.ts
@@ -1,0 +1,4 @@
+declare module "*.svg" {
+  const content: React.FunctionComponent<React.SVGAttributes<SVGElement>>;
+  export default content;
+}


### PR DESCRIPTION
# fix(ui, repo): resolve typescript svg import error

## Overview
This pull request addresses a TypeScript import error related to SVG files in the UI package. The issue was caused by the inability to find the corresponding type declarations for the SVG imports.

## Changes
- Key Changes:
  - Updated the `.vscode/settings.json` file to use the TypeScript SDK from the project's `node_modules` directory instead of the global VSCode installation.
  - Added a `types.d.ts` file in the `ui` package to provide type declarations for SVG imports.
- Refactoring:
  - Removed the unused `blockIcon` import from the `ui/icons/index.ts` file.

## Impact
This change should resolve the TypeScript import error for SVG files in the UI package, allowing the project to build and run without issues related to missing type declarations.

> ✨ Generated with love by Kaizen ❤️


<details>
<summary>Original Description</summary>
resolve typescript svg import error `Cannot find module './add.svg' or its corresponding type declarations.`
use ts from workspace instead of vscode
</details>

