### PR TITLE
Add React type import to types.ts

### DIFF
--- a/packages/ui/memory-graph/types.ts
+++ b/packages/ui/memory-graph/types.ts
@@ -1,3 +1,4 @@
+import type React from "react";
 import type { DocumentsWithMemoriesResponseSchema } from "@repo/validation/api";
 import type { z } from "zod";
 


### PR DESCRIPTION
You're referencing React's types (e.g., React.MouseEvent, React.TouchEvent, React.WheelEvent) but React is not imported in this .ts file. That will typically produce a TypeScript error like "Cannot find namespace 'React'." Add a type-only import from React (or import the specific event types) to fix it.