### PR TITLE
feat: optional posthog intialization

### DIFF
--- a/apps/web/lib/analytics.ts
+++ b/apps/web/lib/analytics.ts
@@ -1,7 +1,14 @@
 import posthog from "posthog-js"
 
+// Helper function to safely capture events
+const safeCapture = (eventName: string, properties?: Record<string, any>) => {
+    if (posthog.__loaded) {
+        posthog.capture(eventName, properties)
+    }
+}
+
 export const analytics = {
-	userSignedOut: () => posthog.capture("user_signed_out"),
+	userSignedOut: () => safeCapture("user_signed_out"),
 
 	memoryAdded: (props: {
 		type: "note" | "link" | "file"
@@ -9,35 +16,35 @@ export const analytics = {
 		content_length?: number
 		file_size?: number
 		file_type?: string
-	}) => posthog.capture("memory_added", props),
+	}) => safeCapture("memory_added", props),
 
-	memoryDetailOpened: () => posthog.capture("memory_detail_opened"),
+	memoryDetailOpened: () => safeCapture("memory_detail_opened"),
 
-	projectCreated: () => posthog.capture("project_created"),
+	projectCreated: () => safeCapture("project_created"),
 
-	newChatStarted: () => posthog.capture("new_chat_started"),
-	chatHistoryViewed: () => posthog.capture("chat_history_viewed"),
-	chatDeleted: () => posthog.capture("chat_deleted"),
+	newChatStarted: () => safeCapture("new_chat_started"),
+	chatHistoryViewed: () => safeCapture("chat_history_viewed"),
+	chatDeleted: () => safeCapture("chat_deleted"),
 
 	viewModeChanged: (mode: "graph" | "list") =>
-		posthog.capture("view_mode_changed", { mode }),
+		safeCapture("view_mode_changed", { mode }),
 
-	documentCardClicked: () => posthog.capture("document_card_clicked"),
+	documentCardClicked: () => safeCapture("document_card_clicked"),
 
-	billingViewed: () => posthog.capture("billing_viewed"),
-	upgradeInitiated: () => posthog.capture("upgrade_initiated"),
-	upgradeCompleted: () => posthog.capture("upgrade_completed"),
-	billingPortalOpened: () => posthog.capture("billing_portal_opened"),
+	billingViewed: () => safeCapture("billing_viewed"),
+	upgradeInitiated: () => safeCapture("upgrade_initiated"),
+	upgradeCompleted: () => safeCapture("upgrade_completed"),
+	billingPortalOpened: () => safeCapture("billing_portal_opened"),
 
 	connectionAdded: (provider: string) =>
-		posthog.capture("connection_added", { provider }),
-	connectionDeleted: () => posthog.capture("connection_deleted"),
-	connectionAuthStarted: () => posthog.capture("connection_auth_started"),
-	connectionAuthCompleted: () => posthog.capture("connection_auth_completed"),
-	connectionAuthFailed: () => posthog.capture("connection_auth_failed"),
+		safeCapture("connection_added", { provider }),
+	connectionDeleted: () => safeCapture("connection_deleted"),
+	connectionAuthStarted: () => safeCapture("connection_auth_started"),
+	connectionAuthCompleted: () => safeCapture("connection_auth_completed"),
+	connectionAuthFailed: () => safeCapture("connection_auth_failed"),
 
-	mcpViewOpened: () => posthog.capture("mcp_view_opened"),
-	mcpInstallCmdCopied: () => posthog.capture("mcp_install_cmd_copied"),
+	mcpViewOpened: () => safeCapture("mcp_view_opened"),
+	mcpInstallCmdCopied: () => safeCapture("mcp_install_cmd_copied"),
 
-	extensionInstallClicked: () => posthog.capture("extension_install_clicked"),
+	extensionInstallClicked: () => safeCapture("extension_install_clicked"),
 }

--- a/packages/lib/error-tracking.tsx
+++ b/packages/lib/error-tracking.tsx
@@ -14,6 +14,7 @@ export function useErrorTracking() {
 		error: Error | unknown,
 		context?: Record<string, any>,
 	) => {
+		if (!posthog.__loaded) return
 		const errorDetails = {
 			error_message: error instanceof Error ? error.message : String(error),
 			error_stack: error instanceof Error ? error.stack : undefined,
@@ -117,6 +118,7 @@ export function useInteractionTracking() {
 	const pathname = usePathname()
 
 	const trackInteraction = (action: string, details?: Record<string, any>) => {
+		if (!posthog.__loaded) return
 		posthog.capture("user_interaction", {
 			action,
 			pathname,
@@ -131,6 +133,7 @@ export function useInteractionTracking() {
 		success: boolean,
 		details?: Record<string, any>,
 	) => {
+		if (!posthog.__loaded) return
 		posthog.capture("form_submission", {
 			form_name: formName,
 			success,

--- a/packages/lib/posthog.tsx
+++ b/packages/lib/posthog.tsx
@@ -11,7 +11,7 @@ function PostHogPageTracking() {
 
 	// Page tracking
 	useEffect(() => {
-		if (pathname) {
+		if (pathname && posthog.__loaded) {
 			let url = window.origin + pathname
 			if (searchParams.toString()) {
 				url = `${url}?${searchParams.toString()}`
@@ -38,19 +38,24 @@ export function PostHogProvider({ children }: { children: React.ReactNode }) {
 
 	useEffect(() => {
 		if (typeof window !== "undefined") {
-			posthog.init(process.env.NEXT_PUBLIC_POSTHOG_KEY ?? "", {
+			const posthogKey = process.env.NEXT_PUBLIC_POSTHOG_KEY
+			if (posthogKey){
+			posthog.init(posthogKey, {
 				api_host: process.env.NEXT_PUBLIC_BACKEND_URL + "/orange",
 				ui_host: "https://us.i.posthog.com",
 				person_profiles: "identified_only",
 				capture_pageview: false,
 				capture_pageleave: true,
-			})
+			})}
+			else{
+				console.warn("PostHog API key is not set. PostHog will not be initialized.")
+			}
 		}
 	}, [])
 
 	// User identification
 	useEffect(() => {
-		if (session?.user) {
+		if (session?.user && posthog.__loaded) {
 			posthog.identify(session.user.id, {
 				email: session.user.email,
 				name: session.user.name,


### PR DESCRIPTION
This pr partially addresses #506 where it was noticed that it's raising error when posthog key is not defined in env vars and thus introduced following changes 


* Introduced a `safeCapture` helper in `analytics.ts` to ensure all analytics events are only sent if PostHog is loaded, and updated all analytics methods to use this helper.
* Added checks for `posthog.__loaded` before capturing error and interaction events in `error-tracking.tsx` to prevent errors if PostHog is not ready. 
* Updated page tracking in `posthog.tsx` to only track pages if PostHog is loaded.
* Modified PostHog initialization to check for the presence of the API key before attempting to initialize, and added a warning if the key is missing.
* Ensured user identification is only attempted when PostHog is loaded.