### PR TITLE
Fix Spaces Breadcrumb

### DIFF
--- a/apps/web/app/(dash)/(memories)/content.tsx
+++ b/apps/web/app/(dash)/(memories)/content.tsx
@@ -33,6 +33,7 @@ import { addUserToSpace, deleteItem, moveItem } from "@/app/actions/doers";
 import { toast } from "sonner";
 import { Input } from "@repo/ui/shadcn/input";
 import { motion } from "framer-motion";
+import { useSearchParams } from "next/navigation";
 
 export function MemoriesPage({
 	memoriesAndSpaces,
@@ -45,7 +46,19 @@ export function MemoriesPage({
 	currentSpace?: StoredSpace;
 	usersWithAccess?: string[];
 }) {
-	const [filter, setFilter] = useState("All");
+	const searchParams = useSearchParams();
+
+	const tab = searchParams.get("tab");
+
+	const initialFilter = useMemo(() => {
+		if (tab === "spaces") return "Spaces";
+		if (tab === "pages") return "Pages";
+		if (tab === "notes") return "Notes";
+		if (tab === "tweet") return "Tweet";
+		return "All";
+	}, [tab]);
+
+	const [filter, setFilter] = useState(initialFilter);
 
 	// Sort Both memories and spaces by their savedAt and createdAt dates respectfully.
 	// The output should be just one single list of items

--- a/apps/web/app/(dash)/header/autoBreadCrumbs.tsx
+++ b/apps/web/app/(dash)/header/autoBreadCrumbs.tsx
@@ -27,16 +27,23 @@ function AutoBreadCrumbs() {
 				{pathname
 					.split("/")
 					.filter(Boolean)
-					.map((path, idx, paths) => (
-						<>
-							<BreadcrumbItem key={path + idx}>
-								<BreadcrumbLink href={`/${paths.slice(0, idx + 1).join("/")}`}>
-									{path.charAt(0).toUpperCase() + path.slice(1)}
-								</BreadcrumbLink>
-							</BreadcrumbItem>
-							<BreadcrumbSeparator hidden={idx === paths.length - 1} />
-						</>
-					))}
+					.map((path, idx, paths) => {
+						const isSpacePath = path === "space";
+						const href = isSpacePath
+							? `/memories?tab=spaces`
+							: `/${paths.slice(0, idx + 1).join("/")}`;
+
+						return (
+							<React.Fragment key={path + idx}>
+								<BreadcrumbItem>
+									<BreadcrumbLink href={href}>
+										{path.charAt(0).toUpperCase() + path.slice(1)}
+									</BreadcrumbLink>
+								</BreadcrumbItem>
+								<BreadcrumbSeparator hidden={idx === paths.length - 1} />
+							</React.Fragment>
+						);
+					})}
 			</BreadcrumbList>
 		</Breadcrumb>
 	);


### PR DESCRIPTION
# Fix Spaces Breadcrumb

## Overview
This pull request addresses issue #148 by enhancing the `autoBreadcrumb` component to improve navigation for users accessing the "spaces" section of the application. It modifies the breadcrumb behavior to ensure that clicking on the "space" breadcrumb redirects users to the appropriate memories view.

## Changes
- Key Changes:
  - Updated the `autoBreadcrumb` component to manually override the href for the "space" breadcrumb, directing users to `/memories?tab=spaces`.
  - Implemented the use of the `next/navigation` package in the `MemoriesPage` to fetch query parameters and set the initial filter state based on the `tab` parameter.

- New Features:
  - Users can now click on the "space" breadcrumb to directly view their spaces, enhancing the user experience by eliminating an extra navigation step.

- Refactoring:
  - Introduced a `useMemo` hook to determine the initial filter state based on the `tab` query parameter, improving performance by avoiding unnecessary recalculations.
  - Refactored the breadcrumb mapping logic to streamline the href assignment and improve readability.

> ✨ Generated with love by Kaizen ❤️


<details>
<summary>Original Description</summary>
Fixes https://github.com/supermemoryai/supermemory/issues/148

This PR updates the autoBreadcrumb component. It manually overrides the href if the pathname is `/space`. It will set the middle breadcrumb, the one that says "space" to `/memories?tab=spaces`

In the MemoriesPage file, it uses the next/navigation package to fetch the query parameters. If the `tab` parameter is present, it will update the `filter` state to automatically use that one.

This allows the user to click on the breadcrumb to view their spaces, and automatically view them instead of having to click the `Spaces` option.
</details>

