### PR TITLE
fix: disable experimental React Compiler in Next.js config and remove babel-plugin-react-compiler dependency.

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,63 +1,62 @@
-import { withSentryConfig } from "@sentry/nextjs";
-import type { NextConfig } from "next";
+import { withSentryConfig } from "@sentry/nextjs"
+import type { NextConfig } from "next"
 
 const nextConfig: NextConfig = {
-				experimental: {
-								reactCompiler: true,
-								viewTransition: true,
-				},
-				eslint: {
-								ignoreDuringBuilds: true,
-				},
-				poweredByHeader: false,
-				async rewrites() {
-								return [
-												{
-																source: "/ingest/static/:path*",
-																destination: "https://us-assets.i.posthog.com/static/:path*",
-												},
-												{
-																source: "/ingest/:path*",
-																destination: "https://us.i.posthog.com/:path*",
-												},
-								];
-				},
-				skipTrailingSlashRedirect: true,
-};
+	experimental: {
+		viewTransition: true,
+	},
+	eslint: {
+		ignoreDuringBuilds: true,
+	},
+	poweredByHeader: false,
+	async rewrites() {
+		return [
+			{
+				source: "/ingest/static/:path*",
+				destination: "https://us-assets.i.posthog.com/static/:path*",
+			},
+			{
+				source: "/ingest/:path*",
+				destination: "https://us.i.posthog.com/:path*",
+			},
+		]
+	},
+	skipTrailingSlashRedirect: true,
+}
 
 export default withSentryConfig(nextConfig, {
- // For all available options, see:
+	// For all available options, see:
 	// https://www.npmjs.com/package/@sentry/webpack-plugin#options
 
 	org: "supermemory",
 
- project: "consumer-app",
+	project: "consumer-app",
 
- // Only print logs for uploading source maps in CI
+	// Only print logs for uploading source maps in CI
 	silent: !process.env.CI,
 
- // For all available options, see:
+	// For all available options, see:
 	// https://docs.sentry.io/platforms/javascript/guides/nextjs/manual-setup/
 
 	// Upload a larger set of source maps for prettier stack traces (increases build time)
 	widenClientFileUpload: true,
 
- // Route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
+	// Route browser requests to Sentry through a Next.js rewrite to circumvent ad-blockers.
 	// This can increase your server load as well as your hosting bill.
 	// Note: Check that the configured route will not match with your Next.js middleware, otherwise reporting of client-
 	// side errors will fail.
 	tunnelRoute: "/monitoring",
 
- // Automatically tree-shake Sentry logger statements to reduce bundle size
+	// Automatically tree-shake Sentry logger statements to reduce bundle size
 	disableLogger: true,
 
- // Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
+	// Enables automatic instrumentation of Vercel Cron Monitors. (Does not yet work with App Router route handlers.)
 	// See the following for more information:
 	// https://docs.sentry.io/product/crons/
 	// https://vercel.com/docs/cron-jobs
 	automaticVercelMonitors: true,
-});
+})
 
-import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare";
+import { initOpenNextCloudflareForDev } from "@opennextjs/cloudflare"
 
-initOpenNextCloudflareForDev();
+initOpenNextCloudflareForDev()

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -51,7 +51,6 @@
 		"@tanstack/react-virtual": "^3.13.12",
 		"ai": "5.0.0-beta.24",
 		"autumn-js": "0.0.116",
-		"babel-plugin-react-compiler": "^19.1.0-rc.2",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",
 		"date-fns": "^4.1.0",

--- a/bun.lock
+++ b/bun.lock
@@ -107,7 +107,6 @@
         "@tanstack/react-virtual": "^3.13.12",
         "ai": "5.0.0-beta.24",
         "autumn-js": "0.0.116",
-        "babel-plugin-react-compiler": "^19.1.0-rc.2",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "date-fns": "^4.1.0",
@@ -186,7 +185,7 @@
     },
     "packages/tools": {
       "name": "@supermemory/tools",
-      "version": "1.0.4",
+      "version": "1.0.41",
       "dependencies": {
         "@ai-sdk/openai": "^2.0.23",
         "@ai-sdk/provider": "^2.0.0",
@@ -3132,7 +3131,7 @@
 
     "postgres-interval": ["postgres-interval@1.2.0", "", { "dependencies": { "xtend": "^4.0.0" } }, "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ=="],
 
-    "posthog-js": ["posthog-js@1.261.0", "", { "dependencies": { "@posthog/core": "1.0.2", "core-js": "^3.38.1", "fflate": "^0.4.8", "preact": "^10.19.3", "web-vitals": "^4.2.4" }, "peerDependencies": { "@rrweb/types": "2.0.0-alpha.17", "rrweb-snapshot": "2.0.0-alpha.17" }, "optionalPeers": ["@rrweb/types", "rrweb-snapshot"] }, "sha512-jyiXqyrCU+VlpbNNVRA6OQYAVut0XZMYNELCZH+XvTd981VqbE4jXn4XCBreo7XCL2gdPgDVxUVOuzNvEuKcmw=="],
+    "posthog-js": ["posthog-js@1.261.7", "", { "dependencies": { "@posthog/core": "1.0.2", "core-js": "^3.38.1", "fflate": "^0.4.8", "preact": "^10.19.3", "web-vitals": "^4.2.4" }, "peerDependencies": { "@rrweb/types": "2.0.0-alpha.17", "rrweb-snapshot": "2.0.0-alpha.17" }, "optionalPeers": ["@rrweb/types", "rrweb-snapshot"] }, "sha512-Fjpbz6VfIMsEbKIN/UyTWhU1DGgVIngqoRjPGRolemIMOVzTfI77OZq8WwiBhMug+rU+wNhGCQhC41qRlR5CxA=="],
 
     "preact": ["preact@10.27.1", "", {}, "sha512-V79raXEWch/rbqoNc7nT9E4ep7lu+mI3+sBmfRD4i1M73R3WLYcCtdI0ibxGVf4eQL8ZIz2nFacqEC+rmnOORQ=="],
 
@@ -4807,8 +4806,6 @@
     "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
 
     "strip-literal/js-tokens": ["js-tokens@9.0.1", "", {}, "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ=="],
-
-    "supermemory-browser-extension/posthog-js": ["posthog-js@1.261.7", "", { "dependencies": { "@posthog/core": "1.0.2", "core-js": "^3.38.1", "fflate": "^0.4.8", "preact": "^10.19.3", "web-vitals": "^4.2.4" }, "peerDependencies": { "@rrweb/types": "2.0.0-alpha.17", "rrweb-snapshot": "2.0.0-alpha.17" }, "optionalPeers": ["@rrweb/types", "rrweb-snapshot"] }, "sha512-Fjpbz6VfIMsEbKIN/UyTWhU1DGgVIngqoRjPGRolemIMOVzTfI77OZq8WwiBhMug+rU+wNhGCQhC41qRlR5CxA=="],
 
     "supermemory-browser-extension/typescript": ["typescript@5.9.2", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A=="],
 


### PR DESCRIPTION
Removed React Compiler from the project configuration and dependencies.

### What changed?

- Removed `reactCompiler: true` from the experimental options in `next.config.ts`
- Removed `babel-plugin-react-compiler` dependency from `package.json`
- Updated formatting in `next.config.ts` to use consistent indentation and semicolons

### Why make this change?

React Compiler (formerly React Forget) is still in experimental phase and may be causing stability issues or unnecessary complexity in the build process. Removing it simplifies our dependency tree while maintaining full functionality. The PostHog update ensures we're using the latest version with any bug fixes or improvements.