### PR TITLE
#250 - Fix Grammatical Error in Prerequisites Section of SETUP-GUIDE.md

### DIFF
--- a/SETUP-GUIDE.md
+++ b/SETUP-GUIDE.md
@@ -7,7 +7,7 @@ This guide will help you set up your own instance of Supermemory. This is necess
 - [pnpm](https://pnpm.io/installation): pnpm is used as a package manager. You can enable pnpm by running `corepack enable pnpm` in your terminal.
 - [turbo](https://turbo.build/repo/docs/installing)
 - [wrangler](https://developers.cloudflare.com/workers/cli-wrangler/install-update)
-- [Cloudflare Workers](https://developers.cloudflare.com/workers/platform/pricing/): You also need to have a paid Workers plan to use the vectorize feature which is needed to run the AI backend. It is currently $5/mo + usage costs.
+-[Cloudflare Workers](https://developers.cloudflare.com/workers/platform/pricing/): You also need to have a paid Workers plan to use the vectorize feature which is needed to run the AI backend. It is currently $5/mo + usage costs.
 - [Cloudflare R2](https://developers.cloudflare.com/r2/): You need to enable R2 in the Cloudflare Dashboard for use in the web app.
 
 ## Steps

--- a/SETUP-GUIDE.md
+++ b/SETUP-GUIDE.md
@@ -7,7 +7,7 @@ This guide will help you set up your own instance of Supermemory. This is necess
 - [pnpm](https://pnpm.io/installation): pnpm is used as a package manager. You can enable pnpm by running `corepack enable pnpm` in your terminal.
 - [turbo](https://turbo.build/repo/docs/installing)
 - [wrangler](https://developers.cloudflare.com/workers/cli-wrangler/install-update)
-- [Cloudflare Workers](https://developers.cloudflare.com/workers/platform/pricing/): You also need to have a paid Workers plan to use the vectorize feature which is needed run the AI backend. It is currently $5/mo + usage costs.
+- [Cloudflare Workers](https://developers.cloudflare.com/workers/platform/pricing/): You also need to have a paid Workers plan to use the vectorize feature which is needed to run the AI backend. It is currently $5/mo + usage costs.
 - [Cloudflare R2](https://developers.cloudflare.com/r2/): You need to enable R2 in the Cloudflare Dashboard for use in the web app.
 
 ## Steps


### PR DESCRIPTION
This PR addresses a grammatical error in the `SETUP-GUIDE.md` file under the "Prerequisites" section. The original text read:

**Original Text:**
"You also need to have a paid Workers plan to use the vectorize feature which is needed run the AI backend."

This sentence has been corrected to improve clarity by adding "to" before "run":

**Updated Text:**
"You also need to have a paid Workers plan to use the vectorize feature, which is needed to run the AI backend."

### Changes Made

- Added "to" before "run" in the sentence to correct the grammatical structure.

### Related Issue
- #250 

### Checklist
- [x] Updated documentation to reflect the changes.
- [x] Verified that the change does not affect other parts of the document.