### PR TITLE
feat: improved add memory UI bits

### DIFF
--- a/apps/web/components/views/add-memory/action-buttons.tsx
+++ b/apps/web/components/views/add-memory/action-buttons.tsx
@@ -26,7 +26,7 @@ export function ActionButtons({
 	return (
 		<div className={`flex gap-3 order-1 sm:order-2 justify-end ${className}`}>
 			<Button
-				className="hover:bg-foreground/10 border-none flex-1 sm:flex-initial"
+				className="hover:bg-foreground/10 border-none flex-1 sm:flex-initial cursor-pointer"
 				onClick={onCancel}
 				type="button"
 				variant="ghost"
@@ -40,7 +40,7 @@ export function ActionButtons({
 				className="flex-1 sm:flex-initial"
 			>
 				<Button
-					className="w-full"
+					className="w-full cursor-pointer"
 					disabled={isSubmitting || isSubmitDisabled}
 					onClick={submitType === "button" ? onSubmit : undefined}
 					type={submitType}

--- a/apps/web/components/views/add-memory/index.tsx
+++ b/apps/web/components/views/add-memory/index.tsx
@@ -556,7 +556,7 @@ export function AddMemoryView({
 							<TabsList className="flex flex-col gap-2 max-w-48 h-fit bg-transparent p-0">
 								<TabsTrigger
 									value="note"
-									className="flex flex-col gap-1 justify-start items-start h-auto w-full"
+									className="flex flex-col gap-1 justify-start items-start h-auto w-full cursor-pointer"
 								>
 									<div className="flex gap-1 items-center">
 										<Brain className="h-4 w-4" />
@@ -568,7 +568,7 @@ export function AddMemoryView({
 								</TabsTrigger>
 								<TabsTrigger
 									value="link"
-									className="flex flex-col gap-1 justify-start items-start h-auto w-full"
+									className="flex flex-col gap-1 justify-start items-start h-auto w-full cursor-pointer"
 								>
 									<div className="flex gap-1 items-center">
 										<LinkIcon className="h-4 w-4" />
@@ -580,7 +580,7 @@ export function AddMemoryView({
 								</TabsTrigger>
 								<TabsTrigger
 									value="file"
-									className="flex flex-col gap-1 justify-start items-start h-auto w-full"
+									className="flex flex-col gap-1 justify-start items-start h-auto w-full cursor-pointer"
 								>
 									<div className="flex gap-1 items-center">
 										<FileIcon className="h-4 w-4" />
@@ -592,7 +592,7 @@ export function AddMemoryView({
 								</TabsTrigger>
 								<TabsTrigger
 									value="connect"
-									className="flex flex-col gap-1 justify-start items-start h-auto w-full"
+									className="flex flex-col gap-1 justify-start items-start h-auto w-full cursor-pointer"
 								>
 									<div className="flex gap-1 items-center">
 										<PlugIcon className="h-4 w-4" />
@@ -1036,7 +1036,7 @@ export function AddMemoryView({
 									whileTap={{ scale: 0.95 }}
 								>
 									<Button
-										className="bg-white/5 hover:bg-white/10 border-white/10 w-full sm:w-auto"
+										className="bg-white/5 hover:bg-white/10 border-white/10 w-full sm:w-auto cursor-pointer"
 										onClick={() => {
 											setShowCreateProjectDialog(false)
 											setNewProjectName("")
@@ -1053,7 +1053,7 @@ export function AddMemoryView({
 									whileTap={{ scale: 0.95 }}
 								>
 									<Button
-										className="bg-white/10 hover:bg-white/20 border-white/20 w-full sm:w-auto"
+										className="bg-white/10 hover:bg-white/20 border-white/20 w-full sm:w-auto cursor-pointer"
 										disabled={
 											createProjectMutation.isPending || !newProjectName.trim()
 										}
@@ -1104,7 +1104,7 @@ export function AddMemoryExpandedView() {
 				<div className="flex flex-wrap gap-2">
 					<motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
 						<Button
-							className="bg-white/10 hover:bg-white/20 border-white/20"
+							className="bg-white/10 hover:bg-white/20 border-white/20 cursor-pointer"
 							onClick={() => handleOpenDialog("note")}
 							size="sm"
 							variant="outline"
@@ -1116,7 +1116,7 @@ export function AddMemoryExpandedView() {
 
 					<motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
 						<Button
-							className="bg-white/10 hover:bg-white/20 border-white/20"
+							className="bg-white/10 hover:bg-white/20 border-white/20 cursor-pointer"
 							onClick={() => handleOpenDialog("link")}
 							size="sm"
 							variant="outline"
@@ -1128,7 +1128,7 @@ export function AddMemoryExpandedView() {
 
 					<motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
 						<Button
-							className="bg-white/10 hover:bg-white/20 border-white/20"
+							className="bg-white/10 hover:bg-white/20 border-white/20 cursor-pointer"
 							onClick={() => handleOpenDialog("file")}
 							size="sm"
 							variant="outline"
@@ -1140,7 +1140,7 @@ export function AddMemoryExpandedView() {
 
 					<motion.div whileHover={{ scale: 1.05 }} whileTap={{ scale: 0.95 }}>
 						<Button
-							className="bg-white/10 hover:bg-white/20 border-white/20"
+							className="bg-white/10 hover:bg-white/20 border-white/20 cursor-pointer"
 							onClick={() => handleOpenDialog("connect")}
 							size="sm"
 							variant="outline"

--- a/apps/web/components/views/add-memory/project-selection.tsx
+++ b/apps/web/components/views/add-memory/project-selection.tsx
@@ -50,7 +50,7 @@ export function ProjectSelection({
       value={selectedProject}
     >
       <SelectTrigger
-        className={`bg-foreground/5 border-foreground/10 ${className}`}
+        className={`bg-foreground/5 border-foreground/10 cursor-pointer ${className}`}
         id={id}
       >
         <SelectValue placeholder="Select a project" />

--- a/apps/web/components/views/add-memory/text-editor.tsx
+++ b/apps/web/components/views/add-memory/text-editor.tsx
@@ -404,7 +404,7 @@ export function TextEditor({
 			variant="ghost"
 			size="sm"
 			className={cn(
-				"h-8 w-8 !p-0 text-foreground/70 transition-all duration-200 rounded-sm",
+				"h-8 w-8 !p-0 text-foreground/70 transition-all duration-200 rounded-sm cursor-pointer",
 				"hover:bg-foreground/15 hover:text-foreground hover:scale-105",
 				"active:scale-95",
 				isActive && "bg-foreground/20 text-foreground",
@@ -425,7 +425,7 @@ export function TextEditor({
 	return (
 		<div className={cn("bg-foreground/5 border border-foreground/10 rounded-md", containerClassName)}>
 			<div className={cn("flex flex-col", className)}>
-			<div className="flex-1 min-h-48 max-h-64 overflow-y-auto">
+			<div className="flex-1 min-h-48 overflow-y-auto">
 				<Slate
 					editor={editor}
 					initialValue={editorValue}
@@ -451,8 +451,8 @@ export function TextEditor({
 							disabled && "opacity-50 cursor-not-allowed",
 						)}
 						style={{
-							minHeight: "11rem",
-							maxHeight: "15rem",
+							minHeight: "23rem",
+							maxHeight: "23rem",
 							padding: "12px",
 							overflowX: "hidden",
 						}}

--- a/apps/web/components/views/connections-tab-content.tsx
+++ b/apps/web/components/views/connections-tab-content.tsx
@@ -213,7 +213,7 @@ export function ConnectionsTabContent() {
 						sync your documents.
 					</p>
 					<Button
-						className="bg-yellow-500/20 text-black-400 hover:bg-yellow-500/30 dark:text-yellow-400 border-yellow-500/30"
+						className="bg-yellow-500/20 text-black-400 hover:bg-yellow-500/30 dark:text-yellow-400 border-yellow-500/30 cursor-pointer"
 						onClick={handleUpgrade}
 						size="sm"
 						variant="secondary"
@@ -280,7 +280,7 @@ export function ConnectionsTabContent() {
 									whileTap={{ scale: 0.9 }}
 								>
 									<Button
-										className="text-foreground/50 hover:text-red-400"
+										className="text-foreground/50 hover:text-red-400 cursor-pointer"
 										disabled={deleteConnectionMutation.isPending}
 										onClick={() =>
 											deleteConnectionMutation.mutate(connection.id)
@@ -311,7 +311,7 @@ export function ConnectionsTabContent() {
 								transition={{ delay: index * 0.05 }}
 							>
 								<Button
-									className="justify-start h-auto p-4 bg-foreground/5 hover:bg-foreground/10 border-foreground/10 w-full"
+									className="justify-start h-auto p-4 bg-foreground/5 hover:bg-foreground/10 border-foreground/10 w-full cursor-pointer"
 									disabled={addConnectionMutation.isPending}
 									onClick={() => {
 										addConnectionMutation.mutate(provider as ConnectorProvider)

--- a/packages/ui/components/shadcn-io/dropzone.tsx
+++ b/packages/ui/components/shadcn-io/dropzone.tsx
@@ -83,7 +83,7 @@ export const Dropzone = ({
 		>
 			<Button
 				className={cn(
-					"relative h-auto w-full flex-col overflow-hidden p-8",
+					"relative h-auto w-full flex-col overflow-hidden p-8 cursor-pointer",
 					isDragActive && "outline-none ring-1 ring-ring",
 					className,
 				)}


### PR DESCRIPTION
# Changed button effect and increased text editor height

Added `cursor-pointer` class to buttons and interactive elements across the add memory interface for better UX, and increased the text editor height for better writing experience.

### Before:

<img width="929" height="521" alt="Screenshot 2025-10-20 at 4 17 57 PM" src="https://github.com/user-attachments/assets/f3789cc7-716d-4727-abae-da1b6e6a377a" />

### After:

<img width="897" height="496" alt="Screenshot 2025-10-20 at 3 34 05 PM" src="https://github.com/user-attachments/assets/5672bae7-305b-4232-9eb2-9aba92e5d9b3" />


## Files changed:
- `apps/web/components/views/add-memory/text-editor.tsx` - Added cursor-pointer to toolbar buttons and increased text area height from 11-15rem to 23rem
- `apps/web/components/views/add-memory/action-buttons.tsx` - Added to Cancel and Submit buttons  
- `apps/web/components/views/add-memory/project-selection.tsx` - Added to SelectTrigger
- `apps/web/components/views/add-memory/index.tsx` - Added to tab triggers and dialog buttons
- `apps/web/components/views/connections-tab-content.tsx` - Added to Connect tab buttons
- `packages/ui/components/shadcn-io/dropzone.tsx` - Added to file upload dropzone

Improves user experience by showing pointer cursor on clickable elements and provides more space for writing notes.