### PR TITLE
Add useKeyPress hook for keyboard event handling

### DIFF
--- a/apps/web/app/(dash)/menu.tsx
+++ b/apps/web/app/(dash)/menu.tsx
@@ -30,6 +30,7 @@ import { createMemory, createSpace } from "../actions/doers";
 import ComboboxWithCreate from "@repo/ui/shadcn/combobox";
 import { StoredSpace } from "@/server/db/schema";
 import useMeasure from "react-use-measure";
+import { useKeyPress } from "@/lib/useKeyPress";
 
 function Menu() {
 	const [spaces, setSpaces] = useState<StoredSpace[]>([]);
@@ -48,7 +49,11 @@ function Menu() {
 			setSpaces(spaces.data);
 		})();
 	}, []);
-
+	useKeyPress("a", () => {
+		if (!dialogOpen) {
+			setDialogOpen(true);
+		}
+	});
 	const menuItems = [
 		{
 			icon: HomeIconWeb,

--- a/apps/web/lib/useKeyPress.ts
+++ b/apps/web/lib/useKeyPress.ts
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+
+export const useKeyPress = (key: string, callback: () => void) => {
+	useEffect(() => {
+		const handler = (e: KeyboardEvent) => {
+			if (e.key === key && e.altKey) {
+				callback();
+			}
+		};
+		window.addEventListener("keydown", handler);
+		return () => {
+			window.removeEventListener("keydown", handler);
+		};
+	}, [key, callback]);
+};


### PR DESCRIPTION
# Add useKeyPress Hook and Keyboard Shortcut for Adding Memory

## Overview
This pull request introduces a custom `useKeyPress` hook for handling keyboard events and adds a keyboard shortcut (ALT+a) to open the memory creation dialog.

## Changes
- **Key Changes:**
    - Added `useKeyPress` hook to `lib/useKeyPress.ts` for detecting key presses.
    - Implemented ALT+a shortcut in `(dash)/menu.tsx` to open the memory creation dialog.
- **New Features:**
    - Added a new keyboard shortcut for creating memories.
- **Refactoring:**
    - No significant refactoring changes.

> ✨ Generated with love by Kaizen ❤️


<details>
<summary>Original Description</summary>
Fixes: #178 

Added a custom hook for implementing keymaps to enhance the user experience.
Added keymap (ALT+a) for adding a memory. 
</details>

