### PR TITLE
fix: add integer and minimum validation for limit parameter

### DIFF
--- a/packages/validation/api.ts
+++ b/packages/validation/api.ts
@@ -269,6 +269,12 @@ export const ListMemoriesQuerySchema = z
 			.regex(/^\d+$/)
 			.or(z.number())
 			.transform(Number)
+			.refine((value) => value % 1 === 0, {
+				message: "Limit must be an integer",
+			})
+			.refine((value) => value >= 1, {
+				message: "Limit must be at least 1",
+			})
 			.refine((value) => value <= 1100, {
 				message: "Limit cannot be greater than 1100",
 			})


### PR DESCRIPTION
HEY @MaheshtheDev @Dhravya 
I was trying to integrate the api to lsit the documents , i accidently put negative number and it returned , there i catched one bug , so  i tried to test it on rest of the things also

I found this
1. It is not working on decimal numbers [ Returning on server error]
2. It is returning even on negative numbers

I have added fixes for it and tested it . Please review and Merge
<img width="1542" height="792" alt="image" src="https://github.com/user-attachments/assets/5229008f-21df-4ec2-8f63-c033fbd6d71a" />
<img width="1363" height="1008" alt="image" src="https://github.com/user-attachments/assets/592f522a-e6f3-4a6c-abce-ce1eab5916fd" />
<img width="1494" height="1060" alt="image" src="https://github.com/user-attachments/assets/ad2bfbca-d553-4721-ad2e-5b9d7646812a" />
