### PR TITLE
Refactor browser extension content scripts to use platform adapters

### DIFF
--- a/apps/browser-extension/entrypoints/content/adapters/platform-adapter.ts
+++ b/apps/browser-extension/entrypoints/content/adapters/platform-adapter.ts
@@ -1,0 +1,17 @@
+export interface PlatformAdapter {
+	/**
+	 * Unique identifier for the adapter. Useful for debugging and telemetry.
+	 */
+	readonly id: string
+
+	/**
+	 * Determines whether this adapter should run for the current page.
+	 */
+	matches(): boolean
+
+	/**
+	 * Performs any one-time setup. Implementations should be idempotent.
+	 */
+	init(): void
+}
+

--- a/apps/browser-extension/entrypoints/content/chatgpt.ts
+++ b/apps/browser-extension/entrypoints/content/chatgpt.ts
@@ -10,6 +10,7 @@ import {
 	createChatGPTInputBarElement,
 	DOMUtils,
 } from "../../utils/ui-components"
+import type { PlatformAdapter } from "./adapters/platform-adapter"
 
 let chatGPTDebounceTimeout: NodeJS.Timeout | null = null
 let chatGPTRouteObserver: MutationObserver | null = null
@@ -37,6 +38,7 @@ export function initializeChatGPT() {
 
 	document.body.setAttribute("data-chatgpt-initialized", "true")
 }
+
 
 function setupChatGPTRouteChangeDetection() {
 	if (chatGPTRouteObserver) {
@@ -253,6 +255,13 @@ function addSupermemoryButtonToMemoriesDialog() {
 		deleteAllContainer.firstChild,
 	)
 }
+
+export const chatGPTAdapter: PlatformAdapter = {
+	id: "chatgpt",
+	matches: () => DOMUtils.isOnDomain(DOMAINS.CHATGPT),
+	init: initializeChatGPT,
+}
+
 
 async function saveMemoriesToSupermemory() {
 	try {

--- a/apps/browser-extension/entrypoints/content/claude.ts
+++ b/apps/browser-extension/entrypoints/content/claude.ts
@@ -10,6 +10,7 @@ import {
 	createClaudeInputBarElement,
 	DOMUtils,
 } from "../../utils/ui-components"
+import type { PlatformAdapter } from "./adapters/platform-adapter"
 
 let claudeDebounceTimeout: NodeJS.Timeout | null = null
 let claudeRouteObserver: MutationObserver | null = null
@@ -588,6 +589,13 @@ function setupClaudePromptCapture() {
 		true,
 	)
 }
+
+export const claudeAdapter: PlatformAdapter = {
+	id: "claude",
+	matches: () => DOMUtils.isOnDomain(DOMAINS.CLAUDE),
+	init: initializeClaude,
+}
+
 
 async function setupClaudeAutoFetch() {
 	const result = await chrome.storage.local.get([


### PR DESCRIPTION
## Summary
- introduce a tiny PlatformAdapter interface so each host (ChatGPT, Claude, etc.) can plug in cleanly
- move ChatGPT and Claude scripts onto the adapter pattern and have the loader iterate adapters instead of hard-coded checks
- lay the groundwork for adding new chat hosts without duplicating the DOM-wiring logic


