### PR TITLE
Fix/clicking on a memory should open it in a new tab #167 (2)

### DIFF
--- a/apps/web/app/(dash)/chat/chatWindow.tsx
+++ b/apps/web/app/(dash)/chat/chatWindow.tsx
@@ -366,6 +366,8 @@ function ChatWindow({
 																		href={source.source}
 																		key={idx}
 																		className="w-[350px] shrink-0 p-4 gap-2 rounded-2xl flex flex-col bg-secondary"
+																		target="_blank"
+																		rel="noopener noreferrer"
 																	>
 																		<div className="flex justify-between text-foreground-menu text-sm">
 																			<span>{source.type}</span>

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
 		"lint-staged": "^15.2.5",
 		"prettier": "^3.3.3",
 		"tailwindcss": "^3.4.3",
-		"turbo": "2.0.3",
+		"turbo": "^2.0.3",
 		"typescript": "^5.5.4"
 	},
 	"engines": {


### PR DESCRIPTION
# Fix/clicking on a memory should open it in a new tab #167 (2)

## Overview
This pull request addresses the issue of external links opening in the same tab when clicking on a memory in the chat window. The changes ensure that external links are opened in a new tab, improving the user experience.

## Changes
- Key Changes: Added `target="_blank"` and `rel="noopener noreferrer"` attributes to the `Link` component for external sources in the `chatWindow.tsx` file.
- Refactoring: Restored the necessary files and removed the `wrangler.toml` from the `.gitignore` file without pushing it to deployment.

> ✨ Generated with love by Kaizen ❤️


<details>
<summary>Original Description</summary>
This PR addresses the issue of external links opening in the same tab. I've added target="_blank" rel="noopener noreferrer" to the Link component for external sources. I am raising this second pr to address the issues in my previous pr as I have restored the necessary files and removed the wrangler.toml from .gitignore without pushing it to deployment.
</details>

