### PR TITLE
fix: await subscription checks

### DIFF
--- a/packages/lib/queries.ts
+++ b/packages/lib/queries.ts
@@ -23,7 +23,7 @@ export const fetchSubscriptionStatus = (
 			await Promise.all(
 				allPlans.map(async (plan) => {
 					try {
-						const res = autumn.check({
+						const res = await autumn.check({
 							productId: plan,
 						})
 						const allowed = res.data?.allowed ?? false


### PR DESCRIPTION
 - Problem: fetchSubscriptionStatus never awaited the response from Autumn. check, so every plan was labeled as not allowed and missing status, even when data was returned. This meant the UI always treated users as having no active product.
 
  - Fix: Await each autumn. Check call before reading res.data, ensuring the fetched subscription status actually reflects the backend response.
 
