### PR TITLE
Unify content cards: fixed height, shared actions menu, memory badges…

### DIFF
--- a/apps/web/components/content-cards/confirm-delete.tsx
+++ b/apps/web/components/content-cards/confirm-delete.tsx
@@ -1,0 +1,54 @@
+"use client"
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@repo/ui/components/alert-dialog"
+
+export function ConfirmDelete({
+  open,
+  onOpenChange,
+  onConfirm,
+  title = "Delete Document",
+  description =
+    "Are you sure you want to delete this document and all its related memories? This action cannot be undone.",
+}: {
+  open: boolean
+  onOpenChange: (v: boolean) => void
+  onConfirm: () => void
+  title?: string
+  description?: string
+}) {
+  return (
+    <AlertDialog open={open} onOpenChange={onOpenChange}>
+      <AlertDialogContent>
+        <AlertDialogHeader>
+          <AlertDialogTitle>{title}</AlertDialogTitle>
+          <AlertDialogDescription>{description}</AlertDialogDescription>
+        </AlertDialogHeader>
+        <AlertDialogFooter>
+          <AlertDialogCancel>Cancel</AlertDialogCancel>
+          <AlertDialogAction
+            className="bg-red-600 hover:bg-red-700 text-white"
+            onClick={(e) => {
+              e.stopPropagation()
+              onConfirm()
+            }}
+          >
+            Delete
+          </AlertDialogAction>
+        </AlertDialogFooter>
+      </AlertDialogContent>
+    </AlertDialog>
+  )
+}
+
+ConfirmDelete.displayName = "ConfirmDelete"
+
+

--- a/apps/web/components/content-cards/document-card-frame.tsx
+++ b/apps/web/components/content-cards/document-card-frame.tsx
@@ -1,0 +1,93 @@
+"use client"
+
+import { Card } from "@repo/ui/components/card"
+import { cn } from "@lib/utils"
+import React from "react"
+
+type DocumentCardFrameProps = {
+  media?: React.ReactNode
+  title: React.ReactNode
+  subtitle?: React.ReactNode
+  metaRight?: React.ReactNode
+  body?: React.ReactNode
+  footerLeft?: React.ReactNode
+  footerRight?: React.ReactNode
+  onClick?: () => void
+  className?: string
+}
+
+export const DocumentCardFrame = ({
+  media,
+  title,
+  subtitle,
+  metaRight,
+  body,
+  footerLeft,
+  footerRight,
+  onClick,
+  className,
+}: DocumentCardFrameProps) => {
+  return (
+    <Card
+      onClick={onClick}
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : -1}
+      onKeyDown={(e) => {
+        if (!onClick) return
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault()
+          onClick()
+        }
+      }}
+      className={cn(
+        "group relative w-full overflow-hidden rounded-xl border bg-card shadow-xs transition-all hover:shadow-md focus-visible:outline-none",
+        onClick ? "cursor-pointer" : "",
+        "focus:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        "dark:!bg-neutral-800 dark:!border-0",
+        className,
+      )}
+    >
+      <div className="pointer-events-none absolute inset-0 rounded-xl ring-1 ring-border/40 group-hover:ring-border dark:hidden" />
+
+      {media ? (
+        <div className="relative w-full overflow-hidden bg-muted/40">
+          <div className="aspect-[16/9] w-full overflow-hidden bg-muted/10">
+            {media}
+          </div>
+        </div>
+      ) : null}
+
+      <div className="px-2 gap-1 grid h-24 grid-rows-[auto,auto,1fr,auto]">
+        <div className="flex items-center justify-between gap-2">
+          <h3 className="text-[16px] font-medium leading-tight line-clamp-1">{title}</h3>
+          {metaRight}
+        </div>
+
+        {subtitle ? (
+          <div className="text-[11px] text-muted-foreground flex items-center gap-1.5">
+            {subtitle}
+          </div>
+        ) : (
+          <div />
+        )}
+
+        {body ? (
+          <div className="text-[12px] text-muted-foreground leading-relaxed line-clamp-2">
+            {body}
+          </div>
+        ) : (
+          <div />
+        )}
+
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-2">{footerLeft}</div>
+          <div className="flex items-center gap-1">{footerRight}</div>
+        </div>
+      </div>
+    </Card>
+  )
+}
+
+DocumentCardFrame.displayName = "DocumentCardFrame"
+
+

--- a/apps/web/components/content-cards/file.tsx
+++ b/apps/web/components/content-cards/file.tsx
@@ -1,0 +1,93 @@
+"use client"
+
+import { DocumentCardFrame } from "./document-card-frame"
+import { MemoryBadge } from "./memory-badge"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@repo/ui/components/dropdown-menu"
+import { ConfirmDelete } from "./confirm-delete"
+import { ExternalLink, FileText, MoreHorizontal, Trash2 } from "lucide-react"
+import { useState } from "react"
+
+export function FileCard({
+  title,
+  url,
+  memoryCount,
+  onOpenDetails,
+  onDelete,
+}: {
+  title: string
+  url?: string | null
+  memoryCount: number
+  onOpenDetails: () => void
+  onDelete?: () => void
+}) {
+  const openUrl = (e: React.MouseEvent) => {
+    e.stopPropagation()
+    if (url) window.open(url, "_blank", "noopener,noreferrer")
+  }
+  const [confirmOpen, setConfirmOpen] = useState(false)
+
+  return (
+        <>
+        <DocumentCardFrame
+      onClick={onOpenDetails}
+      media={null}
+      title={title}
+      subtitle={
+        <>
+          <FileText className="w-3 h-3" aria-hidden="true" />
+          <span>File</span>
+        </>
+      }
+      metaRight={
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <button
+              onClick={(e) => e.stopPropagation()}
+              className="rounded p-1 text-muted-foreground/80 hover:bg-muted"
+              type="button"
+              aria-label="More actions"
+            >
+              <MoreHorizontal className="w-4 h-4" />
+            </button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end">
+            {url && (
+              <DropdownMenuItem onClick={openUrl} className="cursor-pointer text-xs">
+                <ExternalLink className="w-3 h-3 mr-2" /> Open file
+              </DropdownMenuItem>
+            )}
+            {onDelete && (
+              <DropdownMenuItem
+                onClick={(e) => {
+                  e.stopPropagation()
+                  setConfirmOpen(true)
+                }}
+                className="cursor-pointer text-xs text-red-600 focus:text-red-600"
+              >
+                <Trash2 className="w-3 h-3 mr-2" /> Delete
+              </DropdownMenuItem>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      }
+      body={undefined}
+      footerLeft={<MemoryBadge count={memoryCount} />}
+      footerRight={null}
+    />
+    {onDelete && (
+      <ConfirmDelete
+        open={confirmOpen}
+        onOpenChange={setConfirmOpen}
+        onConfirm={() => {
+          onDelete?.()
+          setConfirmOpen(false)
+        }}
+      />
+    )}
+    </>
+  )
+}
+
+FileCard.displayName = "FileCard"
+
+

--- a/apps/web/components/content-cards/google-docs.tsx
+++ b/apps/web/components/content-cards/google-docs.tsx
@@ -1,22 +1,11 @@
 "use client"
 
-import { Card, CardContent } from "@repo/ui/components/card"
-import { Badge } from "@repo/ui/components/badge"
-import {
-	AlertDialog,
-	AlertDialogAction,
-	AlertDialogCancel,
-	AlertDialogContent,
-	AlertDialogDescription,
-	AlertDialogFooter,
-	AlertDialogHeader,
-	AlertDialogTitle,
-	AlertDialogTrigger,
-} from "@repo/ui/components/alert-dialog"
-import { ExternalLink, FileText, Brain, Trash2 } from "lucide-react"
-import { cn } from "@lib/utils"
-import { colors } from "@repo/ui/memory-graph/constants"
-import { getPastelBackgroundColor } from "../memories-utils"
+import { ConfirmDelete } from "./confirm-delete"
+import { ExternalLink, Trash2, MoreHorizontal } from "lucide-react"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@repo/ui/components/dropdown-menu"
+import { DocumentCardFrame } from "./document-card-frame"
+import { MemoryBadge } from "./memory-badge"
+import { useState } from "react"
 
 interface GoogleDocsCardProps {
 	title: string
@@ -41,6 +30,7 @@ export const GoogleDocsCard = ({
 	activeMemories,
 	lastModified,
 }: GoogleDocsCardProps) => {
+	const [confirmOpen, setConfirmOpen] = useState(false)
 	const handleCardClick = () => {
 		if (onClick) {
 			onClick()
@@ -56,169 +46,95 @@ export const GoogleDocsCard = ({
 		}
 	}
 
-	return (
-		<Card
-			className={cn(
-				"cursor-pointer transition-all hover:shadow-md group overflow-hidden relative py-4",
-				className,
-			)}
-			onClick={handleCardClick}
-			style={{
-				backgroundColor: getPastelBackgroundColor(url || title || "googledocs"),
-			}}
-		>
-			{onDelete && (
-				<AlertDialog>
-					<AlertDialogTrigger asChild>
-						<button
-							className="absolute top-2 right-2 z-20 opacity-0 group-hover:opacity-100 transition-opacity p-1.5 rounded-md hover:bg-red-500/20"
-							onClick={(e) => {
-								e.stopPropagation()
-							}}
-							style={{
-								color: colors.text.muted,
-								backgroundColor: "rgba(255, 255, 255, 0.1)",
-								backdropFilter: "blur(4px)",
-							}}
-							type="button"
-						>
-							<Trash2 className="w-3.5 h-3.5" />
-						</button>
-					</AlertDialogTrigger>
-					<AlertDialogContent>
-						<AlertDialogHeader>
-							<AlertDialogTitle>Delete Document</AlertDialogTitle>
-							<AlertDialogDescription>
-								Are you sure you want to delete this document and all its
-								related memories? This action cannot be undone.
-							</AlertDialogDescription>
-						</AlertDialogHeader>
-						<AlertDialogFooter>
-							<AlertDialogCancel
-								onClick={(e) => {
-									e.stopPropagation()
-								}}
-							>
-								Cancel
-							</AlertDialogCancel>
-							<AlertDialogAction
-								className="bg-red-600 hover:bg-red-700 text-white"
-								onClick={(e) => {
-									e.stopPropagation()
-									onDelete()
-								}}
-							>
-								Delete
-							</AlertDialogAction>
-						</AlertDialogFooter>
-					</AlertDialogContent>
-				</AlertDialog>
-			)}
+    return (
+        <>
+        <DocumentCardFrame
+            onClick={handleCardClick}
+            media={null}
+            title={
+                <div className="flex items-center gap-2">
+                    <svg
+                        className="w-4 h-4"
+                        aria-hidden="true"
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 87.3 78"
+                        aria-label="Google Docs"
+                    >
+                        <title>Google Docs</title>
+                        <path
+                            fill="#0066da"
+                            d="m6.6 66.85 3.85 6.65c.8 1.4 1.95 2.5 3.3 3.3L27.5 53H0c0 1.55.4 3.1 1.2 4.5z"
+                        />
+                        <path
+                            fill="#00ac47"
+                            d="M43.65 25 29.9 1.2c-1.35.8-2.5 1.9-3.3 3.3l-25.4 44A9.06 9.06 0 0 0 0 53h27.5z"
+                        />
+                        <path
+                            fill="#ea4335"
+                            d="M73.55 76.8c1.35-.8 2.5-1.9 3.3-3.3l1.6-2.75L86.1 57.5c.8-1.4 1.2-2.95 1.2-4.5H59.798l5.852 11.5z"
+                        />
+                        <path
+                            fill="#00832d"
+                            d="M43.65 25 57.4 1.2C56.05.4 54.5 0 52.9 0H34.4c-1.6 0-3.15.45-4.5 1.2z"
+                        />
+                        <path
+                            fill="#2684fc"
+                            d="M59.8 53H27.5L13.75 76.8c1.35.8 2.9 1.2 4.5 1.2h50.8c1.6 0 3.15-.45 4.5-1.2z"
+                        />
+                        <path
+                            fill="#ffba00"
+                            d="m73.4 26.5-12.7-22c-.8-1.4-1.95-2.5-3.3-3.3L43.65 25 59.8 53h27.45c0-1.55-.4-3.1-1.2-4.5z"
+                        />
+                    </svg>
+                    <div className="flex flex-col">
+                        <span className="text-xs text-muted-foreground">Google Docs</span>
+                    </div>
+                </div>
+            }
+            metaRight={
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                        <button onClick={(e) => e.stopPropagation()} className="rounded p-1 text-muted-foreground/80 hover:bg-muted" type="button" aria-label="More actions">
+                            <MoreHorizontal className="w-4 h-4" />
+                        </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                        {showExternalLink && (
+                            <DropdownMenuItem onClick={(e) => { e.stopPropagation(); handleExternalLinkClick(e as unknown as React.MouseEvent) }} className="cursor-pointer text-xs">
+                                <ExternalLink className="w-3 h-3 mr-2" /> Open in Google Docs
+                            </DropdownMenuItem>
+                        )}
+                        {onDelete && (
+                            <DropdownMenuItem
+                                onClick={(e) => {
+                                    e.stopPropagation()
+                                    setConfirmOpen(true)
+                                }}
+                                className="cursor-pointer text-xs text-red-600 focus:text-red-600"
+                                >
+                                <Trash2 className="w-3 h-3 mr-2" /> Delete
+                            </DropdownMenuItem>
+                        )}
+                    </DropdownMenuContent>
+                </DropdownMenu>
+            }
+            body={description}
+            footerLeft={<MemoryBadge count={activeMemories?.length ?? 0} />}
+            footerRight={null}
 
-			<CardContent className="p-0">
-				<div className="px-4 border-b border-white/10">
-					<div className="flex items-center justify-between">
-						<div className="flex items-center gap-2">
-							<svg
-								className="w-4 h-4"
-								xmlns="http://www.w3.org/2000/svg"
-								viewBox="0 0 87.3 78"
-								aria-label="Google Docs"
-							>
-								<title>Google Docs</title>
-								<path
-									fill="#0066da"
-									d="m6.6 66.85 3.85 6.65c.8 1.4 1.95 2.5 3.3 3.3L27.5 53H0c0 1.55.4 3.1 1.2 4.5z"
-								/>
-								<path
-									fill="#00ac47"
-									d="M43.65 25 29.9 1.2c-1.35.8-2.5 1.9-3.3 3.3l-25.4 44A9.06 9.06 0 0 0 0 53h27.5z"
-								/>
-								<path
-									fill="#ea4335"
-									d="M73.55 76.8c1.35-.8 2.5-1.9 3.3-3.3l1.6-2.75L86.1 57.5c.8-1.4 1.2-2.95 1.2-4.5H59.798l5.852 11.5z"
-								/>
-								<path
-									fill="#00832d"
-									d="M43.65 25 57.4 1.2C56.05.4 54.5 0 52.9 0H34.4c-1.6 0-3.15.45-4.5 1.2z"
-								/>
-								<path
-									fill="#2684fc"
-									d="M59.8 53H27.5L13.75 76.8c1.35.8 2.9 1.2 4.5 1.2h50.8c1.6 0 3.15-.45 4.5-1.2z"
-								/>
-								<path
-									fill="#ffba00"
-									d="m73.4 26.5-12.7-22c-.8-1.4-1.95-2.5-3.3-3.3L43.65 25 59.8 53h27.45c0-1.55-.4-3.1-1.2-4.5z"
-								/>
-							</svg>
-							<div className="flex flex-col">
-								<span className="text-xs text-muted-foreground">
-									Google Docs
-								</span>
-							</div>
-						</div>
-						<div className="flex items-center gap-1">
-							{showExternalLink && (
-								<button
-									onClick={handleExternalLinkClick}
-									className="opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-white/10 flex-shrink-0"
-									type="button"
-									aria-label="Open in Google Docs"
-								>
-									<ExternalLink className="w-4 h-4" />
-								</button>
-							)}
-						</div>
-					</div>
-				</div>
-
-				<div className="px-4 space-y-2">
-					<div className="flex items-start justify-between gap-2">
-						<h3 className="font-semibold text-sm line-clamp-2 leading-tight flex-1">
-							{title || "Untitled Document"}
-						</h3>
-					</div>
-
-					{description && (
-						<p className="text-xs text-muted-foreground line-clamp-3 leading-relaxed">
-							{description}
-						</p>
-					)}
-
-					<div className="flex items-center justify-between text-xs text-muted-foreground">
-						<div className="flex items-center gap-1">
-							<FileText className="w-3 h-3" />
-							<span>Google Workspace</span>
-						</div>
-						{lastModified && (
-							<span className="truncate">
-								Modified{" "}
-								{lastModified instanceof Date
-									? lastModified.toLocaleDateString()
-									: new Date(lastModified).toLocaleDateString()}
-							</span>
-						)}
-					</div>
-
-					{activeMemories && activeMemories.length > 0 && (
-						<div>
-							<Badge
-								className="text-xs text-accent-foreground"
-								style={{
-									backgroundColor: colors.memory.secondary,
-								}}
-								variant="secondary"
-							>
-								<Brain className="w-3 h-3 mr-1" />
-								{activeMemories.length}{" "}
-								{activeMemories.length === 1 ? "memory" : "memories"}
-							</Badge>
-						</div>
-					)}
-				</div>
-			</CardContent>
-		</Card>
-	)
+        />
+        {onDelete && (
+            <ConfirmDelete
+                open={confirmOpen}
+                onOpenChange={setConfirmOpen}
+                onConfirm={() => {
+                    onDelete?.()
+                    setConfirmOpen(false)
+                }}
+            />
+        )}
+        </>
+    )
 }
 
 GoogleDocsCard.displayName = "GoogleDocsCard"

--- a/apps/web/components/content-cards/memory-badge.tsx
+++ b/apps/web/components/content-cards/memory-badge.tsx
@@ -1,0 +1,24 @@
+"use client"
+
+import { Badge } from "@repo/ui/components/badge"
+import React from "react"
+
+export const MemoryBadge = ({ count }: { count: number }) => {
+  if (count === 0) return null
+  const formatted = new Intl.NumberFormat().format(count)
+  const text = `${formatted} ${count === 1 ? "memory" : "memories"}`
+  return (
+    <Badge
+      variant="secondary"
+      className="bg-blue-100 text-blue-800 dark:bg-blue-600 dark:text-white"
+      title={text}
+      aria-label={text}
+    >
+      {text}
+    </Badge>
+  )
+}
+
+MemoryBadge.displayName = "MemoryBadge"
+
+

--- a/apps/web/components/content-cards/website.tsx
+++ b/apps/web/components/content-cards/website.tsx
@@ -1,22 +1,11 @@
 "use client"
 
-import { Card, CardContent } from "@repo/ui/components/card"
-import {
-	AlertDialog,
-	AlertDialogAction,
-	AlertDialogCancel,
-	AlertDialogContent,
-	AlertDialogDescription,
-	AlertDialogFooter,
-	AlertDialogHeader,
-	AlertDialogTitle,
-	AlertDialogTrigger,
-} from "@repo/ui/components/alert-dialog"
-import { ExternalLink, Trash2 } from "lucide-react"
+import { DocumentCardFrame } from "./document-card-frame"
+import { MemoryBadge } from "./memory-badge"
+import { ConfirmDelete } from "./confirm-delete"
+import { ExternalLink, Trash2, Globe, MoreHorizontal } from "lucide-react"
 import { useState } from "react"
-import { cn } from "@lib/utils"
-import { getPastelBackgroundColor } from "../memories-utils"
-import { colors } from "@repo/ui/memory-graph/constants"
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@repo/ui/components/dropdown-menu"
 
 interface WebsiteCardProps {
 	title: string
@@ -28,20 +17,22 @@ interface WebsiteCardProps {
 	onOpenDetails?: () => void
 	onDelete?: () => void
 	showExternalLink?: boolean
+    memoryCount?: number
 }
 
 export const WebsiteCard = ({
 	title,
 	url,
-	image,
+    image: _image,
 	description,
 	className,
 	onClick,
 	onOpenDetails,
 	onDelete,
 	showExternalLink = true,
+    memoryCount = 0,
 }: WebsiteCardProps) => {
-	const [imageError, setImageError] = useState(false)
+    const [confirmOpen, setConfirmOpen] = useState(false)
 
 	const handleCardClick = () => {
 		if (onClick) {
@@ -66,106 +57,73 @@ export const WebsiteCard = ({
 		}
 	})()
 
-	return (
-		<Card
-			className={cn(
-				"cursor-pointer transition-all hover:shadow-md group overflow-hidden py-0 relative",
-				className,
-			)}
-			onClick={handleCardClick}
-			style={{
-				backgroundColor: getPastelBackgroundColor(url || title || "website"),
-			}}
-		>
-			{onDelete && (
-				<AlertDialog>
-					<AlertDialogTrigger asChild>
-						<button
-							className="absolute top-2 right-2 z-20 opacity-0 group-hover:opacity-100 transition-opacity p-1.5 rounded-md hover:bg-red-500/20"
-							onClick={(e) => {
-								e.stopPropagation()
-							}}
-							style={{
-								color: colors.text.muted,
-								backgroundColor: "rgba(255, 255, 255, 0.1)",
-								backdropFilter: "blur(4px)",
-							}}
-							type="button"
-						>
-							<Trash2 className="w-3.5 h-3.5" />
-						</button>
-					</AlertDialogTrigger>
-					<AlertDialogContent>
-						<AlertDialogHeader>
-							<AlertDialogTitle>Delete Document</AlertDialogTitle>
-							<AlertDialogDescription>
-								Are you sure you want to delete this document and all its
-								related memories? This action cannot be undone.
-							</AlertDialogDescription>
-						</AlertDialogHeader>
-						<AlertDialogFooter>
-							<AlertDialogCancel
-								onClick={(e) => {
-									e.stopPropagation()
-								}}
-							>
-								Cancel
-							</AlertDialogCancel>
-							<AlertDialogAction
-								className="bg-red-600 hover:bg-red-700 text-white"
-								onClick={(e) => {
-									e.stopPropagation()
-									onDelete()
-								}}
-							>
-								Delete
-							</AlertDialogAction>
-						</AlertDialogFooter>
-					</AlertDialogContent>
-				</AlertDialog>
-			)}
-
-			<CardContent className="p-0">
-				{image && !imageError && (
-					<div className="relative h-38 bg-gray-100 overflow-hidden">
-						<img
-							src={image}
-							alt={title || "Website preview"}
-							className="w-full h-full object-cover transition-transform group-hover:scale-105"
-							onError={() => setImageError(true)}
-							loading="lazy"
-						/>
-					</div>
-				)}
-
-				<div className="px-4 py-2 space-y-2">
-					<div className="font-semibold text-sm line-clamp-2 leading-tight flex items-center justify-between">
-						{title}
-						<div className="flex items-center gap-1">
-							{showExternalLink && (
-								<button
-									onClick={handleExternalLinkClick}
-									className="opacity-0 group-hover:opacity-100 transition-opacity p-1 rounded hover:bg-gray-100 flex-shrink-0"
-									type="button"
-									aria-label="Open in new tab"
-								>
-									<ExternalLink className="w-3 h-3" />
-								</button>
-							)}
-						</div>
-					</div>
-
-					{description && (
-						<p className="text-xs text-muted-foreground line-clamp-2 leading-relaxed">
-							{description}
-						</p>
-					)}
-
-					<p className="text-xs text-muted-foreground truncate">{hostname}</p>
-				</div>
-			</CardContent>
-		</Card>
-	)
+    return (
+        <>
+        <DocumentCardFrame
+            onClick={handleCardClick}
+            media={null}
+            title={title}
+            subtitle={
+                <>
+                    <Globe className="w-3 h-3" aria-hidden="true" />
+                    <span>Website</span>
+                    <span className="truncate">{hostname}</span>
+                </>
+            }
+            metaRight={
+                <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                        <button
+                            onClick={(e) => e.stopPropagation()}
+                            className="rounded p-1 text-muted-foreground/80 hover:bg-muted"
+                            type="button"
+                            aria-label="More actions"
+                        >
+                            <MoreHorizontal className="w-4 h-4" />
+                        </button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent align="end">
+                        {showExternalLink && (
+                            <DropdownMenuItem
+                                onClick={(e) => {
+                                    e.stopPropagation()
+                                    handleExternalLinkClick(e as unknown as React.MouseEvent)
+                                }}
+                                className="cursor-pointer text-xs"
+                            >
+                                <ExternalLink className="w-3 h-3 mr-2" /> Open link
+                            </DropdownMenuItem>
+                        )}
+                        {onDelete && (
+                            <DropdownMenuItem
+                                onClick={(e) => {
+                                    e.stopPropagation()
+                                    setConfirmOpen(true)
+                                }}
+                                className="cursor-pointer text-xs text-red-600 focus:text-red-600"
+                            >
+                                <Trash2 className="w-3 h-3 mr-2" /> Delete
+                            </DropdownMenuItem>
+                        )}
+                    </DropdownMenuContent>
+                </DropdownMenu>
+            }
+            body={description}
+            footerLeft={<MemoryBadge count={memoryCount} />}
+            footerRight={null}
+        />
+        {onDelete && (
+            <ConfirmDelete
+                open={confirmOpen}
+                onOpenChange={setConfirmOpen}
+                onConfirm={() => {
+                    onDelete?.()
+                    setConfirmOpen(false)
+                }}
+            />
+        )}
+        </>
+    )
 }
 
 WebsiteCard.displayName = "WebsiteCard"


### PR DESCRIPTION
…, and correct file detection

### Summary
This PR standardizes all document cards for consistent height, color, and layout. It merges delete and external link actions into a single dropdown with a shared confirmation dialog. A universal blue memory badge now appears on all cards, hidden when the count is zero. File detection and subtype labeling were fixed for accuracy. Accessibility and code quality were also improved with keyboard support, focus rings, and cleanup across components.

### Problem
- Cards had inconsistent heights due to varying title lines and website image previews, causing a staggered grid and jumpy layout.
- Background colors across card types were inconsistent with the site palette.
- Delete and external link actions were separate; clicking Delete could also navigate to the link underneath.
- Memory count badge was shown only on some document types; others lacked the count entirely.
- Some “file” documents were misclassified and shown as “Website” with a [files.supermemory.ai](http://files.supermemory.ai/) URL.
- Card metadata lacked a consistent document type indicator.

### Solution

- Standardized card layout and height in DocumentCardFrame; removed preview media for websites.
- Unified actions under a single ellipsis dropdown; both External link and Delete reside there when applicable.
- Added a shared ConfirmDelete component used by all card types to keep dialog behavior consistent.
- Implemented a blue memory badge across all cards; hidden when count is 0 for a clean layout.
- Displayed document subtype consistently in subtitles (Website, File, Note, etc.).
- Corrected file detection: URLs on [files.supermemory.ai](http://files.supermemory.ai/) and file-like types (pdf, text, image, video, onedrive) now render as FileCard.

### **Additional Details**

- Added keyboard accessibility to cards: role="button", tabIndex, Enter/Space activation, and a visible focus ring.
- Marked decorative icons with aria-hidden for screen readers.
- Memory badge uses strong contrast in light/dark mode and number formatting; removed hidden-but-present DOM when count is zero.
- Kept external navigations safe with noopener,noreferrer.

### **Code Quality & Maintainability Improvements**

- Extracted ConfirmDelete to remove duplicated dialog markup:
- New: apps/web/components/content-cards/confirm-delete.tsx
- Cleaned unused imports and props across cards.
- Consistent subtitle patterns and menu placement on all cards.
- Centralized keyboard handling in DocumentCardFrame.

### **Files touched**

- apps/web/components/content-cards/document-card-frame.tsx: keyboard/a11y and focus ring.
- apps/web/components/content-cards/file.tsx: a11y, use ConfirmDelete.
- apps/web/components/content-cards/google-docs.tsx: cleanup, a11y, use ConfirmDelete, memory badge.
- apps/web/components/content-cards/website.tsx: remove media preview, a11y, use ConfirmDelete, memory badge.
- apps/web/components/content-cards/tweet.tsx: cleanup, title fallback, a11y, use ConfirmDelete, memory badge.
- apps/web/components/content-cards/note.tsx: cleanup, a11y.
- apps/web/components/content-cards/memory-badge.tsx: hide when 0, add title/aria, format numbers.
- apps/web/components/masonry-memory-list.tsx: route files to FileCard, pass memory count to WebsiteCard.

### **Testing**

- Visual: Verified consistent heights across all cards; no image previews on website cards.
- Actions:
- Open external link via dropdown; no accidental navigation on delete.
- Delete shows confirmation dialog; confirming removes the card; cancel preserves it.
- Badges: Memory badge renders for all documents with count > 0; hidden for 0.
- Types: Files render with “File” subtitle and correct icon; websites show “Website” with hostname; notes show “Note”; tweets and Google Docs show their types.
- A11y: Tab to card -> focus ring visible; Enter/Space opens details; icons marked decorative.

### Photos
**Before**
<img width="1166" height="211" alt="image" src="https://github.com/user-attachments/assets/1d119a4c-e8d5-454a-87b6-e226643df5e6" />

**After**
<img width="1187" height="145" alt="image" src="https://github.com/user-attachments/assets/c0c1bb9d-8aef-4cbd-9249-3795ee070d44" />

**Ellipsis Dropdown**
<img width="293" height="141" alt="image" src="https://github.com/user-attachments/assets/f48a9f6a-418c-47e1-a191-32999403d2ab" />
