### PR TITLE
docs: fixed naming convention of SDK usage examples

### DIFF
--- a/apps/docs/memory-api/sdks/native.mdx
+++ b/apps/docs/memory-api/sdks/native.mdx
@@ -31,7 +31,7 @@ pip install --pre supermemory
 import os
 from supermemory import Supermemory
 
-client = supermemory(
+client = Supermemory(
     api_key=os.environ.get("SUPERMEMORY_API_KEY"),  # This is the default and can be omitted
 )
 
@@ -52,9 +52,9 @@ npm install supermemory
 ## Usage
 
 ```js
-import supermemory from 'supermemory';
+import Supermemory from 'supermemory';
 
-const client = new supermemory({
+const client = new Supermemory({
   apiKey: process.env['SUPERMEMORY_API_KEY'], // This is the default and can be omitted
 });
 

--- a/apps/docs/memory-api/sdks/python.mdx
+++ b/apps/docs/memory-api/sdks/python.mdx
@@ -18,7 +18,7 @@ pip install --pre supermemory
 import os
 from supermemory import Supermemory
 
-client = supermemory(
+client = Supermemory(
     api_key=os.environ.get("SUPERMEMORY_API_KEY"),  # This is the default and can be omitted
 )
 
@@ -35,7 +35,7 @@ so that your API Key is not stored in source control.
 
 ## Async usage
 
-Simply import `AsyncSupermemory` instead of `supermemory` and use `await` with each API call:
+Simply import `AsyncSupermemory` instead of `Supermemory` and use `await` with each API call:
 
 ```python
 import os
@@ -76,7 +76,7 @@ Request parameters that correspond to file uploads can be passed as `bytes`, or 
 from pathlib import Path
 from supermemory import Supermemory
 
-client = supermemory()
+client = Supermemory()
 
 client.memories.upload_file(
     file=Path("/path/to/file"),
@@ -98,7 +98,7 @@ All errors inherit from `supermemory.APIError`.
 import supermemory
 from supermemory import Supermemory
 
-client = supermemory()
+client = Supermemory()
 
 try:
     client.memories.add(
@@ -140,7 +140,7 @@ You can use the `max_retries` option to configure or disable retry settings:
 from supermemory import Supermemory
 
 # Configure the default for all requests:
-client = supermemory(
+client = Supermemory(
     # default is 2
     max_retries=0,
 )
@@ -160,13 +160,13 @@ which accepts a float or an [`httpx.Timeout`](https://www.python-httpx.org/advan
 from supermemory import Supermemory
 
 # Configure the default for all requests:
-client = supermemory(
+client = Supermemory(
     # 20 seconds (default is 1 minute)
     timeout=20.0,
 )
 
 # More granular control:
-client = supermemory(
+client = Supermemory(
     timeout=httpx.Timeout(60.0, read=5.0, write=10.0, connect=2.0),
 )
 
@@ -213,7 +213,7 @@ The "raw" Response object can be accessed by prefixing `.with_raw_response.` to 
 ```py
 from supermemory import Supermemory
 
-client = supermemory()
+client = Supermemory()
 response = client.memories.with_raw_response.add(
     content="This is a detailed article about machine learning concepts...",
 )
@@ -291,7 +291,7 @@ You can directly override the [httpx client](https://www.python-httpx.org/api/#c
 import httpx
 from supermemory import Supermemory, DefaultHttpxClient
 
-client = supermemory(
+client = Supermemory(
     # Or use the `SUPERMEMORY_BASE_URL` env var
     base_url="http://my.test.server.example.com:8083",
     http_client=DefaultHttpxClient(
@@ -314,7 +314,7 @@ By default the library closes underlying HTTP connections whenever the client is
 ```py
 from supermemory import Supermemory
 
-with supermemory() as client:
+with Supermemory() as client:
   # make requests here
   ...
 

--- a/apps/docs/memory-api/sdks/typescript.mdx
+++ b/apps/docs/memory-api/sdks/typescript.mdx
@@ -13,9 +13,9 @@ npm install supermemory
 ## Usage
 
 ```js
-import supermemory from 'supermemory';
+import Supermemory from 'supermemory';
 
-const client = new supermemory({
+const client = new Supermemory({
   apiKey: process.env['SUPERMEMORY_API_KEY'], // This is the default and can be omitted
 });
 
@@ -34,9 +34,9 @@ This library includes TypeScript definitions for all request params and response
 
 
 ```ts
-import supermemory from 'supermemory';
+import Supermemory from 'supermemory';
 
-const client = new supermemory({
+const client = new Supermemory({
   apiKey: process.env['SUPERMEMORY_API_KEY'], // This is the default and can be omitted
 });
 
@@ -63,9 +63,9 @@ Request parameters that correspond to file uploads can be passed in many differe
 
 ```ts
 import fs from 'fs';
-import supermemory, { toFile } from 'supermemory';
+import Supermemory, { toFile } from 'supermemory';
 
-const client = new supermemory();
+const client = new Supermemory();
 
 // If you have access to Node `fs` we recommend using `fs.createReadStream()`:
 await client.memories.uploadFile({ file: fs.createReadStream('/path/to/file') });
@@ -130,7 +130,7 @@ You can use the `maxRetries` option to configure or disable this:
 
 ```js
 // Configure the default for all requests:
-const client = new supermemory({
+const client = new Supermemory({
   maxRetries: 0, // default is 2
 });
 
@@ -147,7 +147,7 @@ Requests time out after 1 minute by default. You can configure this with a `time
 
 ```ts
 // Configure the default for all requests:
-const client = new supermemory({
+const client = new Supermemory({
   timeout: 20 * 1000, // 20 seconds (default is 1 minute)
 });
 
@@ -173,7 +173,7 @@ Unlike `.asResponse()` this method consumes the body, returning once it is parse
 
 
 ```ts
-const client = new supermemory();
+const client = new Supermemory();
 
 const response = await client.memories
   .add({ content: 'This is a detailed article about machine learning concepts...' })
@@ -202,9 +202,9 @@ The log level can be configured in two ways:
 2. Using the `logLevel` client option (overrides the environment variable if set)
 
 ```ts
-import supermemory from 'supermemory';
+import Supermemory from 'supermemory';
 
-const client = new supermemory({
+const client = new Supermemory({
   logLevel: 'debug', // Show all log messages
 });
 ```
@@ -230,12 +230,12 @@ When providing a custom logger, the `logLevel` option still controls which messa
 below the configured level will not be sent to your logger.
 
 ```ts
-import supermemory from 'supermemory';
+import Supermemory from 'supermemory';
 import pino from 'pino';
 
 const logger = pino();
 
-const client = new supermemory({
+const client = new Supermemory({
   logger: logger.child({ name: 'supermemory' }),
   logLevel: 'debug', // Send all messages to pino, allowing it to filter
 });
@@ -300,10 +300,10 @@ globalThis.fetch = fetch;
 Or pass it to the client:
 
 ```ts
-import supermemory from 'supermemory';
+import Supermemory from 'supermemory';
 import fetch from 'my-fetch';
 
-const client = new supermemory({ fetch });
+const client = new Supermemory({ fetch });
 ```
 
 ### Fetch options
@@ -311,9 +311,9 @@ const client = new supermemory({ fetch });
 If you want to set custom `fetch` options without overriding the `fetch` function, you can provide a `fetchOptions` object when instantiating the client or making a request. (Request-specific options override client options.)
 
 ```ts
-import supermemory from 'supermemory';
+import Supermemory from 'supermemory';
 
-const client = new supermemory({
+const client = new Supermemory({
   fetchOptions: {
     // `RequestInit` options
   },
@@ -325,11 +325,11 @@ const client = new supermemory({
 To modify proxy behavior, you can provide custom `fetchOptions` that add runtime-specific proxy options to requests:
 
 ```ts
-import supermemory from 'supermemory';
+import Supermemory from 'supermemory';
 import * as undici from 'undici';
 
 const proxyAgent = new undici.ProxyAgent('http://localhost:8888');
-const client = new supermemory({
+const client = new Supermemory({
   fetchOptions: {
     dispatcher: proxyAgent,
   },
@@ -337,9 +337,9 @@ const client = new supermemory({
 ```
 
 ```ts
-import supermemory from 'supermemory';
+import Supermemory from 'supermemory';
 
-const client = new supermemory({
+const client = new Supermemory({
   fetchOptions: {
     proxy: 'http://localhost:8888',
   },
@@ -347,10 +347,10 @@ const client = new supermemory({
 ```
 
 ```ts
-import supermemory from 'npm:supermemory';
+import Supermemory from 'npm:supermemory';
 
 const httpClient = Deno.createHttpClient({ proxy: { url: 'http://localhost:8888' } });
-const client = new supermemory({
+const client = new Supermemory({
   fetchOptions: {
     client: httpClient,
   },


### PR DESCRIPTION
The Python code examples had the wrong class name. Changed that from `supermemory` to `Supermemory`

Python:
```diff
-client = supermemory()
+client = Supermemory()
```

The JavaScript/TypeScript code examples will work because it's a default import but still following the correct name of the class and to be consistent with the [NPM docs](https://www.npmjs.com/package/supermemory), I renamed it from `supermemory` to `Supermemory`

JS:
```diff
-import supermemory from 'supermemory';
+import Supermemory from 'supermemory';

-const client = new supermemory();
+const client = new Supermemory();
```