### PR TITLE
refactor: replace chrome storage api with wxt's storage api

### DIFF
--- a/apps/browser-extension/entrypoints/content/chatgpt.ts
+++ b/apps/browser-extension/entrypoints/content/chatgpt.ts
@@ -3,9 +3,12 @@ import {
 	ELEMENT_IDS,
 	MESSAGE_TYPES,
 	POSTHOG_EVENT_KEY,
-	STORAGE_KEYS,
 	UI_CONFIG,
 } from "../../utils/constants"
+import {
+	autoSearchEnabled,
+	autoCapturePromptsEnabled,
+} from "../../utils/storage"
 import {
 	createChatGPTInputBarElement,
 	DOMUtils,
@@ -578,12 +581,9 @@ function addSaveChatGPTElementBeforeComposerBtn() {
 }
 
 async function setupChatGPTAutoFetch() {
-	const result = await chrome.storage.local.get([
-		STORAGE_KEYS.AUTO_SEARCH_ENABLED,
-	])
-	const autoSearchEnabled = result[STORAGE_KEYS.AUTO_SEARCH_ENABLED] ?? false
+	const autoSearch = (await autoSearchEnabled.getValue()) ?? false
 
-	if (!autoSearchEnabled) {
+	if (!autoSearch) {
 		return
 	}
 
@@ -640,13 +640,9 @@ function setupChatGPTPromptCapture() {
 	document.body.setAttribute("data-chatgpt-prompt-capture-setup", "true")
 
 	const capturePromptContent = async (source: string) => {
-		const result = await chrome.storage.local.get([
-			STORAGE_KEYS.AUTO_CAPTURE_PROMPTS_ENABLED,
-		])
-		const autoCapturePromptsEnabled =
-			result[STORAGE_KEYS.AUTO_CAPTURE_PROMPTS_ENABLED] ?? false
+		const autoCapture = (await autoCapturePromptsEnabled.getValue()) ?? false
 
-		if (!autoCapturePromptsEnabled) {
+		if (!autoCapture) {
 			console.log("Auto capture prompts is disabled, skipping prompt capture")
 			return
 		}

--- a/apps/browser-extension/entrypoints/content/claude.ts
+++ b/apps/browser-extension/entrypoints/content/claude.ts
@@ -3,9 +3,12 @@ import {
 	ELEMENT_IDS,
 	MESSAGE_TYPES,
 	POSTHOG_EVENT_KEY,
-	STORAGE_KEYS,
 	UI_CONFIG,
 } from "../../utils/constants"
+import {
+	autoSearchEnabled,
+	autoCapturePromptsEnabled,
+} from "../../utils/storage"
 import {
 	createClaudeInputBarElement,
 	DOMUtils,
@@ -488,13 +491,9 @@ function setupClaudePromptCapture() {
 	}
 	document.body.setAttribute("data-claude-prompt-capture-setup", "true")
 	const captureClaudePromptContent = async (source: string) => {
-		const result = await chrome.storage.local.get([
-			STORAGE_KEYS.AUTO_CAPTURE_PROMPTS_ENABLED,
-		])
-		const autoCapturePromptsEnabled =
-			result[STORAGE_KEYS.AUTO_CAPTURE_PROMPTS_ENABLED] ?? false
+		const autoCapture = (await autoCapturePromptsEnabled.getValue()) ?? false
 
-		if (!autoCapturePromptsEnabled) {
+		if (!autoCapture) {
 			console.log("Auto capture prompts is disabled, skipping prompt capture")
 			return
 		}
@@ -600,11 +599,8 @@ function setupClaudePromptCapture() {
 }
 
 async function setupClaudeAutoFetch() {
-	const result = await chrome.storage.local.get([
-		STORAGE_KEYS.AUTO_SEARCH_ENABLED,
-	])
-	const autoSearchEnabled = result[STORAGE_KEYS.AUTO_SEARCH_ENABLED] ?? false
-	if (!autoSearchEnabled) {
+	const autoSearch = (await autoSearchEnabled.getValue()) ?? false
+	if (!autoSearch) {
 		return
 	}
 

--- a/apps/browser-extension/entrypoints/content/shared.ts
+++ b/apps/browser-extension/entrypoints/content/shared.ts
@@ -1,4 +1,5 @@
-import { MESSAGE_TYPES, STORAGE_KEYS } from "../../utils/constants"
+import { MESSAGE_TYPES } from "../../utils/constants"
+import { bearerToken, userData } from "../../utils/storage"
 import { DOMUtils } from "../../utils/ui-components"
 import { default as TurndownService } from "turndown"
 
@@ -95,13 +96,13 @@ export function setupGlobalKeyboardShortcut() {
 }
 
 export function setupStorageListener() {
-	window.addEventListener("message", (event) => {
+	window.addEventListener("message", async (event) => {
 		if (event.source !== window) {
 			return
 		}
-		const bearerToken = event.data.token
-		const userData = event.data.userData
-		if (bearerToken && userData) {
+		const token = event.data.token
+		const user = event.data.userData
+		if (token && user) {
 			if (
 				!(
 					window.location.hostname === "localhost" ||
@@ -115,13 +116,11 @@ export function setupStorageListener() {
 				return
 			}
 
-			chrome.storage.local.set(
-				{
-					[STORAGE_KEYS.BEARER_TOKEN]: bearerToken,
-					[STORAGE_KEYS.USER_DATA]: userData,
-				},
-				() => {},
-			)
+			try {
+				await Promise.all([bearerToken.setValue(token), userData.setValue(user)])
+			} catch {
+				// Do nothing
+			}
 		}
 	})
 }

--- a/apps/browser-extension/entrypoints/content/t3.ts
+++ b/apps/browser-extension/entrypoints/content/t3.ts
@@ -3,9 +3,12 @@ import {
 	ELEMENT_IDS,
 	MESSAGE_TYPES,
 	POSTHOG_EVENT_KEY,
-	STORAGE_KEYS,
 	UI_CONFIG,
 } from "../../utils/constants"
+import {
+	autoSearchEnabled,
+	autoCapturePromptsEnabled,
+} from "../../utils/storage"
 import { createT3InputBarElement, DOMUtils } from "../../utils/ui-components"
 
 let t3DebounceTimeout: NodeJS.Timeout | null = null
@@ -497,13 +500,9 @@ function setupT3PromptCapture() {
 	document.body.setAttribute("data-t3-prompt-capture-setup", "true")
 
 	const captureT3PromptContent = async (source: string) => {
-		const result = await chrome.storage.local.get([
-			STORAGE_KEYS.AUTO_CAPTURE_PROMPTS_ENABLED,
-		])
-		const autoCapturePromptsEnabled =
-			result[STORAGE_KEYS.AUTO_CAPTURE_PROMPTS_ENABLED] ?? false
+		const autoCapture = (await autoCapturePromptsEnabled.getValue()) ?? false
 
-		if (!autoCapturePromptsEnabled) {
+		if (!autoCapture) {
 			console.log("Auto capture prompts is disabled, skipping prompt capture")
 			return
 		}
@@ -677,12 +676,9 @@ function setupT3PromptCapture() {
 }
 
 async function setupT3AutoFetch() {
-	const result = await chrome.storage.local.get([
-		STORAGE_KEYS.AUTO_SEARCH_ENABLED,
-	])
-	const autoSearchEnabled = result[STORAGE_KEYS.AUTO_SEARCH_ENABLED] ?? false
+	const autoSearch = (await autoSearchEnabled.getValue()) ?? false
 
-	if (!autoSearchEnabled) {
+	if (!autoSearch) {
 		return
 	}
 

--- a/apps/browser-extension/utils/api.ts
+++ b/apps/browser-extension/utils/api.ts
@@ -1,7 +1,8 @@
 /**
  * API service for supermemory browser extension
  */
-import { API_ENDPOINTS, STORAGE_KEYS } from "./constants"
+import { API_ENDPOINTS } from "./constants"
+import { bearerToken, defaultProject, userData } from "./storage"
 import {
 	AuthenticationError,
 	type MemoryPayload,
@@ -14,8 +15,7 @@ import {
  * Get bearer token from storage
  */
 async function getBearerToken(): Promise<string> {
-	const result = await chrome.storage.local.get([STORAGE_KEYS.BEARER_TOKEN])
-	const token = result[STORAGE_KEYS.BEARER_TOKEN]
+	const token = await bearerToken.getValue()
 
 	if (!token) {
 		throw new AuthenticationError("Bearer token not found")
@@ -75,10 +75,8 @@ export async function fetchProjects(): Promise<Project[]> {
  */
 export async function getDefaultProject(): Promise<Project | null> {
 	try {
-		const result = await chrome.storage.local.get([
-			STORAGE_KEYS.DEFAULT_PROJECT,
-		])
-		return result[STORAGE_KEYS.DEFAULT_PROJECT] || null
+		const defaultProjectValue = await defaultProject.getValue()
+		return defaultProjectValue || null
 	} catch (error) {
 		console.error("Failed to get default project:", error)
 		return null
@@ -90,9 +88,7 @@ export async function getDefaultProject(): Promise<Project | null> {
  */
 export async function setDefaultProject(project: Project): Promise<void> {
 	try {
-		await chrome.storage.local.set({
-			[STORAGE_KEYS.DEFAULT_PROJECT]: project,
-		})
+		await defaultProject.setValue(project)
 	} catch (error) {
 		console.error("Failed to set default project:", error)
 		throw error
@@ -120,8 +116,7 @@ export async function validateAuthToken(): Promise<boolean> {
  */
 export async function getUserData(): Promise<{ email?: string } | null> {
 	try {
-		const result = await chrome.storage.local.get([STORAGE_KEYS.USER_DATA])
-		return result[STORAGE_KEYS.USER_DATA] || null
+		return (await userData.getValue()) || null
 	} catch (error) {
 		console.error("Failed to get user data:", error)
 		return null

--- a/apps/browser-extension/utils/constants.ts
+++ b/apps/browser-extension/utils/constants.ts
@@ -11,21 +11,6 @@ export const API_ENDPOINTS = {
 } as const
 
 /**
- * Storage Keys
- */
-export const STORAGE_KEYS = {
-	BEARER_TOKEN: "bearer-token",
-	USER_DATA: "user-data",
-	TOKENS_LOGGED: "tokens-logged",
-	TWITTER_COOKIE: "twitter-cookie",
-	TWITTER_CSRF: "twitter-csrf",
-	TWITTER_AUTH_TOKEN: "twitter-auth-token",
-	DEFAULT_PROJECT: "sm-default-project",
-	AUTO_SEARCH_ENABLED: "sm-auto-search-enabled",
-	AUTO_CAPTURE_PROMPTS_ENABLED: "sm-auto-capture-prompts-enabled",
-} as const
-
-/**
  * DOM Element IDs
  */
 export const ELEMENT_IDS = {

--- a/apps/browser-extension/utils/posthog.ts
+++ b/apps/browser-extension/utils/posthog.ts
@@ -1,15 +1,14 @@
 import { PostHog } from "posthog-js/dist/module.no-external"
-import { STORAGE_KEYS } from "./constants"
+import { userData } from "./storage"
 
 export async function identifyUser(posthog: PostHog): Promise<void> {
-	const stored = await chrome.storage.local.get([STORAGE_KEYS.USER_DATA])
-	const userData = stored[STORAGE_KEYS.USER_DATA]
+	const storedUserData = await userData.getValue()
 
-	if (userData?.userId) {
-		posthog.identify(userData.userId, {
-			email: userData.email,
-			name: userData.name,
-			userId: userData.userId,
+	if (storedUserData?.userId) {
+		posthog.identify(storedUserData.userId, {
+			email: storedUserData.email,
+			name: storedUserData.name,
+			userId: storedUserData.userId,
 		})
 	}
 }

--- a/apps/browser-extension/utils/storage.ts
+++ b/apps/browser-extension/utils/storage.ts
@@ -1,0 +1,121 @@
+/**
+ * Centralized storage layer using WXT's built-in storage API
+ */
+
+import { storage } from '#imports';
+import type { Project } from "./types"
+
+/**
+ * User authentication and profile data
+ */
+export interface UserData {
+	userId?: string
+	email?: string
+	name?: string
+}
+
+/**
+ * Twitter authentication tokens for API requests
+ */
+export interface TwitterAuthTokens {
+	cookie: string
+	csrf: string
+	auth: string
+}
+
+/**
+ * Local Storage Items (persistent across sessions)
+ */
+export const bearerToken = storage.defineItem<string>("local:bearer-token")
+
+export const userData = storage.defineItem<UserData>("local:user-data")
+
+export const defaultProject = storage.defineItem<Project>(
+	"local:sm-default-project",
+)
+
+export const autoSearchEnabled = storage.defineItem<boolean>(
+	"local:sm-auto-search-enabled",
+	{
+		fallback: false,
+	},
+)
+
+export const autoCapturePromptsEnabled = storage.defineItem<boolean>(
+	"local:sm-auto-capture-prompts-enabled",
+	{
+		fallback: false,
+	},
+)
+
+/**
+ * Session Storage Items (cleared when browser closes)
+ */
+export const tokensLogged = storage.defineItem<boolean>(
+	"session:tokens-logged",
+	{
+		fallback: false,
+	},
+)
+
+export const twitterCookie = storage.defineItem<string>(
+	"session:twitter-cookie",
+)
+
+export const twitterCsrf = storage.defineItem<string>("session:twitter-csrf")
+
+export const twitterAuthToken = storage.defineItem<string>(
+	"session:twitter-auth-token",
+)
+
+/**
+ * Helper function to get Twitter authentication tokens
+ * @returns Promise resolving to tokens or null if not available
+ */
+export async function getTwitterTokens(): Promise<TwitterAuthTokens | null> {
+	const [cookie, csrf, auth] = await Promise.all([
+		twitterCookie.getValue(),
+		twitterCsrf.getValue(),
+		twitterAuthToken.getValue(),
+	])
+
+	if (!cookie || !csrf || !auth) {
+		return null
+	}
+
+	return {
+		cookie,
+		csrf,
+		auth,
+	}
+}
+
+/**
+ * Helper function to set Twitter authentication tokens
+ * @param tokens - Twitter authentication tokens to store
+ */
+export async function setTwitterTokens(
+	tokens: TwitterAuthTokens,
+): Promise<void> {
+	await Promise.all([
+		twitterCookie.setValue(tokens.cookie),
+		twitterCsrf.setValue(tokens.csrf),
+		twitterAuthToken.setValue(tokens.auth),
+	])
+}
+
+/**
+ * Helper function to check if tokens have been logged (for one-time logging)
+ * @returns Promise resolving to boolean indicating if tokens were previously logged
+ */
+export async function getTokensLogged(): Promise<boolean> {
+	return (await tokensLogged.getValue()) ?? false
+}
+
+/**
+ * Helper function to mark tokens as logged
+ */
+export async function setTokensLogged(): Promise<void> {
+	await tokensLogged.setValue(true)
+}
+

--- a/apps/browser-extension/utils/twitter-import.ts
+++ b/apps/browser-extension/utils/twitter-import.ts
@@ -4,7 +4,8 @@
  */
 import { saveAllTweets } from "./api"
 import type { MemoryPayload } from "./types"
-import { createTwitterAPIHeaders, getTwitterTokens } from "./twitter-auth"
+import { createTwitterAPIHeaders } from "./twitter-auth"
+import { getTwitterTokens } from "./storage"
 import {
 	BOOKMARKS_URL,
 	BOOKMARK_COLLECTION_URL,


### PR DESCRIPTION
Implements: https://github.com/supermemoryai/supermemory/issues/527

This is the initial PR. I also have some ideas to implement storage.watch() from WXT in places where an explicit refresh is currently required for changes to reflect. This can be improved by adding some reactivity. I’ll be creating the next PR shortly.

Thanks @lirena00 for the heads-up. 

And I would request @MaheshtheDev  or @lirena00 to test it once more in their local before merging to main