### PR TITLE
Document MCP context prompt feature

### DIFF
--- a/apps/docs/changelog/developer-platform.mdx
+++ b/apps/docs/changelog/developer-platform.mdx
@@ -6,6 +6,10 @@ description: "API updates, new endpoints, and SDK releases"
 
 API updates, new endpoints, SDK releases, and developer-focused features.
 
+## December 30, 2025
+
+- **MCP Context Prompt:** New `context` prompt in the Supermemory MCP server for automatic user profile injection into AI conversations. Returns formatted system messages with stable preferences and recent activity, designed for context injection at conversation start. Supports optional `containerTag` for project scoping and `includeRecent` parameter to control recent activity inclusion.
+
 ## October 27, 2025
 
 - **Enhanced Filtering Capabilities:** Major improvements to the search filtering API with new `string_contains` filter type for partial string matching, `ignoreCase` option for case-insensitive string operations, and improved negation support across all filter types including proper numeric equality negation. The implementation also includes enhanced SQL injection protection and wildcard escaping for improved security.

--- a/apps/docs/supermemory-mcp/mcp.mdx
+++ b/apps/docs/supermemory-mcp/mcp.mdx
@@ -100,9 +100,27 @@ Get the current logged-in user's information. Returns `{ userId, email, name, cl
 
 ## Prompts
 
-| Name | Description |
-|------|-------------|
-| `context` | User profile and preferences for system context injection |
+### `context`
+
+Inject user profile and preferences as system context for AI conversations. Returns a formatted message with the user's stable preferences and recent activity.
+You can access this in Cursor and Claude Code by just doing /context, which will give the LLMs just enough context to use and query supermemory more.
+**Purpose:** Unlike the `recall` tool (which searches for specific information) or the `profile` resource (which returns raw data), the `context` prompt provides a pre-formatted system message designed for context injection at the start of conversations.
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `containerTag` | string | No | Project tag to scope the profile (max 128 chars) |
+| `includeRecent` | boolean | No | Include recent activity in the profile. Default: `true` |
+
+**Output format:**
+- Includes instructions to save new memories using the `memory` tool
+- **Stable Preferences:** Long-term user facts and preferences
+- **Recent Activity:** Recent interactions and context (when `includeRecent` is `true`)
+- Fallback message when no profile exists yet
+
+**When to use:**
+- Use `context` prompt for automatic system context injection at conversation start
+- Use `recall` tool when you need to search for specific information
+- Use `profile` resource when you need raw profile data for custom processing
 
 <Card title="MCP Server Source Code" icon="github" href="https://github.com/supermemoryai/supermemory/tree/main/apps/mcp">
   View the open-source implementation


### PR DESCRIPTION
Added documentation for the new `context` prompt in the Supermemory MCP server that enables automatic user profile injection into AI conversations. Updated the MCP overview page with detailed parameter documentation and usage guidance, and added a changelog entry for December 30, 2025.

**Files changed:**
- `apps/docs/supermemory-mcp/mcp.mdx` - Added Prompts section with `context` prompt documentation
- `apps/docs/changelog/developer-platform.mdx` - Added December 30, 2025 changelog entry

Generated from [fix: prompt injection with mcp](https://github.com/supermemoryai/supermemory/pull/638) @MaheshtheDev