### PR TITLE
Updated AddMemory.tsx component to fix overflow memory category/tabs UI  

### DIFF
--- a/apps/web/app/components/memories/AddMemory.tsx
+++ b/apps/web/app/components/memories/AddMemory.tsx
@@ -163,7 +163,7 @@ export function AddMemoryModal({
 							activeTab === "integrations" && "lg:col-span-3",
 						)}
 					>
-						<TabsList className="border md:flex-col md:h-full h-max md:justify-start md:space-y-2 bg-[#FAFBFC] dark:bg-zinc-800 md:col-span-1 p-2 flex flex-row justify-between overflow-x-auto md:overflow-visible shrink-0">
+						<TabsList className="border md:flex-col md:h-full h-max md:justify-start md:space-y-2 bg-[#FAFBFC] dark:bg-zinc-800 md:col-span-1 p-2 flex flex-row justify-between overflow-x-auto md:overflow-visible shrink-0 overflow-auto">
 							<TabsTrigger
 								className="w-full justify-start text-left px-4 py-3 rounded-lg border border-transparent data-[state=active]:border-indigo-500/20 data-[state=active]:bg-indigo-500/10 hover:bg-zinc-100 dark:hover:bg-zinc-700 flex flex-col items-start gap-2 transition-all duration-200 hover:shadow-sm"
 								id="url-tab"


### PR DESCRIPTION
Updated AddMemory.tsx component to fix overflow memory category/tabs UI  while selecting the category of the new memory


before: ![image](https://github.com/user-attachments/assets/a27c7e4e-6323-45da-808c-376e7271fc19)
after: ![image](https://github.com/user-attachments/assets/8fc91292-6314-4a09-a499-f281f4f05137)

