### PR TITLE
chore(ui): justify thinkpad to center

### DIFF
--- a/apps/web/app/(thinkpad)/thinkpad/page.tsx
+++ b/apps/web/app/(thinkpad)/thinkpad/page.tsx
@@ -21,7 +21,7 @@ async function page() {
 
 			<BlurHeaderMenu />
 
-			<div className="w-full flex py-20">
+			<div className="w-full flex py-20 justify-center">
 				{!canvas.success || canvas.error ? (
 					<div>Hmmm... Something went wrong. :/</div>
 				) : (


### PR DESCRIPTION
# chore(ui): justify thinkpad to center

## Overview
This pull request centers the content of the "thinkpad" page on the web application.

## Changes
- Key Changes: Adjusted the CSS class on the main container div to add the `justify-center` utility, centering the content horizontally.
- New Features: None
- Refactoring: None

> ✨ Generated with love by [Kaizen](https://cloudcode.ai) ❤️


<details>
<summary>Original Description</summary>
None
</details>

