### PR TITLE
Update line of memories to not overflow

### DIFF
--- a/apps/web/app/(dash)/(memories)/content.tsx
+++ b/apps/web/app/(dash)/(memories)/content.tsx
@@ -312,7 +312,7 @@ function LinkComponent({
 						<div className="text-lg text-[#fff] mt-4 line-clamp-2">
 							{title.replace(/(<---chunkId: .*?\n.*?\n---->)/g, "")}
 						</div>
-						<div className="line-clamp-3 mt-2">
+						<div className="truncate line-clamp-3 mt-2">
 							{content.replace(title, "")}
 						</div>
 					</>


### PR DESCRIPTION
# Update line of memories to not overflow

## Overview
This pull request addresses an issue where the link of a note in the "Memories" section was overflowing and not being properly formatted, unlike the formatting for the pages. The goal is to ensure consistent formatting and prevent the link from overflowing.

## Changes
- Key Changes: Added the `truncate` class from Tailwind CSS to the link component in the `content.tsx` file, which applies the following styles to handle overflow:
  - `overflow: hidden;`
  - `text-overflow: ellipsis;`
  - `white-space: nowrap;`
- Refactoring: No major refactoring changes were made, the fix was a targeted update to the existing code.

> ✨ Generated with love by Kaizen ❤️


<details>
<summary>Original Description</summary>
# Update line of memories to not overflow

## Overview
This pull request addresses an issue where the link of a note in the "Memories" section was overflowing and not being properly formatted, unlike the formatting for the pages. The goal is to ensure consistent formatting and prevent the link from overflowing.

## Changes
- Key Changes: Added the `truncate` class from Tailwind CSS to the link component in the `content.tsx` file, which applies the following styles to handle overflow:
  - `overflow: hidden;`
  - `text-overflow: ellipsis;`
  - `white-space: nowrap;`
- Refactoring: No major refactoring changes were made, the fix was a targeted update to the existing code.

> ✨ Generated with love by Kaizen ❤️


<details>
<summary>Original Description</summary>
Before fix:
<img width="1470" alt="Pasted image 20240726153637" src="https://github.com/user-attachments/assets/638bc550-c278-45b2-a716-bb66c01f3f7b">

After fix:
<img width="1470" alt="Pasted image 20240726153608" src="https://github.com/user-attachments/assets/022f2dc1-19d9-40b0-9f1b-023653623b12">

---
In `supermemory/apps/web/app/(dash)/(memories)/content.tsx`, the code is not handling if the link of a note overflows. it does handle the same for pages. 

<img width="824" alt="image" src="https://github.com/user-attachments/assets/9ebb5630-7a28-4854-920d-b751cff5c6cc">

So I added `truncate` class from tailwind so the formatting for overflowing link of page remains same to that of note.
```
overflow: hidden;
text-overflow: ellipsis;
white-space: nowrap;
```
See for more info: https://tailwindcss.com/docs/text-overflow

</details>


</details>

