### PR TITLE
feat(chat): increase maxSteps to allow multiple tool-calling rounds

### DIFF
--- a/apps/web/components/views/chat/chat-messages.tsx
+++ b/apps/web/components/views/chat/chat-messages.tsx
@@ -247,7 +247,7 @@ export function ChatMessages() {
 					},
 				},
 			}),
-			maxSteps: 10, // Allow multiple tool-calling rounds
+			maxSteps: 10,
 			onFinish: (result) => {
 				const activeId = activeChatIdRef.current
 				if (!activeId) return


### PR DESCRIPTION
I was facing this issue multiple times when it would do 2 tool calls (for either add+search or 2 search calls) and then abruptly stop. I brought this issue up with @sohamd22 and we thought it was Claude API that was down, but I looked into the code found this `maxSteps` set to 2 in `apps/web/components/views/chat/chat-messages.tsx` which would end the chat after the second tool-call result was fetched. 

For reference, I have attached a few images to this chat where I encountered this issue. 

<img width="2940" height="1840" alt="IMG_4374" src="https://github.com/user-attachments/assets/26b73a41-c7d3-40a9-add0-b3fb00532c29" />
<img width="2940" height="1840" alt="IMG_6743" src="https://github.com/user-attachments/assets/76da0550-2f4e-4c2f-ac78-acf8567a810f" />

And, I got the supermemory chat to work when I explicitly asked it to NOT add memories but rather just search.

<img width="2824" height="1586" alt="IMG_2999" src="https://github.com/user-attachments/assets/91ab3663-604f-48f0-b92c-de4d4df7c728" />


Therefore, I have increased it to 10 to support complex queries or just adding multiple memories per chat while also having the capacity to search. To be honest, 10 is an arbitrarily picked number but I think it's high enough for most people to not hit it.