### PR TITLE
feat: migrate to api_pro billing and add credits-based usage display

### DIFF
--- a/apps/web/app/(auth)/login/new/page.tsx
+++ b/apps/web/app/(auth)/login/new/page.tsx
@@ -2,7 +2,7 @@
 
 import { signIn } from "@lib/auth"
 import { usePostHog } from "@lib/posthog"
-import { TextSeparator } from "@repo/ui/components/text-separator"
+import { TextSeparator } from "@ui/components/text-separator"
 import { ExternalAuthButton } from "@ui/button/external-auth"
 import { Button } from "@ui/components/button"
 import { Badge } from "@ui/components/badge"

--- a/apps/web/app/(navigation)/layout.tsx
+++ b/apps/web/app/(navigation)/layout.tsx
@@ -15,7 +15,7 @@ export default function NavigationLayout({
 	const [showAddMemoryView, setShowAddMemoryView] = useState(false)
 	const pathname = usePathname()
 	const router = useRouter()
-	const flagEnabled = useFeatureFlagEnabled("nova-alpha-access")
+	const flagEnabled = true
 
 	useEffect(() => {
 		if (flagEnabled && !pathname.includes("/new")) {

--- a/apps/web/app/(navigation)/page.tsx
+++ b/apps/web/app/(navigation)/page.tsx
@@ -16,7 +16,7 @@ import { useFeatureFlagEnabled } from "posthog-js/react"
 export default function Page() {
 	const { user, session } = useAuth()
 	const router = useRouter()
-	const flagEnabled = useFeatureFlagEnabled("nova-alpha-access")
+	const flagEnabled = true
 
 	// TODO: remove this flow after the feature flag is removed
 	// Old app: localStorage-backed onboarding

--- a/apps/web/app/new/layout.tsx
+++ b/apps/web/app/new/layout.tsx
@@ -7,7 +7,7 @@ import { MobileBanner } from "@/components/new/mobile-banner"
 
 export default function NewLayout({ children }: { children: React.ReactNode }) {
 	const router = useRouter()
-	const flagEnabled = useFeatureFlagEnabled("nova-alpha-access")
+	const flagEnabled = true
 
 	useEffect(() => {
 		if (!flagEnabled) {

--- a/apps/web/components/menu.tsx
+++ b/apps/web/components/menu.tsx
@@ -1,10 +1,7 @@
 "use client"
 
 import { useIsMobile } from "@hooks/use-mobile"
-import {
-	fetchConsumerProProduct,
-	fetchMemoriesFeature,
-} from "@repo/lib/queries"
+import { fetchApiProProduct, fetchMemoriesFeature } from "@repo/lib/queries"
 import { Button } from "@repo/ui/components/button"
 import { ConnectAIModal } from "./connect-ai-modal"
 import { HeadingH2Bold } from "@repo/ui/text/heading/heading-h2-bold"
@@ -74,7 +71,7 @@ function Menu({ id }: { id?: string }) {
 	const memoriesUsed = memoriesCheck?.usage ?? 0
 	const memoriesLimit = memoriesCheck?.included_usage ?? 0
 
-	const { data: proCheck } = fetchConsumerProProduct(autumn)
+	const { data: proCheck } = fetchApiProProduct(autumn)
 
 	useEffect(() => {
 		if (memoriesCheck) {

--- a/apps/web/components/new/add-document/connections.tsx
+++ b/apps/web/components/new/add-document/connections.tsx
@@ -59,9 +59,8 @@ export function ConnectContent({ selectedProject }: ConnectContentProps) {
 	useEffect(() => {
 		if (!autumn.isLoading) {
 			setIsProUser(
-				autumn.customer?.products.some(
-					(product) => product.id === "consumer_pro",
-				) ?? false,
+				autumn.customer?.products.some((product) => product.id === "api_pro") ??
+					false,
 			)
 		}
 	}, [autumn.isLoading, autumn.customer])
@@ -70,7 +69,7 @@ export function ConnectContent({ selectedProject }: ConnectContentProps) {
 		setIsUpgrading(true)
 		try {
 			await autumn.attach({
-				productId: "consumer_pro",
+				productId: "api_pro",
 				successUrl: window.location.href,
 			})
 		} catch (error) {

--- a/apps/web/components/new/settings/connections-mcp.tsx
+++ b/apps/web/components/new/settings/connections-mcp.tsx
@@ -342,12 +342,12 @@ export default function ConnectionsMCP() {
 	// Billing data
 	const {
 		data: status = {
-			consumer_pro: { allowed: false, status: null },
+			api_pro: { allowed: false, status: null },
 		},
 		isLoading: isCheckingStatus,
 	} = fetchSubscriptionStatus(autumn, !autumn.isLoading)
 
-	const hasProProduct = status.consumer_pro?.status !== null
+	const hasProProduct = status.api_pro?.status !== null
 
 	// Get connections data directly from autumn customer
 	const connectionsFeature = autumn.customer?.features?.connections
@@ -415,7 +415,7 @@ export default function ConnectionsMCP() {
 	const handleUpgrade = async () => {
 		try {
 			await autumn.attach({
-				productId: "consumer_pro",
+				productId: "api_pro",
 				successUrl: "https://app.supermemory.ai/new/settings#connections",
 			})
 			window.location.reload()

--- a/apps/web/components/onboarding/new-onboarding-modal.tsx
+++ b/apps/web/components/onboarding/new-onboarding-modal.tsx
@@ -16,7 +16,7 @@ import { useIsMobile } from "@hooks/use-mobile"
 
 export function NewOnboardingModal() {
 	const router = useRouter()
-	const flagEnabled = useFeatureFlagEnabled("nova-alpha-access")
+	const flagEnabled = true
 	const isMobile = useIsMobile()
 	const [open, setOpen] = useState(false)
 

--- a/apps/web/components/views/billing.tsx
+++ b/apps/web/components/views/billing.tsx
@@ -24,12 +24,12 @@ export function BillingView() {
 
 	const {
 		data: status = {
-			consumer_pro: { allowed: false, status: null },
+			api_pro: { allowed: false, status: null },
 		},
 		isLoading: isCheckingStatus,
 	} = fetchSubscriptionStatus(autumn, !autumn.isLoading)
 
-	const proStatus = status.consumer_pro
+	const proStatus = status.api_pro
 	const proProductStatus = proStatus?.status
 	const isPastDue = proProductStatus === "past_due"
 	const hasProProduct = proProductStatus !== null
@@ -55,7 +55,7 @@ export function BillingView() {
 		setIsLoading(true)
 		try {
 			await autumn.attach({
-				productId: "consumer_pro",
+				productId: "api_pro",
 				successUrl: "https://app.supermemory.ai/",
 			})
 			analytics.upgradeCompleted()

--- a/apps/web/components/views/connections-tab-content.tsx
+++ b/apps/web/components/views/connections-tab-content.tsx
@@ -48,7 +48,7 @@ export function ConnectionsTabContent() {
 	const handleUpgrade = async () => {
 		try {
 			await autumn.attach({
-				productId: "consumer_pro",
+				productId: "api_pro",
 				successUrl: "https://app.supermemory.ai/",
 			})
 			window.location.reload()
@@ -61,9 +61,8 @@ export function ConnectionsTabContent() {
 	useEffect(() => {
 		if (!autumn.isLoading) {
 			setIsProUser(
-				autumn.customer?.products.some(
-					(product) => product.id === "consumer_pro",
-				) ?? false,
+				autumn.customer?.products.some((product) => product.id === "api_pro") ??
+					false,
 			)
 		}
 	}, [autumn.isLoading, autumn.customer])

--- a/apps/web/components/views/integrations.tsx
+++ b/apps/web/components/views/integrations.tsx
@@ -171,7 +171,7 @@ export function IntegrationsView() {
 	const handleUpgrade = async () => {
 		try {
 			await autumn.attach({
-				productId: "consumer_pro",
+				productId: "api_pro",
 				successUrl: "https://app.supermemory.ai/",
 			})
 			window.location.reload()
@@ -183,9 +183,8 @@ export function IntegrationsView() {
 	useEffect(() => {
 		if (!autumn.isLoading) {
 			setIsProUser(
-				autumn.customer?.products.some(
-					(product) => product.id === "consumer_pro",
-				) ?? false,
+				autumn.customer?.products.some((product) => product.id === "api_pro") ??
+					false,
 			)
 		}
 	}, [autumn.isLoading, autumn.customer])

--- a/apps/web/components/views/profile.tsx
+++ b/apps/web/components/views/profile.tsx
@@ -48,12 +48,12 @@ export function ProfileView() {
 
 	const {
 		data: status = {
-			consumer_pro: { allowed: false, status: null },
+			api_pro: { allowed: false, status: null },
 		},
 		isLoading: isCheckingStatus,
 	} = fetchSubscriptionStatus(autumn, !autumn.isLoading)
 
-	const proStatus = status.consumer_pro
+	const proStatus = status.api_pro
 	const isPro = proStatus?.allowed ?? false
 	const proProductStatus = proStatus?.status
 	const isPastDue = proProductStatus === "past_due"
@@ -76,7 +76,7 @@ export function ProfileView() {
 		setIsLoading(true)
 		try {
 			await autumn.attach({
-				productId: "consumer_pro",
+				productId: "api_pro",
 				successUrl: "https://app.supermemory.ai/",
 			})
 			window.location.reload()

--- a/apps/web/hooks/use-memories-usage.ts
+++ b/apps/web/hooks/use-memories-usage.ts
@@ -4,12 +4,12 @@ import type { useCustomer } from "autumn-js/react"
 export function useMemoriesUsage(autumn: ReturnType<typeof useCustomer>) {
 	const {
 		data: status = {
-			consumer_pro: { allowed: false, status: null },
+			api_pro: { allowed: false, status: null },
 		},
 		isLoading: isCheckingStatus,
 	} = fetchSubscriptionStatus(autumn, !autumn.isLoading)
 
-	const proStatus = status.consumer_pro
+	const proStatus = status.api_pro
 	const hasProProduct = proStatus?.status !== null
 
 	const { data: memoriesCheck, isLoading: isLoadingMemories } =

--- a/apps/web/hooks/use-token-usage.ts
+++ b/apps/web/hooks/use-token-usage.ts
@@ -1,0 +1,57 @@
+import { fetchSubscriptionStatus } from "@lib/queries"
+import type { useCustomer } from "autumn-js/react"
+import { calculateUsagePercent, getDaysRemaining } from "@/lib/billing-utils"
+
+export type PlanType = "free" | "pro" | "scale" | "enterprise"
+
+export function useTokenUsage(autumn: ReturnType<typeof useCustomer>) {
+	const {
+		data: status = {
+			api_pro: { allowed: false, status: null },
+			api_scale: { allowed: false, status: null },
+			api_enterprise: { allowed: false, status: null },
+		},
+		isLoading: isCheckingStatus,
+	} = fetchSubscriptionStatus(autumn, !autumn.isLoading)
+
+	let currentPlan: PlanType = "free"
+	if (status.api_enterprise?.status !== null) {
+		currentPlan = "enterprise"
+	} else if (status.api_scale?.status !== null) {
+		currentPlan = "scale"
+	} else if (status.api_pro?.status !== null) {
+		currentPlan = "pro"
+	}
+
+	const hasPaidPlan = currentPlan !== "free"
+
+	// Get token usage from autumn customer features
+	const tokensFeature = autumn.customer?.features?.api_tokens
+	const tokensUsed = tokensFeature?.usage ?? 0
+	const tokensLimit = tokensFeature?.included_usage ?? 0
+	const tokensResetAt = tokensFeature?.next_reset_at
+
+	// Get search queries usage from autumn customer features
+	const searchesFeature = autumn.customer?.features?.api_search_queries
+	const searchesUsed = searchesFeature?.usage ?? 0
+	const searchesLimit = searchesFeature?.included_usage ?? 0
+
+	const isLoading = autumn.isLoading || isCheckingStatus
+
+	const tokensPercent = calculateUsagePercent(tokensUsed, tokensLimit)
+	const searchesPercent = calculateUsagePercent(searchesUsed, searchesLimit)
+	const daysRemaining = getDaysRemaining(tokensResetAt)
+
+	return {
+		tokensUsed,
+		tokensLimit,
+		tokensPercent,
+		searchesUsed,
+		searchesLimit,
+		searchesPercent,
+		currentPlan,
+		hasPaidPlan,
+		isLoading,
+		daysRemaining,
+	}
+}

--- a/apps/web/lib/billing-utils.ts
+++ b/apps/web/lib/billing-utils.ts
@@ -1,0 +1,49 @@
+/**
+ * Convert tokens to credits
+ * 100,000 tokens = 1 credit
+ * Uses floor rounding (2.9 credits shows as 2, only shows 3 when it hits 3.0)
+ */
+export function tokensToCredits(tokens: number): number {
+	return Math.floor(tokens / 100_000)
+}
+
+/**
+ * Format a number with K/M suffix for display
+ * @example formatUsageNumber(1500000) => "1.5M"
+ * @example formatUsageNumber(50000) => "50K"
+ */
+export function formatUsageNumber(value: number): string {
+	if (value >= 1_000_000) {
+		const millions = value / 1_000_000
+		return millions % 1 === 0 ? `${millions}M` : `${millions.toFixed(1)}M`
+	}
+	if (value >= 1_000) {
+		const thousands = value / 1_000
+		return thousands % 1 === 0 ? `${thousands}K` : `${thousands.toFixed(1)}K`
+	}
+	return value.toString()
+}
+
+/**
+ * Calculate usage percentage, clamped between 0 and 100
+ */
+export function calculateUsagePercent(used: number, limit: number): number {
+	if (limit <= 0) return 0
+	return Math.min(Math.max((used / limit) * 100, 0), 100)
+}
+
+/**
+ * Get the number of days remaining until a reset date
+ * @param resetAt - Unix timestamp in milliseconds (from Autumn billing)
+ * @returns number of days, or null if no date provided
+ */
+export function getDaysRemaining(
+	resetAt: number | null | undefined,
+): number | null {
+	if (!resetAt) return null
+	const end = new Date(resetAt)
+	const now = new Date()
+	const diffMs = end.getTime() - now.getTime()
+	const diffDays = Math.ceil(diffMs / (1000 * 60 * 60 * 24))
+	return Math.max(0, diffDays)
+}

--- a/packages/lib/queries.ts
+++ b/packages/lib/queries.ts
@@ -14,7 +14,7 @@ export const fetchSubscriptionStatus = (
 ) =>
 	useQuery({
 		queryFn: async () => {
-			const allPlans = ["consumer_pro"]
+			const allPlans = ["api_pro", "api_scale", "api_enterprise"]
 			const statusMap: Record<
 				string,
 				{ allowed: boolean; status: string | null }
@@ -84,15 +84,13 @@ export const fetchConnectionsFeature = (
 	})
 
 // Product checks
-export const fetchConsumerProProduct = (
-	autumn: ReturnType<typeof useCustomer>,
-) =>
+export const fetchApiProProduct = (autumn: ReturnType<typeof useCustomer>) =>
 	useQuery({
 		queryFn: async () => {
-			const res = autumn.check({ productId: "consumer_pro" })
+			const res = autumn.check({ productId: "api_pro" })
 			return res.data
 		},
-		queryKey: ["autumn-product", "consumer_pro"],
+		queryKey: ["autumn-product", "api_pro"],
 		staleTime: 30 * 1000, // 30 seconds
 		gcTime: 5 * 60 * 1000, // 5 minutes
 	})

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,6 +3,9 @@
 	"version": "0.0.0",
 	"private": true,
 	"type": "module",
+	"exports": {
+		"./*": "./*"
+	},
 	"dependencies": {
 		"@pixi/react": "^8.0.3",
 		"@radix-ui/react-accordion": "^1.2.11",


### PR DESCRIPTION
Summary

  - Migrate from consumer_pro to api_pro billing product across the app
  - Enable Nova app for all users (remove feature flag)
  - Add credits-based usage tracking with tokens abstraction