### PR TITLE
fix(mcp): include r.memory in getProfile fallback chain

### DIFF
--- a/apps/mcp/src/client.ts
+++ b/apps/mcp/src/client.ts
@@ -172,7 +172,7 @@ export class SupermemoryClient {
 				response.searchResults = {
 					results: (result.searchResults.results as SDKResult[]).map((r) => ({
 						id: r.id,
-						memory: limitByChars(r.content || r.context || ""),
+						memory: limitByChars(r.content || r.memory || r.context || ""),
 						similarity: r.similarity,
 						title: r.title,
 						content: r.content,


### PR DESCRIPTION
## Summary
- Add missing `r.memory` fallback in `getProfile()` searchResults mapping
- Aligns with existing `search()` method behavior (line 140)
- Fixes empty memory content in MCP `recall` tool output

**Related discussion:** #694

## Problem
The `recall` tool returns match percentages but empty memory content:
```
### Memory 1 (73% match)

### Memory 2 (72% match)
```

## Root Cause
`getProfile()` at line 175 was missing `r.memory` in its fallback chain:
```typescript
// Before
memory: limitByChars(r.content || r.context || ""),

// After  
memory: limitByChars(r.content || r.memory || r.context || ""),
```

## Test plan
- [ ] Verify `recall` returns memory content with the fix
- [ ] Confirm `search` behavior unchanged