### PR TITLE
fix: disable google drive connection due to upstream provider issue

### DIFF
--- a/apps/web/components/views/connections-tab-content.tsx
+++ b/apps/web/components/views/connections-tab-content.tsx
@@ -111,6 +111,13 @@ export function ConnectionsTabContent() {
 	// Add connection mutation
 	const addConnectionMutation = useMutation({
 		mutationFn: async (provider: ConnectorProvider) => {
+			// Check if Google Drive is disabled
+			if (provider === "google-drive") {
+				throw new Error(
+					"Google Drive connections are temporarily disabled. This will be resolved soon.",
+				)
+			}
+
 			// Check if user can add connections
 			if (!canAddConnection && !isProUser) {
 				throw new Error(
@@ -312,7 +319,10 @@ export function ConnectionsTabContent() {
 							>
 								<Button
 									className="justify-start h-auto p-4 bg-foreground/5 hover:bg-foreground/10 border-foreground/10 w-full cursor-pointer"
-									disabled={addConnectionMutation.isPending}
+									disabled={
+										provider === "google-drive" ||
+										addConnectionMutation.isPending
+									}
 									onClick={() => {
 										addConnectionMutation.mutate(provider as ConnectorProvider)
 									}}
@@ -324,6 +334,11 @@ export function ConnectionsTabContent() {
 										<div className="text-sm text-foreground/60 mt-0.5">
 											{config.description}
 										</div>
+										{provider === "google-drive" && (
+											<div className="text-xs text-muted-foreground/80 mt-1">
+												Temporarily disabled. This will be resolved soon.
+											</div>
+										)}
 									</div>
 								</Button>
 							</motion.div>

--- a/apps/web/components/views/integrations.tsx
+++ b/apps/web/components/views/integrations.tsx
@@ -280,6 +280,12 @@ export function IntegrationsView() {
 				throw new Error("This integration is coming soon!")
 			}
 
+			if (provider === "google-drive") {
+				throw new Error(
+					"Google Drive connections are temporarily disabled. This will be resolved soon.",
+				)
+			}
+
 			if (!canAddConnection && !isProUser) {
 				throw new Error(
 					"Free plan doesn't include connections. Upgrade to Pro for unlimited connections.",
@@ -890,6 +896,13 @@ export function IntegrationsView() {
 																</div>
 															)}
 														</div>
+													) : provider === "google-drive" ? (
+														<div className="flex items-center gap-1 mt-1">
+															<div className="w-2 h-2 bg-muted-foreground rounded-full" />
+															<span className="text-xs text-muted-foreground font-medium">
+																Temporarily Disabled
+															</span>
+														</div>
 													) : (
 														<div className="flex items-center gap-1 mt-1">
 															<div className="w-2 h-2 bg-muted-foreground rounded-full" />
@@ -919,12 +932,20 @@ export function IntegrationsView() {
 											{config.description}
 										</p>
 
+										{!isConnected &&
+											!isMoreComing &&
+											provider === "google-drive" && (
+												<p className="text-xs text-muted-foreground/80 mb-3 leading-relaxed">
+													Google Drive connections are temporarily disabled.
+													This will be resolved soon.
+												</p>
+											)}
+
 										{isConnected && !isMoreComing && (
 											<div className="space-y-1">
 												{connection?.email && (
 													<p className="text-xs text-muted-foreground/70">
-														Email:{" "}
-														{connection.email}
+														Email: {connection.email}
 													</p>
 												)}
 												{connection?.metadata?.lastSyncedAt && (
@@ -1026,6 +1047,7 @@ export function IntegrationsView() {
 												<Button
 													className="flex-shrink-0 disabled:cursor-not-allowed w-20 justify-center"
 													disabled={
+														provider === "google-drive" ||
 														addConnectionMutation.isPending ||
 														connectingProvider === provider ||
 														!isProUser


### PR DESCRIPTION
> [!NOTE]
> Temporarily disabled Google Drive connections with appropriate UI indicators and error messages.

### What changed?

- Added checks to prevent users from connecting to Google Drive in both the connections tab and integrations view
- Added error messages explaining that Google Drive connections are temporarily disabled
- Updated UI to visually indicate that Google Drive is disabled:
    - Added "Temporarily disabled" status indicator in the integrations list
    - Added explanatory text in multiple locations
    - Disabled the connect button for Google Drive specifically