### PR TITLE
fixes #146 multiple memory submission bug

### DIFF
--- a/apps/web/app/(dash)/menu.tsx
+++ b/apps/web/app/(dash)/menu.tsx
@@ -31,9 +31,19 @@ import ComboboxWithCreate from "@repo/ui/shadcn/combobox";
 import { StoredSpace } from "@repo/db/schema";
 import useMeasure from "react-use-measure";
 import { useKeyPress } from "@/lib/useKeyPress";
+import { useFormStatus } from "react-dom";
 
 function Menu() {
 	const [spaces, setSpaces] = useState<StoredSpace[]>([]);
+
+	function SubmitButton() {
+		const status = useFormStatus();
+		return (
+			<Button disabled={status.pending} variant={"secondary"} type="submit">
+				Save {autoDetectedType != "none" && autoDetectedType}
+			</Button>
+		);
+	}
 
 	useEffect(() => {
 		(async () => {
@@ -319,13 +329,7 @@ function Menu() {
 						</div>
 
 						<DialogFooter>
-							<Button
-								disabled={autoDetectedType === "none"}
-								variant={"secondary"}
-								type="submit"
-							>
-								Save {autoDetectedType != "none" && autoDetectedType}
-							</Button>
+							<SubmitButton />
 						</DialogFooter>
 					</form>
 				</DialogContent>


### PR DESCRIPTION
# Fixes Multiple Memory Submission Bug

## Overview
This pull request addresses issue #146 by implementing a solution to prevent multiple submissions of a form, which was causing memory-related bugs. The main change involves utilizing the `useFormStatus` hook to manage the state of the submit button, ensuring it is disabled during form submission.

## Changes
- Key Changes: 
  - Introduced the `SubmitButton` component that leverages `useFormStatus` to disable the button when a submission is in progress.
  - Removed the inline button definition from the `DialogFooter` and replaced it with the new `SubmitButton` component for better encapsulation and readability.

- New Features: 
  - The `SubmitButton` component provides a more user-friendly experience by preventing multiple submissions, thereby enhancing form reliability.

- Refactoring: 
  - The button logic has been refactored into a separate `SubmitButton` component, improving code organization and maintainability.
  - This change promotes reusability and adheres to the single responsibility principle, making the `Menu` component cleaner and easier to understand.

> ✨ Generated with love by [Kaizen](https://cloudcode.ai) ❤️


<details>
<summary>Original Description</summary>
used useFormStatus to disable to submit button
</details>

