### PR TITLE
Add markdown rendering support to memory content display

### DIFF
--- a/apps/web/components/memories-utils/html-content-renderer.tsx
+++ b/apps/web/components/memories-utils/html-content-renderer.tsx
@@ -36,22 +36,17 @@ export const HTMLContentRenderer = memo(
 				}
 			}
 
-			// Preprocess content to improve markdown detection and formatting
 			let processed = content
 
-			// Handle terminal commands (lines starting with $)
 			if (content.includes("\n$ ")) {
-				// Convert terminal commands to code blocks for better formatting
 				processed = content.replace(/^\$ (.*$)/gm, "```bash\n$ $1\n```")
 			}
 
-			// Handle cases where content looks like JSON but isn't in code blocks
 			if (
 				content.trim().startsWith("{") &&
 				content.includes('"') &&
 				content.includes(":")
 			) {
-				// Check if it looks like JSON and wrap it in a code block
 				const lines = content.split("\n")
 				let inJsonBlock = false
 				const jsonLines: string[] = []
@@ -86,7 +81,7 @@ export const HTMLContentRenderer = memo(
 
 			return {
 				isHTML: false,
-				isMarkdown: true, // Try markdown rendering for all non-HTML content
+				isMarkdown: true,
 				processedContent: processed,
 			}
 		}, [content])
@@ -195,7 +190,6 @@ export const HTMLContentRenderer = memo(
 					</div>
 				)
 			} catch {
-				// Fallback to plain text if markdown parsing fails
 				return (
 					<p
 						className={`text-sm leading-relaxed whitespace-pre-wrap text-foreground ${className}`}


### PR DESCRIPTION
feat: format memory dialog content in markdown

- Add markdown rendering support to memory content display
- Auto-detect and format JSON responses in code blocks  
- Convert terminal commands to bash code blocks
- Improve code block styling with monospace font and compact spacing
- Fallback to plain text if markdown parsing fails"

Before:
<img width="819" height="691" alt="image" src="https://github.com/user-attachments/assets/229feca0-e209-463f-87ff-b890ab15cb0e" />

Now:
<img width="730" height="449" alt="image" src="https://github.com/user-attachments/assets/b5b423c3-3d0b-4ab6-be9e-0b5f5b2f20a0" />
