### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Run Claude Code Review
         id: claude-review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@f64219702d7454cf29fe32a74104be6ed43dc637  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@f64219702d7454cf29fe32a74104be6ed43dc637  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/publish-ai-sdk.yml
+++ b/.github/workflows/publish-ai-sdk.yml
@@ -26,10 +26,10 @@ jobs:
                 registry-url: 'https://registry.npmjs.org'
 
             - name: Setup Bun
-              uses: oven-sh/setup-bun@v2
+              uses: oven-sh/setup-bun@3d267786b128fe76c2f16a390aa2448b815359f3  # v2.1.2
             
             - name: Setup pnpm
-              uses: pnpm/action-setup@v4
+              uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061  # v4.2.0
 
             - name: Install dependencies
               run: bun install


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `anthropics/claude-code-action` | [`v1`](https://github.com/anthropics/claude-code-action/releases/tag/v1) | [`f642197`](https://github.com/anthropics/claude-code-action/commit/f64219702d7454cf29fe32a74104be6ed43dc637) | [Release](https://github.com/anthropics/claude-code-action/releases/tag/v1) | claude-code-review.yml, claude.yml |
| `oven-sh/setup-bun` | [`v2`](https://github.com/oven-sh/setup-bun/releases/tag/v2) | [`3d26778`](https://github.com/oven-sh/setup-bun/commit/3d267786b128fe76c2f16a390aa2448b815359f3) | [Release](https://github.com/oven-sh/setup-bun/releases/tag/v2) | publish-ai-sdk.yml |
| `pnpm/action-setup` | [`v4`](https://github.com/pnpm/action-setup/releases/tag/v4) | [`41ff726`](https://github.com/pnpm/action-setup/commit/41ff72655975bd51cab0327fa583b6e92b6d3061) | [Release](https://github.com/pnpm/action-setup/releases/tag/v4) | publish-ai-sdk.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
