### PR TITLE
create memory adding option in vercel sdk

### DIFF
--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@supermemory/tools",
   "type": "module",
-  "version": "1.2.0",
+  "version": "1.2.13",
   "description": "Memory tools for AI SDK and OpenAI function calling with supermemory",
   "scripts": {
     "build": "tsdown",

--- a/packages/tools/src/vercel/index.ts
+++ b/packages/tools/src/vercel/index.ts
@@ -37,7 +37,11 @@ import { createSupermemoryMiddleware } from "./middleware"
 const wrapVercelLanguageModel = (
 	model: LanguageModelV2,
 	containerTag: string,
-	options?: { verbose?: boolean; mode?: "profile" | "query" | "full" },
+	options?: { 
+		verbose?: boolean; 
+		mode?: "profile" | "query" | "full";
+		addMemory?: "always" | "never";
+	},
 ): LanguageModelV2 => {
 	const SUPERMEMORY_API_KEY = process.env.SUPERMEMORY_API_KEY
 
@@ -47,10 +51,11 @@ const wrapVercelLanguageModel = (
 
 	const verbose = options?.verbose ?? false
 	const mode = options?.mode ?? "profile"
+	const addMemory = options?.addMemory ?? "never"
 
 	const wrappedModel = wrapLanguageModel({
 		model,
-		middleware: createSupermemoryMiddleware(containerTag, verbose, mode),
+		middleware: createSupermemoryMiddleware(containerTag, verbose, mode, addMemory),
 	})
 
 	return wrappedModel


### PR DESCRIPTION
### TL;DR

Added support for automatically saving user messages to Supermemory.

### What changed?

- Added a new `addMemory` option to `wrapVercelLanguageModel` that accepts either "always" or "never" (defaults to "never")
- Implemented the `addMemoryTool` function to save user messages to Supermemory
- Modified the middleware to check the `addMemory` setting and save the last user message when appropriate
- Initialized the Supermemory client in the middleware to enable memory storage

### How to test?

1. Set the `SUPERMEMORY_API_KEY` environment variable
2. Use the `wrapVercelLanguageModel` function with the new `addMemory: "always"` option
3. Send a user message through the model
4. Verify that the message is saved to Supermemory with the specified container tag

### Why make this change?

This change enables automatic memory creation from user messages, which improves the system's ability to build a knowledge base without requiring explicit memory creation calls. This is particularly useful for applications that want to automatically capture and store user interactions for future reference.