### PR TITLE
fix: add button type to ModelSelector and ProjectSelector components

### DIFF
--- a/apps/web/components/model-selector.tsx
+++ b/apps/web/components/model-selector.tsx
@@ -48,6 +48,7 @@ export function ModelSelector({
 	return (
 		<div className="relative">
 			<Button
+				type="button"
 				variant="ghost"
 				className="flex items-center gap-1.5 px-2 py-1.5 rounded-md transition-colors"
 				onClick={() => !disabled && setIsOpen(!isOpen)}

--- a/apps/web/components/project-selector.tsx
+++ b/apps/web/components/project-selector.tsx
@@ -95,6 +95,7 @@ export function ProjectSelector() {
 	return (
 		<div className="relative">
 			<Button
+				type="button"
 				variant="ghost"
 				className="flex items-center gap-1.5 px-2 py-1.5 rounded-md transition-colors"
 				onClick={() => setIsOpen(!isOpen)}


### PR DESCRIPTION
### Current Issue
Clicking the model picker or project selector on the home screen would submit the chat form instead of opening the dropdown menu.

https://github.com/user-attachments/assets/0d69f133-2700-4d8b-8553-c8da95acf199

### Root Cause
Buttons inside a `<form>` element default to `type="submit"` in HTML. Without explicitly specifying `type="button"`, the ModelSelector and ProjectSelector buttons were being treated as submit buttons.

### Solution
Added `type="button"` to both selector buttons:
- `ModelSelector` component
- `ProjectSelector` component

This prevents form submission and allows the buttons to only execute their `onClick` handlers.

---