### PR TITLE
feat: allow prompt template for @supermemory/tools package

### DIFF
--- a/packages/tools/README.md
+++ b/packages/tools/README.md
@@ -217,6 +217,41 @@ const modelWithOptions = withSupermemory(openai("gpt-4"), "user-123", {
 })
 ```
 
+#### Custom Prompt Templates
+
+Customize how memories are formatted and injected into the system prompt using the `promptTemplate` option. This is useful for:
+- Using XML-based prompting (e.g., for Claude models)
+- Custom branding (removing "supermemories" references)
+- Controlling how your agent describes where information comes from
+
+```typescript
+import { generateText } from "ai"
+import { withSupermemory, type MemoryPromptData } from "@supermemory/tools/ai-sdk"
+import { openai } from "@ai-sdk/openai"
+
+const customPrompt = (data: MemoryPromptData) => `
+<user_memories>
+Here is some information about your past conversations with the user:
+${data.userMemories}
+${data.generalSearchMemories}
+</user_memories>
+`.trim()
+
+const modelWithCustomPrompt = withSupermemory(openai("gpt-4"), "user-123", {
+  mode: "full",
+  promptTemplate: customPrompt,
+})
+
+const result = await generateText({
+  model: modelWithCustomPrompt,
+  messages: [{ role: "user", content: "What do you know about me?" }],
+})
+```
+
+The `MemoryPromptData` object provides:
+- `userMemories`: Pre-formatted markdown combining static profile facts (name, preferences, goals) and dynamic context (current projects, recent interests)
+- `generalSearchMemories`: Pre-formatted search results based on semantic similarity to the current query
+
 ### OpenAI SDK Usage
 
 #### OpenAI Middleware with Supermemory

--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@supermemory/tools",
   "type": "module",
-  "version": "1.3.65",
+  "version": "1.3.66",
   "description": "Memory tools for AI SDK and OpenAI function calling with supermemory",
   "scripts": {
     "build": "tsdown",

--- a/packages/tools/src/vercel/util.ts
+++ b/packages/tools/src/vercel/util.ts
@@ -21,22 +21,43 @@ export type LanguageModelStreamPart =
 	| LanguageModelV2StreamPart
 	| LanguageModelV3StreamPart
 
+/**
+ * Response structure from the Supermemory profile API.
+ */
 export interface ProfileStructure {
 	profile: {
+		/**
+		 * Core, stable facts about the user that rarely change.
+		 * Examples: name, profession, long-term preferences, goals.
+		 */
 		static?: Array<{ memory: string; metadata?: Record<string, unknown> }>
+		/**
+		 * Recently learned or frequently updated information about the user.
+		 * Examples: current projects, recent interests, ongoing topics.
+		 */
 		dynamic?: Array<{ memory: string; metadata?: Record<string, unknown> }>
 	}
 	searchResults: {
+		/**
+		 * Memories retrieved based on semantic similarity to the current query.
+		 * Most relevant to the immediate conversation context.
+		 */
 		results: Array<{ memory: string; metadata?: Record<string, unknown> }>
 	}
 }
 
+/**
+ * Simplified profile data for markdown conversion.
+ */
 export interface ProfileMarkdownData {
 	profile: {
+		/** Core, stable user facts (name, preferences, goals) */
 		static?: string[]
+		/** Recently learned or updated information (current projects, interests) */
 		dynamic?: string[]
 	}
 	searchResults: {
+		/** Query-relevant memories based on semantic similarity */
 		results: Array<{ memory: string }>
 	}
 }


### PR DESCRIPTION
## Add customizable prompt templates for memory injection

**Changes:**

- Add `promptTemplate` option to `withSupermemory()` for full control over injected memory format (XML, custom branding, etc.)
- New `MemoryPromptData` interface with `userMemories` and `generalSearchMemories` fields
- Exclude `system` messages from persistence to avoid storing injected prompts
- Add JSDoc comments to all public interfaces for better DevEx

**Usage:**

```typescript
const customPrompt = (data: MemoryPromptData) => `
<user_memories>
${data.userMemories}
${data.generalSearchMemories}
</user_memories>
`.trim()

const model = withSupermemory(openai("gpt-4"), "user-123", {
  promptTemplate: customPrompt,
})
```