### PR TITLE
fix #350: GitHub Icon not visible

### DIFF
--- a/apps/extension/public/globals.css
+++ b/apps/extension/public/globals.css
@@ -107,7 +107,7 @@
 }
 
 /*
-! tailwindcss v3.4.15 | MIT License | https://tailwindcss.com
+! tailwindcss v3.4.17 | MIT License | https://tailwindcss.com
 */
 
 /*

--- a/apps/web/app/components/icons/IntegrationIcons.tsx
+++ b/apps/web/app/components/icons/IntegrationIcons.tsx
@@ -44,7 +44,7 @@ export const GithubIcon = (props: SVGProps<SVGSVGElement>) => (
 		viewBox="0 0 256 250"
 		width="1em"
 		height="1em"
-		fill="#fff"
+		fill="currentColor"
 		xmlns="http://www.w3.org/2000/svg"
 		preserveAspectRatio="xMidYMid"
 		{...props}


### PR DESCRIPTION
fixes: #350 

before: 
![image](https://github.com/user-attachments/assets/7668c6bc-68d9-46c8-b54a-71b5a4e5c9ac)

now:
![image](https://github.com/user-attachments/assets/f4439ab0-6873-43d5-9b72-de4df721ba0a)
