### PR TITLE
feat: onboarding config, reset onboarding, xai agentic migration

### DIFF
--- a/apps/web/components/new/header.tsx
+++ b/apps/web/components/new/header.tsx
@@ -15,6 +15,7 @@ import {
 	HelpCircle,
 	MenuIcon,
 	MessageCircleIcon,
+	RotateCcw,
 } from "lucide-react"
 import { Button } from "@ui/components/button"
 import { cn } from "@lib/utils"
@@ -34,6 +35,7 @@ import { useRouter } from "next/navigation"
 import Link from "next/link"
 import { SpaceSelector } from "./space-selector"
 import { useIsMobile } from "@hooks/use-mobile"
+import { useOrgOnboarding } from "@hooks/use-org-onboarding"
 
 interface HeaderProps {
 	onAddMemory?: () => void
@@ -53,6 +55,12 @@ export function Header({
 	const { switchProject } = useProjectMutations()
 	const router = useRouter()
 	const isMobile = useIsMobile()
+	const { resetOrgOnboarded } = useOrgOnboarding()
+
+	const handleTryOnboarding = () => {
+		resetOrgOnboarded()
+		router.push("/new/onboarding?step=input&flow=welcome")
+	}
 
 	const displayName =
 		user?.displayUsername ||
@@ -315,6 +323,13 @@ export function Header({
 							>
 								<Settings className="h-4 w-4 text-[#737373]" />
 								Settings
+							</DropdownMenuItem>
+							<DropdownMenuItem
+								onClick={handleTryOnboarding}
+								className="px-3 py-2.5 rounded-md hover:bg-[#293952]/40 cursor-pointer text-white text-sm font-medium gap-2"
+							>
+								<RotateCcw className="h-4 w-4 text-[#737373]" />
+								Restart Onboarding
 							</DropdownMenuItem>
 							<DropdownMenuSeparator className="bg-[#2E3033]" />
 							<DropdownMenuItem

--- a/apps/web/components/new/onboarding/setup/integrations-step.tsx
+++ b/apps/web/components/new/onboarding/setup/integrations-step.tsx
@@ -7,7 +7,7 @@ import { XBookmarksDetailView } from "@/components/new/onboarding/x-bookmarks-de
 import { useRouter } from "next/navigation"
 import { cn } from "@lib/utils"
 import { dmSansClassName } from "@/lib/fonts"
-import { useOnboardingStorage } from "@hooks/use-onboarding-storage"
+import { useOrgOnboarding } from "@hooks/use-org-onboarding"
 import { analytics } from "@/lib/analytics"
 
 const integrationCards = [
@@ -61,11 +61,11 @@ const integrationCards = [
 export function IntegrationsStep() {
 	const router = useRouter()
 	const [selectedCard, setSelectedCard] = useState<string | null>(null)
-	const { markOnboardingCompleted } = useOnboardingStorage()
+	const { markOrgOnboarded } = useOrgOnboarding()
 
 	const handleContinue = () => {
+		markOrgOnboarded()
 		analytics.onboardingCompleted()
-		markOnboardingCompleted()
 		router.push("/new")
 	}
 

--- a/packages/hooks/use-org-onboarding.ts
+++ b/packages/hooks/use-org-onboarding.ts
@@ -1,0 +1,85 @@
+"use client"
+
+import { useCallback, useMemo } from "react"
+import { useAuth } from "@lib/auth-context"
+import { authClient } from "@lib/auth"
+
+/**
+ * DB-backed onboarding completion hook for the new app flow.
+ * Uses consumer org `metadata.isOnboarded` instead of localStorage.
+ *
+ * TODO: remove this after the feature flag is removed
+ * This hook is for the new app flow only (feature-flagged `nova-alpha-access`).
+ * The old onboarding flow will continue to use `useOnboardingStorage` (localStorage).
+ */
+export function useOrgOnboarding() {
+	const { org, updateOrgMetadata } = useAuth()
+
+	const isOrgOnboarded = useMemo(() => {
+		if (!org) return null
+		return org.metadata?.isOnboarded === true
+	}, [org])
+
+	const markOrgOnboarded = useCallback(() => {
+		if (!org?.id) {
+			console.error("No organization context when marking as onboarded")
+			return
+		}
+
+		// Optimistic update: update in-memory state immediately
+		updateOrgMetadata({ isOnboarded: true })
+
+		authClient.organization
+			.update({
+				organizationId: org.id,
+				data: {
+					metadata: {
+						...org.metadata,
+						isOnboarded: true,
+					},
+				},
+			})
+			.catch((error) => {
+				console.error("Failed to mark organization as onboarded:", error)
+				updateOrgMetadata({ isOnboarded: false })
+			})
+	}, [org, updateOrgMetadata])
+
+	const resetOrgOnboarded = useCallback(() => {
+		if (!org?.id) {
+			console.error("No organization context when resetting onboarding")
+			return
+		}
+
+		// Optimistic update: update in-memory state immediately
+		updateOrgMetadata({ isOnboarded: false })
+
+		authClient.organization
+			.update({
+				organizationId: org.id,
+				data: {
+					metadata: {
+						...org.metadata,
+						isOnboarded: false,
+					},
+				},
+			})
+			.catch((error) => {
+				console.error("Failed to reset organization onboarding:", error)
+				updateOrgMetadata({ isOnboarded: true })
+			})
+	}, [org, updateOrgMetadata])
+
+	const shouldShowOnboarding = useCallback(() => {
+		if (isOrgOnboarded === null) return null // Still loading (org not ready)
+		return !isOrgOnboarded
+	}, [isOrgOnboarded])
+
+	return {
+		isOrgOnboarded,
+		markOrgOnboarded,
+		resetOrgOnboarded,
+		shouldShowOnboarding,
+		isLoading: org === null,
+	}
+}

--- a/packages/lib/auth-context.tsx
+++ b/packages/lib/auth-context.tsx
@@ -3,6 +3,7 @@
 import {
 	createContext,
 	type ReactNode,
+	useCallback,
 	useContext,
 	useEffect,
 	useState,
@@ -17,6 +18,9 @@ interface AuthContextType {
 	user: SessionData["user"] | null
 	org: Organization | null
 	setActiveOrg: (orgSlug: string) => Promise<void>
+	updateOrgMetadata: (
+		partial: Record<string, unknown>,
+	) => void
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
@@ -34,6 +38,22 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 		})
 		setOrg(activeOrg)
 	}
+
+	const updateOrgMetadata = useCallback(
+		(partial: Record<string, unknown>) => {
+			setOrg((prev) => {
+				if (!prev) return prev
+				return {
+					...prev,
+					metadata: {
+						...prev.metadata,
+						...partial,
+					},
+				}
+			})
+		},
+		[],
+	)
 
 	// biome-ignore lint/correctness/useExhaustiveDependencies: ignoring the setActiveOrg dependency
 	useEffect(() => {
@@ -99,6 +119,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 				session: session?.session ?? null,
 				user: session?.user ?? null,
 				setActiveOrg,
+				updateOrgMetadata,
 			}}
 		>
 			{children}


### PR DESCRIPTION
- Created a new `useOrgOnboarding` hook that uses `org.metadata.isOnboarded` to track onboarding state
- Updated the home page to conditionally use either the old localStorage-based onboarding or the new DB-backed onboarding based on feature flag
- Added a "Restart Onboarding" option in the user dropdown menu
- Improved the onboarding chat sidebar with per-link loading indicators
- Enhanced the X/Twitter research API to better handle different URL formats
- Updated the integrations step to use the new onboarding completion method
- Added `updateOrgMetadata` function to the auth context for easier metadata updates