### PR TITLE
fix(tools): pass apiKey to profile search instead of using process.env

### DIFF
--- a/packages/tools/src/vercel/memory-prompt.ts
+++ b/packages/tools/src/vercel/memory-prompt.ts
@@ -16,22 +16,23 @@ const supermemoryProfileSearch = async (
 	containerTag: string,
 	queryText: string,
 	baseUrl: string,
+	apiKey: string,
 ): Promise<ProfileStructure> => {
 	const payload = queryText
 		? JSON.stringify({
-				q: queryText,
-				containerTag: containerTag,
-			})
+			q: queryText,
+			containerTag: containerTag,
+		})
 		: JSON.stringify({
-				containerTag: containerTag,
-			})
+			containerTag: containerTag,
+		})
 
 	try {
 		const response = await fetch(`${baseUrl}/v4/profile`, {
 			method: "POST",
 			headers: {
 				"Content-Type": "application/json",
-				Authorization: `Bearer ${process.env.SUPERMEMORY_API_KEY}`,
+				Authorization: `Bearer ${apiKey}`,
 			},
 			body: payload,
 		})
@@ -57,7 +58,8 @@ export const addSystemPrompt = async (
 	containerTag: string,
 	logger: Logger,
 	mode: "profile" | "query" | "full",
-	baseUrl = "https://api.supermemory.ai",
+	baseUrl: string,
+	apiKey: string,
 ): Promise<LanguageModelCallOptions> => {
 	const systemPromptExists = params.prompt.some(
 		(prompt) => prompt.role === "system",
@@ -66,22 +68,23 @@ export const addSystemPrompt = async (
 	const queryText =
 		mode !== "profile"
 			? params.prompt
-					.slice()
-					.reverse()
-					.find((prompt: { role: string }) => prompt.role === "user")
-					?.content?.filter(
-						(content: { type: string }) => content.type === "text",
-					)
-					?.map((content: { type: string; text: string }) =>
-						content.type === "text" ? content.text : "",
-					)
-					?.join(" ") || ""
+				.slice()
+				.reverse()
+				.find((prompt: { role: string }) => prompt.role === "user")
+				?.content?.filter(
+					(content: { type: string }) => content.type === "text",
+				)
+				?.map((content: { type: string; text: string }) =>
+					content.type === "text" ? content.text : "",
+				)
+				?.join(" ") || ""
 			: ""
 
 	const memoriesResponse = await supermemoryProfileSearch(
 		containerTag,
 		queryText,
 		baseUrl,
+		apiKey,
 	)
 
 	const memoryCountStatic = memoriesResponse.profile.static?.length || 0
@@ -120,18 +123,18 @@ export const addSystemPrompt = async (
 	const profileData =
 		mode !== "query"
 			? convertProfileToMarkdown({
-					profile: {
-						static: deduplicated.static,
-						dynamic: deduplicated.dynamic,
-					},
-					searchResults: { results: [] },
-				})
+				profile: {
+					static: deduplicated.static,
+					dynamic: deduplicated.dynamic,
+				},
+				searchResults: { results: [] },
+			})
 			: ""
 	const searchResultsMemories =
 		mode !== "profile"
 			? `Search results for user's recent message: \n${deduplicated.searchResults
-					.map((memory) => `- ${memory}`)
-					.join("\n")}`
+				.map((memory) => `- ${memory}`)
+				.join("\n")}`
 			: ""
 
 	const memories =

--- a/packages/tools/src/vercel/middleware.ts
+++ b/packages/tools/src/vercel/middleware.ts
@@ -234,6 +234,7 @@ export const transformParamsWithMemory = async (
 		ctx.logger,
 		ctx.mode,
 		ctx.normalizedBaseUrl,
+		ctx.apiKey,
 	)
 	return transformedParams
 }


### PR DESCRIPTION
## Summary

Fixes a regression where the API key passed via `options.apiKey` in `withSupermemory()` was not being used for profile search requests. Instead, the code was hardcoded to use `process.env.SUPERMEMORY_API_KEY`, causing failures in environments where the environment variable is not set (for example, Vercel middleware).

## Root Cause

This regression was introduced in PR #628 (`feat(@supermemory/tools): vercel ai sdk compatible with v5 and v6`). That change rewrote `memory-prompt.ts` but did not preserve the `apiKey` parameter flow that was originally added in PR #599 (`feat(tools): allow passing apiKey via options for browser support`).

## Changes

- Added an `apiKey` parameter to the `supermemoryProfileSearch` function  
- Added an `apiKey` parameter to the `addSystemPrompt` function  
- Updated the `Authorization` header to use the passed `apiKey` instead of `process.env.SUPERMEMORY_API_KEY`  
- Updated `transformParamsWithMemory` in `middleware.ts` to pass `ctx.apiKey` to `addSystemPrompt`

## Behavior

The API key resolution priority remains:

1. `options.apiKey` (if provided) — highest priority  
2. `process.env.SUPERMEMORY_API_KEY` — fallback  

This is resolved in `index.ts` (line 71):

```ts
const providedApiKey = options?.apiKey ?? process.env.SUPERMEMORY_API_KEY;
````

This fix ensures that the resolved `apiKey` is consistently propagated to all API calls, including profile search requests.
