### PR TITLE
feat: added close chat button to chat interface

### DIFF
--- a/apps/web/components/views/chat/chat-messages.tsx
+++ b/apps/web/components/views/chat/chat-messages.tsx
@@ -17,9 +17,10 @@ import { useCallback, useEffect, useRef, useState } from "react"
 import { toast } from "sonner"
 import { Streamdown } from "streamdown"
 import { TextShimmer } from "@/components/text-shimmer"
-import { usePersistentChat, useProject } from "@/stores"
+import { useChatOpen, usePersistentChat, useProject } from "@/stores"
 import { useGraphHighlights } from "@/stores/highlights"
 import { Spinner } from "../../spinner"
+import { useRouter } from "next/navigation"
 
 interface MemoryResult {
 	documentId?: string
@@ -205,6 +206,8 @@ function useStickyAutoScroll(triggerKeys: ReadonlyArray<unknown>) {
 }
 
 export function ChatMessages() {
+	const router = useRouter()
+	const { setIsOpen } = useChatOpen()
 	const { selectedProject } = useProject()
 	const {
 		currentChatId,
@@ -386,8 +389,25 @@ export function ChatMessages() {
 		scrollToBottom,
 	} = useStickyAutoScroll([messages, status])
 
+	const handleCloseChat = () => {
+		setIsOpen(false)
+		router.push("/")
+	}
+
 	return (
 		<div className="h-full flex flex-col w-full">
+			{/* Close chat button */}
+			<div className="flex items-center justify-between px-4 py-3 border-b border-border">
+				<Button
+					variant="ghost"
+					size="sm"
+					onClick={handleCloseChat}
+					className="gap-2"
+				>
+					<X className="h-4 w-4" />
+					Close Chat
+				</Button>
+			</div>
 			<div className="flex-1 relative">
 				<div
 					className="flex flex-col gap-2 absolute inset-0 overflow-y-auto px-4 pt-4 pb-7 scroll-pb-7 custom-scrollbar"

--- a/packages/ui/components/button.tsx
+++ b/packages/ui/components/button.tsx
@@ -4,7 +4,7 @@ import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
 
 const buttonVariants = cva(
-	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-2 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+	"inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-2 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive cursor-pointer",
 	{
 		variants: {
 			variant: {


### PR DESCRIPTION
## Description

Added a "Close Chat" button to the chat interface so an easy way to exit the chat view and return to the home page.

### Problem
Currently, users would have to click on supermemory icon at top-left to close the chat.

### Updated look

<img width="935" height="347" alt="Screenshot 2025-10-17 at 11 45 24 AM" src="https://github.com/user-attachments/assets/c34dfcd2-0193-4dbb-812c-c6343ca0a4d7" />


### Changes Made

#### 1. Modified `apps/web/components/views/chat/chat-messages.tsx`
- Added imports for `useChatOpen` and `useRouter`
- Created `handleCloseChat` function to close chat state and navigate to home

#### 2. Modified `packages/ui/components/button.tsx`
- Added `cursor-pointer` to base button styles for better UX