### PR TITLE
docs: add ClawdBot integration page

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -3,7 +3,11 @@
 	"api": {
 		"examples": {
 			"defaults": "required",
-			"languages": ["javascript", "python", "curl"]
+			"languages": [
+				"javascript",
+				"python",
+				"curl"
+			]
 		},
 		"openapi": "https://api.supermemory.ai/v3/openapi"
 	},
@@ -13,7 +17,12 @@
 		"primary": "#1E3A8A"
 	},
 	"contextual": {
-		"options": ["copy", "view", "chatgpt", "claude"]
+		"options": [
+			"copy",
+			"view",
+			"chatgpt",
+			"claude"
+		]
 	},
 	"favicon": "/favicon.png",
 	"fonts": {
@@ -33,7 +42,9 @@
 			"x": "https://x.com/supermemory"
 		}
 	},
-	"icons": { "library": "lucide" },
+	"icons": {
+		"library": "lucide"
+	},
 	"logo": {
 		"dark": "/logo/dark.svg",
 		"light": "/logo/light.svg"
@@ -68,7 +79,11 @@
 							{
 								"group": "Getting Started",
 								"icon": "rocket",
-								"pages": ["intro", "quickstart", "vibe-coding"]
+								"pages": [
+									"intro",
+									"quickstart",
+									"vibe-coding"
+								]
 							},
 							{
 								"group": "Concepts",
@@ -94,7 +109,10 @@
 									{
 										"group": "Manage Content",
 										"icon": "folder-cog",
-										"pages": ["document-operations", "memory-operations"]
+										"pages": [
+											"document-operations",
+											"memory-operations"
+										]
 									},
 									"overview/use-cases"
 								]
@@ -128,7 +146,10 @@
 									{
 										"group": "From another provider",
 										"icon": "truck",
-										"pages": ["migration/from-mem0", "migration/from-zep"]
+										"pages": [
+											"migration/from-mem0",
+											"migration/from-zep"
+										]
 									}
 								]
 							}
@@ -137,7 +158,10 @@
 					{
 						"anchor": "Supermemory MCP",
 						"icon": "terminal",
-						"pages": ["supermemory-mcp/mcp", "supermemory-mcp/setup"]
+						"pages": [
+							"supermemory-mcp/mcp",
+							"supermemory-mcp/setup"
+						]
 					}
 				],
 				"tab": "Developer Platform"
@@ -155,7 +179,13 @@
 							"integrations/claude-memory",
 							"integrations/pipecat",
 							"integrations/n8n",
-							"integrations/zapier"
+							"integrations/zapier",
+							{
+								"group": "Plugins",
+								"pages": [
+									"integrations/clawdbot"
+								]
+							}
 						]
 					}
 				],
@@ -172,7 +202,6 @@
 				],
 				"tab": "API Reference"
 			},
-
 			{
 				"icon": "flask-conical",
 				"anchors": [
@@ -184,7 +213,10 @@
 							"memorybench/github",
 							{
 								"group": "Getting Started",
-								"pages": ["memorybench/installation", "memorybench/quickstart"]
+								"pages": [
+									"memorybench/installation",
+									"memorybench/quickstart"
+								]
 							},
 							{
 								"group": "Development",
@@ -197,7 +229,10 @@
 							},
 							{
 								"group": "Reference",
-								"pages": ["memorybench/cli", "memorybench/integrations"]
+								"pages": [
+									"memorybench/cli",
+									"memorybench/integrations"
+								]
 							}
 						]
 					}
@@ -233,7 +268,10 @@
 				"anchors": [
 					{
 						"anchor": "Changelog",
-						"pages": ["changelog/overview", "changelog/developer-platform"]
+						"pages": [
+							"changelog/overview",
+							"changelog/developer-platform"
+						]
 					}
 				],
 				"tab": "Changelog"
@@ -462,6 +500,8 @@
 			"source": "/memory-api/overview"
 		}
 	],
-	"styling": { "eyebrows": "breadcrumbs" },
+	"styling": {
+		"eyebrows": "breadcrumbs"
+	},
 	"theme": "mint"
 }

--- a/apps/docs/integrations/clawdbot.mdx
+++ b/apps/docs/integrations/clawdbot.mdx
@@ -1,0 +1,122 @@
+---
+title: "ClawdBot"
+sidebarTitle: "ClawdBot"
+description: "ClawdBot Supermemory Plugin — works across Telegram, WhatsApp, Discord, Slack, and more"
+icon: "shrimp"
+---
+
+[ClawdBot](https://github.com/supermemoryai/clawdbot-supermemory) is a multi-platform AI messaging gateway that connects to WhatsApp, Telegram, Discord, Slack, iMessage, and other messaging channels. The Supermemory plugin gives ClawdBot memory across every channel.
+
+## Get Your API Key
+
+Create a Supermemory API key from the [API Keys](https://console.supermemory.ai/keys) page, then add it to your shell profile so it persists across sessions:
+
+<Tabs>
+  <Tab title="macOS / Linux (zsh)">
+    ```bash
+    echo 'export SUPERMEMORY_CLAWDBOT_API_KEY="sm_..."' >> ~/.zshrc
+    source ~/.zshrc
+    ```
+  </Tab>
+  <Tab title="macOS / Linux (bash)">
+    ```bash
+    echo 'export SUPERMEMORY_CLAWDBOT_API_KEY="sm_..."' >> ~/.bashrc
+    source ~/.bashrc
+    ```
+  </Tab>
+  <Tab title="Windows (PowerShell)">
+    ```powershell
+    [System.Environment]::SetEnvironmentVariable("SUPERMEMORY_CLAWDBOT_API_KEY", "sm_...", "User")
+    ```
+    Restart your terminal after running this.
+  </Tab>
+</Tabs>
+
+## Install the Plugin
+
+```bash
+clawdbot plugins install @supermemory/clawdbot-supermemory
+```
+
+Restart ClawdBot after installing.
+
+## How It Works
+
+Once installed, the plugin runs automatically with zero interaction:
+
+- **Auto-Recall** — Before every AI turn, Supermemory is queried for relevant memories and the user's profile. These are injected as context so the AI sees preferences, facts, and semantically similar past conversations.
+- **Auto-Capture** — After every AI turn, the conversation exchange is sent to Supermemory for extraction and long-term storage. Supermemory handles deduplication and profile building.
+
+## Features
+
+### AI Tools
+
+The AI can use these tools autonomously during conversations:
+
+| Tool | Description |
+|------|-------------|
+| `supermemory_store` | Save information to long-term memory. |
+| `supermemory_search` | Search memories by query with similarity scores. |
+| `supermemory_forget` | Delete a memory by query or ID. |
+| `supermemory_profile` | View the user profile — persistent facts and recent context. |
+
+### Slash Commands
+
+Users can interact with memory directly in chat:
+
+| Command | Description |
+|---------|-------------|
+| `/remember [text]` | Manually save something to memory. |
+| `/recall [query]` | Search memories and see results with similarity scores. |
+
+### CLI Commands
+
+```bash
+clawdbot supermemory search <query>    # Search memories from the terminal
+clawdbot supermemory profile           # View user profile
+clawdbot supermemory wipe              # Delete all memories (requires confirmation)
+```
+
+## Manual Configuration
+
+Optional — only needed if you prefer to set the API key directly in the config file instead of the environment variable.
+
+Add the plugin to your `clawdbot.json`:
+
+```json5
+{
+  "plugins": {
+    "entries": {
+      "clawdbot-supermemory": {
+        "enabled": true,
+        "config": {
+          "apiKey": "sm_..."
+        }
+      }
+    }
+  }
+}
+```
+
+### Advanced Options
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `autoRecall` | `boolean` | `true` | Inject relevant memories before every AI turn. |
+| `autoCapture` | `boolean` | `true` | Store conversation content after every turn. |
+| `maxRecallResults` | `number` | `10` | Max memories injected into context per turn. |
+| `profileFrequency` | `number` | `50` | Inject full user profile every N turns. |
+| `captureMode` | `string` | `"all"` | `"all"` filters noise. `"everything"` captures all messages. |
+| `debug` | `boolean` | `false` | Verbose debug logs. |
+
+## Next Steps
+
+<CardGroup cols={2}>
+  <Card title="GitHub Repository" icon="github" href="https://github.com/supermemoryai/clawdbot-supermemory">
+    Source code, issues, and detailed README.
+  </Card>
+
+  <Card title="Claude Memory Tool" icon="brain" href="/integrations/claude-memory">
+    Use Claude's native memory tool with Supermemory as backend.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
Clawdbot docs

Changes:
  - Added integrations/clawdbot.mdx — ClawdBot Supermemory Plugin documentation page with shrimp icon
  - Added "Plugins" group to the bottom of the Integrations sidebar in docs.json
  - Page covers: API key setup (zsh/bash/PowerShell), plugin install, how it works (auto-recall/auto-capture), features (AI
  tools, slash commands, CLI), manual configuration, and advanced options