### PR TITLE
fix(web): history a11y and mobile issues

### DIFF
--- a/apps/web/app/(dash)/header/header.tsx
+++ b/apps/web/app/(dash)/header/header.tsx
@@ -6,6 +6,7 @@ import Logo from "../../../public/logo.svg";
 import { getChatHistory } from "../../actions/fetchers";
 import NewChatButton from "./newChatButton";
 import AutoBreadCrumbs from "./autoBreadCrumbs";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@repo/ui/shadcn/dropdown-menu";
 
 async function Header() {
 	const chatThreads = await getChatHistory();
@@ -32,26 +33,23 @@ async function Header() {
 				<div className="flex items-center gap-2">
 					<NewChatButton />
 
-					<div className="relative group">
-						<button className="flex duration-200 items-center text-[#7D8994] hover:bg-[#1F2429] text-[13px] gap-2 px-3 py-2 rounded-xl">
-							History
-						</button>
-
-						<div className="absolute p-4 hidden group-hover:block right-0 w-full md:w-[400px] max-h-[70vh] overflow-auto">
-							<div className="bg-[#1F2429] rounded-xl p-2 flex flex-col shadow-lg">
-								{chatThreads.data.map((thread) => (
+					<DropdownMenu>
+						<DropdownMenuTrigger>History</DropdownMenuTrigger>
+						<DropdownMenuContent className="p-4 w-full md:w-[400px] max-h-[70vh] overflow-auto border-none">
+							{chatThreads.data.map((thread) => (
+								<DropdownMenuItem asChild>
 									<Link
 										prefetch={false}
 										href={`/chat/${thread.id}`}
 										key={thread.id}
-										className="p-2 rounded-md hover:bg-secondary"
+										className="p-2 rounded-md cursor-pointer focus:bg-secondary focus:text-current"
 									>
 										{thread.firstMessage}
 									</Link>
-								))}
-							</div>
-						</div>
-					</div>
+								</DropdownMenuItem>
+							))}
+						</DropdownMenuContent>
+					</DropdownMenu>
 				</div>
 			</div>
 		</div>

--- a/apps/web/app/(dash)/header/header.tsx
+++ b/apps/web/app/(dash)/header/header.tsx
@@ -7,6 +7,7 @@ import { getChatHistory } from "../../actions/fetchers";
 import NewChatButton from "./newChatButton";
 import AutoBreadCrumbs from "./autoBreadCrumbs";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@repo/ui/shadcn/dropdown-menu";
+import { CaretDownIcon } from "@radix-ui/react-icons";
 
 async function Header() {
 	const chatThreads = await getChatHistory();
@@ -34,7 +35,10 @@ async function Header() {
 					<NewChatButton />
 
 					<DropdownMenu>
-						<DropdownMenuTrigger>History</DropdownMenuTrigger>
+						<DropdownMenuTrigger className="inline-flex flex-row flex-nowrap items-center text-muted-foreground hover:text-foreground">
+              History
+              <CaretDownIcon />
+            </DropdownMenuTrigger>
 						<DropdownMenuContent className="p-4 w-full md:w-[400px] max-h-[70vh] overflow-auto border-none">
 							{chatThreads.data.map((thread) => (
 								<DropdownMenuItem asChild>


### PR DESCRIPTION
# Fix: History Dropdown Accessibility and Mobile Issues

## Overview
This pull request improves the accessibility and mobile responsiveness of the history dropdown in the web application's header.

## Changes
- **Key Changes:**
    - Replaced the custom history dropdown implementation with the `@repo/ui/shadcn/dropdown-menu` component for improved accessibility and consistency.
    - Added `CaretDownIcon` from `@radix-ui/react-icons` to visually indicate the dropdown.
    - Updated styling and layout for better mobile responsiveness.
- **New Features:**
    - None
- **Refactoring:**
    - Replaced custom dropdown with a standardized component.

> ✨ Generated with love by Kaizen ❤️


<details>
<summary>Original Description</summary>
# Fix: History Dropdown Accessibility and Mobile Issues

## Overview
This pull request addresses accessibility and mobile UI issues with the history dropdown in the web application's header.

## Changes
- **Key Changes:**
    - Replaced the custom history dropdown implementation with the `@repo/ui/shadcn/dropdown-menu` component for improved accessibility and consistency.
    - Added `CaretDownIcon` from `@radix-ui/react-icons` to visually indicate the dropdown.
    - Updated styling and layout for better mobile responsiveness.
- **New Features:**
    - None
- **Refactoring:**
    - Replaced custom dropdown with a standardized component.

> ✨ Generated with love by Kaizen ❤️


before
![Screenshot 2024-07-23 at 8 41 15 AM](https://github.com/user-attachments/assets/1f3cf7ac-96a5-4daa-8b25-324dca3357b5)

after
![Screenshot 2024-07-23 at 8 41 35 AM](https://github.com/user-attachments/assets/a303c00a-2c72-4e7f-a8dc-67e5e1ac83c9)

<details>
<summary>Original Description</summary>
History dropdown was not complying with a11y. There were UI issues on mobile


</details>


</details>

