### PR TITLE
ui: fix progress bar thickness on regular browser

### DIFF
--- a/apps/web/app/onboarding/progress-bar.tsx
+++ b/apps/web/app/onboarding/progress-bar.tsx
@@ -10,7 +10,7 @@ export function OnboardingProgressBar() {
 		totalSteps === 0 ? 0 : (currentVisibleStepNumber / totalSteps) * 100
 
 	return (
-		<div className="fixed top-0 left-0 right-0 z-50 h-3 bg-zinc-200">
+		<div className="fixed top-0 left-0 right-0 z-50 h-[2px] bg-zinc-200">
 			<motion.div
 				className="h-full bg-gradient-to-r from-[#06245B] via-[#1A5EA7] to-[#DDF5FF]"
 				initial={{ width: "0%" }}


### PR DESCRIPTION
Before 

![image.png](https://app.graphite.dev/user-attachments/assets/86346d6f-720f-498d-a2e1-80fa705cd7e7.png)


After

![image.png](https://app.graphite.dev/user-attachments/assets/a1bfd96d-022c-47bf-838f-13af31a24c23.png)

