### PR TITLE
Fix broken Authkit URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Built with:
 
 - [Remix](https://remix.run/)
 - [Hono](https://hono.dev/)
-- [authkit-remix-cloudflare by Supermemory](https://github.com/supermemory/authkit-remix-cloudflare)
+- [authkit-remix-cloudflare by Supermemory](https://github.com/supermemoryai/authkit-remix-cloudflare)
 - [Drizzle ORM](https://drizzle.team/)
 - [TailwindCSS](https://tailwindcss.com)
 - [shadcn-ui](https://ui.shadcn.com)


### PR DESCRIPTION
# Update Authkit URL in README

- **Purpose:**
 Correct the URL for the authkit-remix-cloudflare repository.
- **Key Changes:**
  - Updated the link for authkit-remix-cloudflare from `supermemory` to `supermemoryai`.
- **Impact:**
 Ensures users access the correct repository for the authentication kit.

> ✨ Generated with love by [Kaizen](https://cloudcode.ai) ❤️


<details>
<summary>Original Description</summary>
None
</details>

