### PR TITLE
chore: Update Telegram bot with Markdown Support

### DIFF
--- a/apps/web/app/api/telegram/route.ts
+++ b/apps/web/app/api/telegram/route.ts
@@ -21,7 +21,10 @@ bot.command("start", async (ctx) => {
 
 	const cipherd = cipher(user.id.toString());
 	await ctx.reply(
-		`Welcome to Supermemory bot. I am here to help you remember things better. Click here to create and link your account: https://supermemory.ai/signin?telegramUser=${cipherd}`,
+		`Welcome to Supermemory bot. I am here to help you remember things better. [Click here to create and link your account](https://supermemory.ai/signin?telegramUser=${cipherd})`,
+		{
+			parse_mode: "MarkdownV2",
+		},
 	);
 });
 
@@ -38,7 +41,10 @@ bot.on("message", async (ctx) => {
 
 	if (!dbUser) {
 		await ctx.reply(
-			`Welcome to Supermemory bot. I am here to help you remember things better. Click here to create and link your account: https://supermemory.ai/signin?telegramUser=${cipherd}`,
+			`Welcome to Supermemory bot. I am here to help you remember things better. [Click here to create and link your account](https://supermemory.ai/signin?telegramUser=${cipherd})`,
+			{
+				parse_mode: "MarkdownV2",
+			},
 		);
 
 		return;
@@ -103,7 +109,14 @@ bot.on("message", async (ctx) => {
 			.returning({ id: storedContent.id });
 	}
 
-	await ctx.api.editMessageText(ctx.chat.id, message.message_id, data.response);
+	await ctx.api.editMessageText(
+		ctx.chat.id,
+		message.message_id,
+		data.response,
+		{
+			parse_mode: "MarkdownV2",
+		},
+	);
 });
 
 export const POST = webhookCallback(bot, "std/http");


### PR DESCRIPTION
# Update Telegram Bot with Markdown Support

## Overview
This pull request enhances the Telegram bot by enabling Markdown support for improved message formatting.

## Changes
- Key Changes:
    - Added `parse_mode: "MarkdownV2"` to `ctx.reply` and `ctx.api.editMessageText` calls to enable Markdown formatting.
- New Features:
    - Markdown support for bot messages.
- Refactoring:
    - None.

> ✨ Generated with love by [Kaizen](https://cloudcode.ai) ❤️


<details>
<summary>Original Description</summary>
None
</details>

