### PR TITLE
feat: add file attachments to AI chat with drag-drop and sessionStora…

### DIFF
--- a/apps/web/components/attachments/attachment-picker.tsx
+++ b/apps/web/components/attachments/attachment-picker.tsx
@@ -1,0 +1,89 @@
+"use client"
+
+import { useRef, useState } from "react"
+import { cn } from "@lib/utils"
+import { Button } from "@ui/components/button"
+import { Paperclip } from "lucide-react"
+
+export function AttachmentPicker({
+	onFilesSelected,
+	disabled,
+	accept = ".pdf,.doc,.docx,.txt,image/*",
+	multiple = true,
+	className,
+}: {
+	onFilesSelected: (files: File[]) => void
+	disabled?: boolean
+	accept?: string
+	multiple?: boolean
+	className?: string
+}) {
+ 	const inputRef = useRef<HTMLInputElement | null>(null)
+ 	const [isDragOver, setIsDragOver] = useState(false)
+
+ 	function handlePick() {
+ 		if (!disabled) inputRef.current?.click()
+ 	}
+
+ 	function handleChange(e: React.ChangeEvent<HTMLInputElement>) {
+ 		const files = Array.from(e.target.files || [])
+ 		if (files.length > 0) onFilesSelected(files)
+ 		// reset so selecting the same file again still fires change
+ 		e.currentTarget.value = ""
+ 	}
+
+ 	function preventDefaults(e: React.DragEvent) {
+ 		e.preventDefault()
+ 		e.stopPropagation()
+ 	}
+
+ 	function handleDrop(e: React.DragEvent) {
+ 		preventDefaults(e)
+ 		setIsDragOver(false)
+ 		if (disabled) return
+ 		const files = Array.from(e.dataTransfer.files || [])
+ 		if (files.length > 0) onFilesSelected(files)
+ 	}
+
+ 	return (
+ 		<div
+ 			className={cn(
+ 				"inline-flex items-center",
+ 				isDragOver ? "ring-2 ring-primary/40 rounded-lg" : "",
+ 				className,
+ 			)}
+ 			onDragEnter={(e) => {
+ 				preventDefaults(e)
+ 				setIsDragOver(true)
+ 			}}
+ 			onDragOver={preventDefaults}
+ 			onDragLeave={(e) => {
+ 				preventDefaults(e)
+ 				setIsDragOver(false)
+ 			}}
+ 			onDrop={handleDrop}
+ 		>
+ 			<input
+ 				ref={inputRef}
+ 				type="file"
+ 				accept={accept}
+ 				multiple={multiple}
+ 				className="hidden"
+ 				onChange={handleChange}
+ 			/>
+ 			<Button
+ 				variant="ghost"
+ 				size="icon"
+ 				type="button"
+ 				disabled={disabled}
+ 				aria-label="Attach files"
+ 				onClick={handlePick}
+ 			>
+ 				<Paperclip className="size-4" />
+ 			</Button>
+ 		</div>
+ 	)
+}
+
+
+

--- a/apps/web/components/chat-input.tsx
+++ b/apps/web/components/chat-input.tsx
@@ -4,17 +4,47 @@ import { useState, useEffect } from "react"
 import { useRouter } from "next/navigation"
 import { generateId } from "@lib/generate-id"
 import { usePersistentChat } from "@/stores/chat"
-import { ArrowUp } from "lucide-react"
+import { ArrowUp, X } from "lucide-react"
 import { Button } from "@ui/components/button"
 import { ProjectSelector } from "./project-selector"
 import { ModelSelector } from "./model-selector"
 import { useAuth } from "@lib/auth-context"
+import { AttachmentPicker } from "@/components/attachments/attachment-picker"
+import { toast } from "sonner"
+import {
+	ALLOWED_MIME_PREFIXES,
+	ALLOWED_MIME_TYPES,
+	MAX_ATTACHMENTS,
+	MAX_FILE_BYTES,
+	SESSION_BUDGET_BYTES,
+	buildAttachmentKey,
+	downscaleImageToDataUrl,
+	estimateDataUrlSize,
+	fileToDataUrl,
+	filterDuplicates,
+	wouldExceedSessionBudget,
+} from "@/lib/attachments"
 
 export function ChatInput() {
 	const [message, setMessage] = useState("")
 	const [selectedModel, setSelectedModel] = useState<
 		"gpt-5" | "claude-sonnet-4.5" | "gemini-2.5-pro"
 	>("gemini-2.5-pro")
+
+	// Attachments state and DnD for the home prompt
+
+	interface AttachmentItem {
+		id: string
+		file: File
+		kind: "image" | "doc"
+		previewUrl?: string
+		mimeType: string
+		name: string
+		size: number
+	}
+
+	const [attachments, setAttachments] = useState<AttachmentItem[]>([])
+	const [isDraggingOverForm, setIsDraggingOverForm] = useState(false)
 	const router = useRouter()
 	const { setCurrentChatId } = usePersistentChat()
 	const { user } = useAuth()
@@ -39,19 +69,101 @@ export function ChatInput() {
 		localStorage.setItem("selectedModel", modelId)
 	}
 
-	const handleSend = () => {
-		if (!message.trim()) return
+ function validateFile(file: File): string | null {
+ 		if (file.size > MAX_FILE_BYTES) return `File exceeds 25MB: ${file.name}`
+ 		const type = file.type
+ 		const isImage = ALLOWED_MIME_PREFIXES.some((p) => type.startsWith(p))
+ 		const allowed = isImage || ALLOWED_MIME_TYPES.includes(type)
+ 		if (!allowed) return `Unsupported type: ${file.name}`
+ 		return null
+ 	}
+
+	function onFilesSelected(files: File[]) {
+ 		const existingKeys = new Set(attachments.map((a) => buildAttachmentKey(a.file)))
+ 		const { accepted, duplicates } = filterDuplicates(files, existingKeys)
+ 		duplicates.forEach((f) => toast.error(`Already attached: ${f.name}`))
+ 		const filtered: File[] = []
+ 		for (const file of accepted) {
+			const err = validateFile(file)
+			if (err) {
+				toast.error(err)
+				continue
+			}
+ 			filtered.push(file)
+ 		}
+ 		if (attachments.length + filtered.length > MAX_ATTACHMENTS) {
+ 			toast.error(`You can attach up to ${MAX_ATTACHMENTS} files`)
+ 			return
+ 		}
+ 		// Optional: sessionStorage budget estimate for initial navigation pass-through
+ 		if (wouldExceedSessionBudget(filtered)) {
+ 			toast.error("Attachments too large to pass to chat. Please reduce size/count.")
+ 			return
+ 		}
+ 		const newItems: AttachmentItem[] = []
+ 		for (const file of filtered) {
+ 			const isImage = file.type.startsWith("image/")
+			const item: AttachmentItem = {
+				id: crypto.randomUUID(),
+				file,
+				kind: isImage ? "image" : "doc",
+				previewUrl: isImage ? URL.createObjectURL(file) : undefined,
+				mimeType: file.type,
+				name: file.name,
+				size: file.size,
+			}
+			newItems.push(item)
+		}
+		if (newItems.length > 0) setAttachments((prev) => [...prev, ...newItems])
+	}
+
+	function removeAttachment(id: string) {
+		setAttachments((prev) => {
+			const next = prev.filter((a) => a.id !== id)
+			const removed = prev.find((a) => a.id === id)
+			if (removed?.previewUrl) URL.revokeObjectURL(removed.previewUrl)
+			return next
+		})
+	}
+
+ // fileToDataUrl and downscaleImageToDataUrl imported from utils
+
+	const handleSend = async () => {
+		if (!message.trim() && attachments.length === 0) return
 
 		const newChatId = generateId()
 
 		setCurrentChatId(newChatId)
 
-		sessionStorage.setItem(`chat-initial-${newChatId}`, message.trim())
+		// Prepare attachments as parts for initial send
+		let attachmentParts: any[] = []
+		if (attachments.length > 0) {
+			const processed = await Promise.all(
+				attachments.map(async (a) => {
+					if (a.kind === "image") {
+						const res = await downscaleImageToDataUrl(a.file)
+						return { type: "image", mimeType: res.mimeType, data: res.dataUrl }
+					}
+					const dataUrl = await fileToDataUrl(a.file)
+					return { type: "file", name: a.name, mimeType: a.mimeType, data: dataUrl }
+				}),
+			)
+			attachmentParts = processed
+		}
+
 		sessionStorage.setItem(`chat-model-${newChatId}`, selectedModel)
+		if (message.trim()) sessionStorage.setItem(`chat-initial-${newChatId}`, message.trim())
+		if (attachmentParts.length > 0)
+			sessionStorage.setItem(
+				`chat-initial-attachments-${newChatId}`,
+				JSON.stringify(attachmentParts),
+			)
 
 		router.push(`/chat/${newChatId}`)
 
 		setMessage("")
+		attachments.forEach((a) => a.previewUrl && URL.revokeObjectURL(a.previewUrl))
+		setAttachments([])
 	}
 
 	const handleKeyDown = (e: React.KeyboardEvent) => {
@@ -71,13 +183,64 @@ export function ChatInput() {
 				</div>
 				<div className="relative">
 					<form
-						className="flex flex-col items-end bg-card border border-border rounded-[14px] shadow-lg"
+						className={`flex flex-col items-end bg-card border border-border rounded-[14px] shadow-lg ${
+							isDraggingOverForm ? "ring-2 ring-primary/40" : ""
+						}`}
 						onSubmit={(e) => {
 							e.preventDefault()
-							if (!message.trim()) return
 							handleSend()
 						}}
+						onDragEnter={(e) => {
+							e.preventDefault()
+							e.stopPropagation()
+							setIsDraggingOverForm(true)
+						}}
+						onDragOver={(e) => {
+							e.preventDefault()
+							e.stopPropagation()
+							setIsDraggingOverForm(true)
+						}}
+						onDragLeave={(e) => {
+							e.preventDefault()
+							e.stopPropagation()
+							setIsDraggingOverForm(false)
+						}}
+						onDrop={(e) => {
+							e.preventDefault()
+							e.stopPropagation()
+							setIsDraggingOverForm(false)
+							const files = Array.from(e.dataTransfer.files || [])
+							if (files.length > 0) onFilesSelected(files)
+						}}
 					>
+						{attachments.length > 0 && (
+							<div className="w-full flex flex-wrap gap-2 px-6 pt-3">
+								{attachments.map((a) => (
+									<div
+										key={a.id}
+										className="flex items-center gap-2 border border-border rounded-md px-2 py-1 bg-accent/40"
+									>
+										{a.kind === "image" && a.previewUrl ? (
+											<img
+												src={a.previewUrl}
+												alt={a.name}
+												className="w-8 h-8 rounded object-cover"
+											/>
+										) : null}
+										<div className="text-xs max-w-40 truncate">{a.name}</div>
+										<Button
+											variant="ghost"
+											size="icon"
+											type="button"
+											onClick={() => removeAttachment(a.id)}
+											aria-label={`Remove ${a.name}`}
+										>
+											<X className="size-3.5" />
+										</Button>
+									</div>
+								))}
+							</div>
+						)}
 						<textarea
 							value={message}
 							onChange={(e) => setMessage(e.target.value)}
@@ -87,7 +250,14 @@ export function ChatInput() {
 							rows={2}
 						/>
 						<div className="flex items-center gap-2 w-full justify-between py-2 px-3 rounded-b-[14px]">
-							<ProjectSelector />
+							<div className="flex items-center gap-2">
+								<AttachmentPicker
+									onFilesSelected={onFilesSelected}
+									accept=".pdf,.doc,.docx,.txt,image/*"
+									multiple
+								/>
+								<ProjectSelector />
+							</div>
 							<div className="flex items-center gap-2">
 								<ModelSelector
 									selectedModel={selectedModel}
@@ -95,7 +265,7 @@ export function ChatInput() {
 								/>
 								<Button
 									onClick={handleSend}
-									disabled={!message.trim()}
+									disabled={!message.trim() && attachments.length === 0}
 									className="text-primary-foreground border-0 rounded-xl transition-colors disabled:opacity-50 disabled:cursor-not-allowed !bg-primary h-8 w-8"
 									variant="outline"
 									size="icon"

--- a/apps/web/lib/attachments.ts
+++ b/apps/web/lib/attachments.ts
@@ -1,0 +1,102 @@
+export const MAX_ATTACHMENTS = 5
+export const MAX_FILE_BYTES = 25 * 1024 * 1024 // 25MB
+export const ALLOWED_MIME_PREFIXES = ["image/"]
+export const ALLOWED_MIME_TYPES = [
+	"application/pdf",
+	"text/plain",
+	"application/msword",
+	"application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+]
+
+export function buildAttachmentKey(file: File): string {
+	// lastModified may be undefined in some environments
+	const last = (file as any)?.lastModified ?? 0
+	return `${file.name}:${file.size}:${last}`
+}
+
+export function validateFile(file: File): string | null {
+	if (file.size > MAX_FILE_BYTES) return `File exceeds 25MB: ${file.name}`
+	const type = file.type
+	const isImage = ALLOWED_MIME_PREFIXES.some((p) => type.startsWith(p))
+	const allowed = isImage || ALLOWED_MIME_TYPES.includes(type)
+	if (!allowed) return `Unsupported type: ${file.name}`
+	return null
+}
+
+export function fileToDataUrl(file: File): Promise<string> {
+	return new Promise((resolve, reject) => {
+		const reader = new FileReader()
+		reader.onload = () => resolve(String(reader.result))
+		reader.onerror = reject
+		reader.readAsDataURL(file)
+	})
+}
+
+export async function downscaleImageToDataUrl(
+	file: File,
+	maxDim = 1600,
+	quality = 0.85,
+): Promise<{ dataUrl: string; mimeType: string }> {
+	const originalDataUrl = await fileToDataUrl(file)
+	return new Promise((resolve) => {
+		const img = new Image()
+		img.onload = () => {
+			let { width, height } = img as HTMLImageElement
+			if (width <= maxDim && height <= maxDim) {
+				resolve({ dataUrl: originalDataUrl, mimeType: file.type || "image/jpeg" })
+				return
+			}
+			const scale = Math.min(maxDim / width, maxDim / height)
+			width = Math.floor(width * scale)
+			height = Math.floor(height * scale)
+			const canvas = document.createElement("canvas")
+			canvas.width = width
+			canvas.height = height
+			const ctx = canvas.getContext("2d")
+			if (!ctx) {
+				resolve({ dataUrl: originalDataUrl, mimeType: file.type || "image/jpeg" })
+				return
+			}
+			ctx.drawImage(img, 0, 0, width, height)
+			const outType = file.type && file.type.startsWith("image/png") ? "image/png" : "image/jpeg"
+			const dataUrl = canvas.toDataURL(outType, outType === "image/jpeg" ? quality : undefined)
+			resolve({ dataUrl, mimeType: outType })
+		}
+		img.onerror = () => resolve({ dataUrl: originalDataUrl, mimeType: file.type || "image/jpeg" })
+		img.src = originalDataUrl
+	})
+}
+
+export function filterDuplicates(files: File[], existingKeys: Set<string>) {
+	const accepted: File[] = []
+	const duplicates: File[] = []
+	const newKeys = new Set<string>()
+	for (const f of files) {
+		const key = buildAttachmentKey(f)
+		if (existingKeys.has(key) || newKeys.has(key)) {
+			duplicates.push(f)
+			continue
+		}
+		accepted.push(f)
+		newKeys.add(key)
+	}
+	return { accepted, duplicates }
+}
+
+// Very rough safe budget for sessionStorage in bytes; keep well below 5MB typical limits
+export const SESSION_BUDGET_BYTES = Math.floor(3.5 * 1024 * 1024)
+
+// Estimate base64 data URL size (payload grows by ~4/3)
+export function estimateDataUrlSize(bytes: number): number {
+	return Math.ceil(bytes * 1.37) + 64 // +64 for small headers
+}
+
+export function wouldExceedSessionBudget(
+	files: File[],
+	extraTextBytes = 0,
+): boolean {
+	const total = files.reduce((sum, f) => sum + estimateDataUrlSize(f.size), 0) + extraTextBytes
+	return total > SESSION_BUDGET_BYTES
+}
+
+


### PR DESCRIPTION
### Problem:
Users cannot attach files to AI chat conversations. The chat interface lacks file upload functionality, preventing users from sharing documents or images for analysis.
### Solution:

- added file attachment system with clip icon picker and drag-drop support

- implemented image downscaling (1600px max, 85% quality) and document support

- created sessionStorage handoff mechanism for initial attachments on new chats

- added duplicate file detection and validation (5 files max, 25MB each)

- built shared attachment utilities for consistent validation and processing

### Additional Details:

- files are sent inline as vision/document input, not ingested as memories

- drag-drop works across entire prompt input form area with visual ring feedback

- attachment previews show file names with download links for documents

- auto sends initial attachments when navigating from default page to chat

- includes accessibility attributes and sessionStorage size budget protection

### Code Quality & Maintainability Improvements:

- extracted shared attachment utilities (lib/attachments.ts) to eliminate code duplication between components

- improved duplicate detection logic: check duplicates first, then enforce max count limits

- added sessionStorage size budget estimation to prevent quota exceeded errors

- enhanced accessibility with proper aria-label attributes on interactive elements

- centralized file validation, image processing, and key generation logic

- improved error handling with specific toast messages for different failure cases (file too large, too many files, duplicate files etc)

- added proper cleanup for object URLs to prevent memory leaks

### Testing

- tested file upload via clip icon with various file types (pdf, docx, txt, png, jpg)
- tested drag-drop functionality across entire prompt input form area
- verifed duplicate file detection shows appropriate toast notifications
- tested file size limits (25MB per file) and count limits (5 files max)
- verified image downscaling works for large images
- tested sessionStorage handoff when navigating from default page to chat
- berified initial attachments auto-send when opening new chat
- tested accessibility with keyboard navigation and screen readers
- verified proper cleanup of object URLs and sessionStorage keys

### IMPORTANT: Requirement for /chat Backend Implementation:
backend /chat endpoint must handle new message part types:
`{ type: 'image', mimeType: string, data: 'data:image/...;base64,...' }`
`{ type: 'file', name?: string, mimeType?: string, data?: 'data:...;base64,...' }`
Convert these to model-specific image/document inputs. Current implementation sends attachments as parts array alongside text parts.

### Photos
**Before:**
<img width="818" height="192" alt="image" src="https://github.com/user-attachments/assets/29dc0c10-e0fe-4782-8e32-d0589e70d008" />
**After:**
<img width="828" height="186" alt="image" src="https://github.com/user-attachments/assets/a2b8dc24-64a2-4c5a-a3fd-173f03051f51" />

**Drag and Drop:**
<img width="839" height="191" alt="image" src="https://github.com/user-attachments/assets/d35753a7-4032-4725-8da7-7dc45448638a" />
<img width="848" height="255" alt="image" src="https://github.com/user-attachments/assets/5d4f71aa-47f4-4c30-908d-d9d783ea2dbd" />

**In chat message:**
<img width="249" height="92" alt="image" src="https://github.com/user-attachments/assets/02080462-35f9-4693-ae64-2dd7059bca96" />

**File upload in chat page:**
<img width="816" height="185" alt="image" src="https://github.com/user-attachments/assets/7d7bd47b-0f71-49aa-9a9c-70651260990b" />

**Error Notifications**
<img width="329" height="97" alt="image" src="https://github.com/user-attachments/assets/ed9a6f2b-16cd-472b-a002-7d76eae56319" />

