### PR TITLE
fix(mcp): register handler on bare /mcp path to match MCP transport spec

### DIFF
--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -100,9 +100,6 @@ const mcpHandler = SupermemoryMCP.mount("/mcp", {
 	},
 })
 
-// MCP request handler — registered on both bare and wildcard paths
-// to comply with MCP Streamable HTTP transport spec, which requires
-// a single endpoint that accepts POST, GET, and DELETE.
 const handleMcpRequest = async (c: Context<{ Bindings: Bindings }>) => {
 	const authHeader = c.req.header("Authorization")
 	const token = authHeader?.replace(/^Bearer\s+/i, "")

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -6,17 +6,17 @@ import { initPosthog } from "./posthog"
 import type { ContentfulStatusCode } from "hono/utils/http-status"
 
 type Bindings = {
-  MCP_SERVER: DurableObjectNamespace
-  API_URL?: string
-  POSTHOG_API_KEY?: string
+	MCP_SERVER: DurableObjectNamespace
+	API_URL?: string
+	POSTHOG_API_KEY?: string
 }
 
 type Props = {
-  userId: string
-  apiKey: string
-  containerTag?: string
-  email?: string
-  name?: string
+	userId: string
+	apiKey: string
+	containerTag?: string
+	email?: string
+	name?: string
 }
 
 const app = new Hono<{ Bindings: Bindings }>()
@@ -25,153 +25,153 @@ const DEFAULT_API_URL = "https://api.supermemory.ai"
 
 // CORS
 app.use(
-  "*",
-  cors({
-    origin: "*",
-    allowMethods: ["GET", "POST", "OPTIONS"],
-    allowHeaders: ["Content-Type", "Authorization", "x-sm-project"],
-  }),
+	"*",
+	cors({
+		origin: "*",
+		allowMethods: ["GET", "POST", "OPTIONS"],
+		allowHeaders: ["Content-Type", "Authorization", "x-sm-project"],
+	}),
 )
 
 app.use("*", async (c, next) => {
-  initPosthog(c.env.POSTHOG_API_KEY)
-  await next()
+	initPosthog(c.env.POSTHOG_API_KEY)
+	await next()
 })
 
 app.get("/", (c) => {
-  return c.json({
-    name: "supermemory-mcp",
-    version: "4.0.0",
-    description: "Give your AI a memory",
-    docs: "https://docs.supermemory.ai/mcp",
-  })
+	return c.json({
+		name: "supermemory-mcp",
+		version: "4.0.0",
+		description: "Give your AI a memory",
+		docs: "https://docs.supermemory.ai/mcp",
+	})
 })
 
 // MCP clients use this to discover the authorization server
 app.get("/.well-known/oauth-protected-resource", (c) => {
-  const apiUrl = c.env.API_URL || DEFAULT_API_URL
-  const resourceUrl =
-    c.env.API_URL === "http://localhost:8787"
-      ? "http://localhost:8788"
-      : "https://mcp.supermemory.ai"
+	const apiUrl = c.env.API_URL || DEFAULT_API_URL
+	const resourceUrl =
+		c.env.API_URL === "http://localhost:8787"
+			? "http://localhost:8788"
+			: "https://mcp.supermemory.ai"
 
-  return c.json({
-    resource: resourceUrl,
-    authorization_servers: [apiUrl],
-    scopes_supported: ["openid", "profile", "email", "offline_access"],
-    bearer_methods_supported: ["header"],
-    resource_documentation: "https://docs.supermemory.ai/mcp",
-  })
+	return c.json({
+		resource: resourceUrl,
+		authorization_servers: [apiUrl],
+		scopes_supported: ["openid", "profile", "email", "offline_access"],
+		bearer_methods_supported: ["header"],
+		resource_documentation: "https://docs.supermemory.ai/mcp",
+	})
 })
 
 // Proxy endpoint for MCP clients that don't follow the spec correctly
 // Some clients look for oauth-authorization-server on the MCP server domain
 // instead of following the authorization_servers array
 app.get("/.well-known/oauth-authorization-server", async (c) => {
-  const apiUrl = c.env.API_URL || DEFAULT_API_URL
+	const apiUrl = c.env.API_URL || DEFAULT_API_URL
 
-  try {
-    // Fetch the authorization server metadata from the main API
-    const response = await fetch(
-      `${apiUrl}/.well-known/oauth-authorization-server`,
-    )
+	try {
+		// Fetch the authorization server metadata from the main API
+		const response = await fetch(
+			`${apiUrl}/.well-known/oauth-authorization-server`,
+		)
 
-    if (!response.ok) {
-      return c.json(
-        { error: "Failed to fetch authorization server metadata" },
-        { status: response.status as ContentfulStatusCode },
-      )
-    }
+		if (!response.ok) {
+			return c.json(
+				{ error: "Failed to fetch authorization server metadata" },
+				{ status: response.status as ContentfulStatusCode },
+			)
+		}
 
-    const metadata = await response.json()
-    return c.json(metadata)
-  } catch (error) {
-    console.error("Error fetching OAuth authorization server metadata:", error)
-    return c.json({ error: "Internal server error" }, 500)
-  }
+		const metadata = await response.json()
+		return c.json(metadata)
+	} catch (error) {
+		console.error("Error fetching OAuth authorization server metadata:", error)
+		return c.json({ error: "Internal server error" }, 500)
+	}
 })
 
 const mcpHandler = SupermemoryMCP.mount("/mcp", {
-  binding: "MCP_SERVER",
-  corsOptions: {
-    origin: "*",
-    methods: "GET, POST, OPTIONS",
-    headers: "Content-Type, Authorization, x-sm-project",
-  },
+	binding: "MCP_SERVER",
+	corsOptions: {
+		origin: "*",
+		methods: "GET, POST, OPTIONS",
+		headers: "Content-Type, Authorization, x-sm-project",
+	},
 })
 
 // MCP request handler — registered on both bare and wildcard paths
 // to comply with MCP Streamable HTTP transport spec, which requires
 // a single endpoint that accepts POST, GET, and DELETE.
 const handleMcpRequest = async (c: Context<{ Bindings: Bindings }>) => {
-  const authHeader = c.req.header("Authorization")
-  const token = authHeader?.replace(/^Bearer\s+/i, "")
-  const containerTag = c.req.header("x-sm-project")
-  const apiUrl = c.env.API_URL || DEFAULT_API_URL
+	const authHeader = c.req.header("Authorization")
+	const token = authHeader?.replace(/^Bearer\s+/i, "")
+	const containerTag = c.req.header("x-sm-project")
+	const apiUrl = c.env.API_URL || DEFAULT_API_URL
 
-  if (!token) {
-    return new Response("Unauthorized", {
-      status: 401,
-      headers: {
-        "WWW-Authenticate": `Bearer resource_metadata="/.well-known/oauth-protected-resource"`,
-        "Access-Control-Expose-Headers": "WWW-Authenticate",
-      },
-    })
-  }
+	if (!token) {
+		return new Response("Unauthorized", {
+			status: 401,
+			headers: {
+				"WWW-Authenticate": `Bearer resource_metadata="/.well-known/oauth-protected-resource"`,
+				"Access-Control-Expose-Headers": "WWW-Authenticate",
+			},
+		})
+	}
 
-  let authUser: {
-    userId: string
-    apiKey: string
-    email?: string
-    name?: string
-  } | null = null
+	let authUser: {
+		userId: string
+		apiKey: string
+		email?: string
+		name?: string
+	} | null = null
 
-  if (isApiKey(token)) {
-    console.log("Authenticating with API key")
-    authUser = await validateApiKey(token, apiUrl)
-  } else {
-    console.log("Authenticating with OAuth token")
-    authUser = await validateOAuthToken(token, apiUrl)
-  }
+	if (isApiKey(token)) {
+		console.log("Authenticating with API key")
+		authUser = await validateApiKey(token, apiUrl)
+	} else {
+		console.log("Authenticating with OAuth token")
+		authUser = await validateOAuthToken(token, apiUrl)
+	}
 
-  if (!authUser) {
-    const errorMessage = isApiKey(token)
-      ? "Unauthorized: Invalid or expired API key"
-      : "Unauthorized: Invalid or expired token"
+	if (!authUser) {
+		const errorMessage = isApiKey(token)
+			? "Unauthorized: Invalid or expired API key"
+			: "Unauthorized: Invalid or expired token"
 
-    return new Response(
-      JSON.stringify({
-        jsonrpc: "2.0",
-        error: {
-          code: -32000,
-          message: errorMessage,
-        },
-        id: null,
-      }),
-      {
-        status: 401,
-        headers: {
-          "Content-Type": "application/json",
-          "WWW-Authenticate": `Bearer error="invalid_token", resource_metadata="/.well-known/oauth-protected-resource"`,
-          "Access-Control-Expose-Headers": "WWW-Authenticate",
-        },
-      },
-    )
-  }
+		return new Response(
+			JSON.stringify({
+				jsonrpc: "2.0",
+				error: {
+					code: -32000,
+					message: errorMessage,
+				},
+				id: null,
+			}),
+			{
+				status: 401,
+				headers: {
+					"Content-Type": "application/json",
+					"WWW-Authenticate": `Bearer error="invalid_token", resource_metadata="/.well-known/oauth-protected-resource"`,
+					"Access-Control-Expose-Headers": "WWW-Authenticate",
+				},
+			},
+		)
+	}
 
-  // Create execution context with authenticated user props
-  const ctx = {
-    ...c.executionCtx,
-    props: {
-      userId: authUser.userId,
-      apiKey: authUser.apiKey,
-      containerTag,
-      email: authUser.email,
-      name: authUser.name,
-    } satisfies Props,
-  } as ExecutionContext & { props: Props }
+	// Create execution context with authenticated user props
+	const ctx = {
+		...c.executionCtx,
+		props: {
+			userId: authUser.userId,
+			apiKey: authUser.apiKey,
+			containerTag,
+			email: authUser.email,
+			name: authUser.name,
+		} satisfies Props,
+	} as ExecutionContext & { props: Props }
 
-  return mcpHandler.fetch(c.req.raw, c.env, ctx)
+	return mcpHandler.fetch(c.req.raw, c.env, ctx)
 }
 
 app.all("/mcp", handleMcpRequest)

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -1,22 +1,22 @@
 import { cors } from "hono/cors"
-import { Hono } from "hono"
+import { Hono, type Context } from "hono"
 import { SupermemoryMCP } from "./server"
 import { isApiKey, validateApiKey, validateOAuthToken } from "./auth"
 import { initPosthog } from "./posthog"
 import type { ContentfulStatusCode } from "hono/utils/http-status"
 
 type Bindings = {
-	MCP_SERVER: DurableObjectNamespace
-	API_URL?: string
-	POSTHOG_API_KEY?: string
+  MCP_SERVER: DurableObjectNamespace
+  API_URL?: string
+  POSTHOG_API_KEY?: string
 }
 
 type Props = {
-	userId: string
-	apiKey: string
-	containerTag?: string
-	email?: string
-	name?: string
+  userId: string
+  apiKey: string
+  containerTag?: string
+  email?: string
+  name?: string
 }
 
 const app = new Hono<{ Bindings: Bindings }>()
@@ -25,151 +25,157 @@ const DEFAULT_API_URL = "https://api.supermemory.ai"
 
 // CORS
 app.use(
-	"*",
-	cors({
-		origin: "*",
-		allowMethods: ["GET", "POST", "OPTIONS"],
-		allowHeaders: ["Content-Type", "Authorization", "x-sm-project"],
-	}),
+  "*",
+  cors({
+    origin: "*",
+    allowMethods: ["GET", "POST", "OPTIONS"],
+    allowHeaders: ["Content-Type", "Authorization", "x-sm-project"],
+  }),
 )
 
 app.use("*", async (c, next) => {
-	initPosthog(c.env.POSTHOG_API_KEY)
-	await next()
+  initPosthog(c.env.POSTHOG_API_KEY)
+  await next()
 })
 
 app.get("/", (c) => {
-	return c.json({
-		name: "supermemory-mcp",
-		version: "4.0.0",
-		description: "Give your AI a memory",
-		docs: "https://docs.supermemory.ai/mcp",
-	})
+  return c.json({
+    name: "supermemory-mcp",
+    version: "4.0.0",
+    description: "Give your AI a memory",
+    docs: "https://docs.supermemory.ai/mcp",
+  })
 })
 
 // MCP clients use this to discover the authorization server
 app.get("/.well-known/oauth-protected-resource", (c) => {
-	const apiUrl = c.env.API_URL || DEFAULT_API_URL
-	const resourceUrl =
-		c.env.API_URL === "http://localhost:8787"
-			? "http://localhost:8788"
-			: "https://mcp.supermemory.ai"
+  const apiUrl = c.env.API_URL || DEFAULT_API_URL
+  const resourceUrl =
+    c.env.API_URL === "http://localhost:8787"
+      ? "http://localhost:8788"
+      : "https://mcp.supermemory.ai"
 
-	return c.json({
-		resource: resourceUrl,
-		authorization_servers: [apiUrl],
-		scopes_supported: ["openid", "profile", "email", "offline_access"],
-		bearer_methods_supported: ["header"],
-		resource_documentation: "https://docs.supermemory.ai/mcp",
-	})
+  return c.json({
+    resource: resourceUrl,
+    authorization_servers: [apiUrl],
+    scopes_supported: ["openid", "profile", "email", "offline_access"],
+    bearer_methods_supported: ["header"],
+    resource_documentation: "https://docs.supermemory.ai/mcp",
+  })
 })
 
 // Proxy endpoint for MCP clients that don't follow the spec correctly
 // Some clients look for oauth-authorization-server on the MCP server domain
 // instead of following the authorization_servers array
 app.get("/.well-known/oauth-authorization-server", async (c) => {
-	const apiUrl = c.env.API_URL || DEFAULT_API_URL
+  const apiUrl = c.env.API_URL || DEFAULT_API_URL
 
-	try {
-		// Fetch the authorization server metadata from the main API
-		const response = await fetch(
-			`${apiUrl}/.well-known/oauth-authorization-server`,
-		)
+  try {
+    // Fetch the authorization server metadata from the main API
+    const response = await fetch(
+      `${apiUrl}/.well-known/oauth-authorization-server`,
+    )
 
-		if (!response.ok) {
-			return c.json(
-				{ error: "Failed to fetch authorization server metadata" },
-				{ status: response.status as ContentfulStatusCode },
-			)
-		}
+    if (!response.ok) {
+      return c.json(
+        { error: "Failed to fetch authorization server metadata" },
+        { status: response.status as ContentfulStatusCode },
+      )
+    }
 
-		const metadata = await response.json()
-		return c.json(metadata)
-	} catch (error) {
-		console.error("Error fetching OAuth authorization server metadata:", error)
-		return c.json({ error: "Internal server error" }, 500)
-	}
+    const metadata = await response.json()
+    return c.json(metadata)
+  } catch (error) {
+    console.error("Error fetching OAuth authorization server metadata:", error)
+    return c.json({ error: "Internal server error" }, 500)
+  }
 })
 
 const mcpHandler = SupermemoryMCP.mount("/mcp", {
-	binding: "MCP_SERVER",
-	corsOptions: {
-		origin: "*",
-		methods: "GET, POST, OPTIONS",
-		headers: "Content-Type, Authorization, x-sm-project",
-	},
+  binding: "MCP_SERVER",
+  corsOptions: {
+    origin: "*",
+    methods: "GET, POST, OPTIONS",
+    headers: "Content-Type, Authorization, x-sm-project",
+  },
 })
 
-app.all("/mcp/*", async (c) => {
-	const authHeader = c.req.header("Authorization")
-	const token = authHeader?.replace(/^Bearer\s+/i, "")
-	const containerTag = c.req.header("x-sm-project")
-	const apiUrl = c.env.API_URL || DEFAULT_API_URL
+// MCP request handler — registered on both bare and wildcard paths
+// to comply with MCP Streamable HTTP transport spec, which requires
+// a single endpoint that accepts POST, GET, and DELETE.
+const handleMcpRequest = async (c: Context<{ Bindings: Bindings }>) => {
+  const authHeader = c.req.header("Authorization")
+  const token = authHeader?.replace(/^Bearer\s+/i, "")
+  const containerTag = c.req.header("x-sm-project")
+  const apiUrl = c.env.API_URL || DEFAULT_API_URL
 
-	if (!token) {
-		return new Response("Unauthorized", {
-			status: 401,
-			headers: {
-				"WWW-Authenticate": `Bearer resource_metadata="/.well-known/oauth-protected-resource"`,
-				"Access-Control-Expose-Headers": "WWW-Authenticate",
-			},
-		})
-	}
+  if (!token) {
+    return new Response("Unauthorized", {
+      status: 401,
+      headers: {
+        "WWW-Authenticate": `Bearer resource_metadata="/.well-known/oauth-protected-resource"`,
+        "Access-Control-Expose-Headers": "WWW-Authenticate",
+      },
+    })
+  }
 
-	let authUser: {
-		userId: string
-		apiKey: string
-		email?: string
-		name?: string
-	} | null = null
+  let authUser: {
+    userId: string
+    apiKey: string
+    email?: string
+    name?: string
+  } | null = null
 
-	if (isApiKey(token)) {
-		console.log("Authenticating with API key")
-		authUser = await validateApiKey(token, apiUrl)
-	} else {
-		console.log("Authenticating with OAuth token")
-		authUser = await validateOAuthToken(token, apiUrl)
-	}
+  if (isApiKey(token)) {
+    console.log("Authenticating with API key")
+    authUser = await validateApiKey(token, apiUrl)
+  } else {
+    console.log("Authenticating with OAuth token")
+    authUser = await validateOAuthToken(token, apiUrl)
+  }
 
-	if (!authUser) {
-		const errorMessage = isApiKey(token)
-			? "Unauthorized: Invalid or expired API key"
-			: "Unauthorized: Invalid or expired token"
+  if (!authUser) {
+    const errorMessage = isApiKey(token)
+      ? "Unauthorized: Invalid or expired API key"
+      : "Unauthorized: Invalid or expired token"
 
-		return new Response(
-			JSON.stringify({
-				jsonrpc: "2.0",
-				error: {
-					code: -32000,
-					message: errorMessage,
-				},
-				id: null,
-			}),
-			{
-				status: 401,
-				headers: {
-					"Content-Type": "application/json",
-					"WWW-Authenticate": `Bearer error="invalid_token", resource_metadata="/.well-known/oauth-protected-resource"`,
-					"Access-Control-Expose-Headers": "WWW-Authenticate",
-				},
-			},
-		)
-	}
+    return new Response(
+      JSON.stringify({
+        jsonrpc: "2.0",
+        error: {
+          code: -32000,
+          message: errorMessage,
+        },
+        id: null,
+      }),
+      {
+        status: 401,
+        headers: {
+          "Content-Type": "application/json",
+          "WWW-Authenticate": `Bearer error="invalid_token", resource_metadata="/.well-known/oauth-protected-resource"`,
+          "Access-Control-Expose-Headers": "WWW-Authenticate",
+        },
+      },
+    )
+  }
 
-	// Create execution context with authenticated user props
-	const ctx = {
-		...c.executionCtx,
-		props: {
-			userId: authUser.userId,
-			apiKey: authUser.apiKey,
-			containerTag,
-			email: authUser.email,
-			name: authUser.name,
-		} satisfies Props,
-	} as ExecutionContext & { props: Props }
+  // Create execution context with authenticated user props
+  const ctx = {
+    ...c.executionCtx,
+    props: {
+      userId: authUser.userId,
+      apiKey: authUser.apiKey,
+      containerTag,
+      email: authUser.email,
+      name: authUser.name,
+    } satisfies Props,
+  } as ExecutionContext & { props: Props }
 
-	return mcpHandler.fetch(c.req.raw, c.env, ctx)
-})
+  return mcpHandler.fetch(c.req.raw, c.env, ctx)
+}
+
+app.all("/mcp", handleMcpRequest)
+app.all("/mcp/*", handleMcpRequest)
 
 // Export the Durable Object class for Cloudflare Workers
 export { SupermemoryMCP }


### PR DESCRIPTION
## Problem

The Supermemory MCP server returns `404 Not Found` when MCP clients send requests to the bare `/mcp` endpoint. This breaks compatibility with standard MCP clients such as [mcp-cli](https://github.com/philschmid/mcp-cli) and any client that follows the MCP Streamable HTTP transport specification.

The root cause is the Hono route pattern `app.all("/mcp/*")` in `apps/mcp/src/index.ts`. In Hono, the `/*` wildcard requires at least one path segment after `/mcp/` — meaning `POST /mcp` does not match, while `POST /mcp/sse` or `POST /mcp/message` would.

When mcp-cli connects using the standard HTTP transport configuration:

```json
{
  "type": "http",
  "url": "https://mcp.supermemory.ai/mcp",
  "headers": { "Authorization": "Bearer <token>" }
}
```

It sends `POST /mcp` with the JSON-RPC `initialize` request. The server responds with 404 before the request ever reaches the auth middleware or the MCP handler.

For comparison, the [NeonDB MCP server](https://github.com/neondatabase/mcp-server-neon) (`mcp-server-neon`) handles the same `POST /mcp` request correctly because its `mcp-handler` library matches exact paths rather than relying on wildcard patterns. Running `mcp-cli -d neon` succeeds while `mcp-cli -d supermemory-mcp` fails with:

```
Error [SERVER_CONNECTION_FAILED]: Failed to connect to server "supermemory-mcp"
Details: Streamable HTTP error: Error POSTing to endpoint: Not Found
```

## What the MCP specification requires

The [MCP Streamable HTTP transport specification](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports) (revision 2025-03-26) states:

> An MCP server that supports Streamable HTTP transport MUST provide a single HTTP endpoint path (hereafter referred to as the MCP endpoint) that accepts requests.

The server MUST accept `POST` (client-to-server JSON-RPC messages), `GET` (opening an SSE stream for server-to-client notifications), and `DELETE` (session termination) on that single endpoint. The client sends requests directly to the configured URL — in this case `/mcp` — not to a sub-path of it.

Full specification reference: https://modelcontextprotocol.info/

The mcp-cli implementation (https://github.com/philschmid/mcp-cli) follows this spec correctly: it POSTs the JSON-RPC `initialize` request directly to the configured URL, without appending any sub-path. Any MCP server that does not respond to requests on the exact configured endpoint path is non-compliant.

## Changes

### `apps/mcp/src/index.ts`

**1. Added `Context` type import from Hono (line 2)**

Required for the type annotation on the extracted handler function.

```typescript
// Before
import { Hono } from "hono"

// After
import { Hono, type Context } from "hono"
```

**2. Extracted inline route handler to a named `handleMcpRequest` function (lines 103-175)**

The authentication logic and Durable Object delegation are completely unchanged. The handler body was moved out of the inline `app.all()` callback into a named const to avoid duplicating it across two route registrations.

**3. Registered the handler on both `/mcp` and `/mcp/*` (lines 177-178)**

```typescript
// Before
app.all("/mcp/*", async (c) => {
  // auth + handler logic inline
})

// After
const handleMcpRequest = async (c: Context<{ Bindings: Bindings }>) => {
  // same auth + handler logic, unchanged
}

app.all("/mcp", handleMcpRequest)
app.all("/mcp/*", handleMcpRequest)
```

The bare `/mcp` registration handles the standard MCP client behavior (POST/GET/DELETE to the exact endpoint path). The `/mcp/*` wildcard registration preserves backward compatibility with any clients or internal routing that may use sub-paths.

No logic changes. No new dependencies. No changes to authentication, tool definitions, resources, or prompts.

## How other HTTP MCP servers handle this correctly

**NeonDB MCP server** (`mcp-server-neon`): Uses the `mcp-handler` library with `createMcpHandler()`, which internally matches exact paths. Their route handler in `landing/app/api/[transport]/route.ts` also includes explicit path normalization (lines 685-703) that rewrites `/mcp` to `/api/mcp` before passing to the handler, ensuring the endpoint always matches regardless of how the client addresses it:

```typescript
const handleRequest = (req: Request) => {
  const url = new URL(req.url);
  if (url.pathname === '/mcp') {
    url.pathname = '/api/mcp';
  }
  // ...
  return authHandler(normalizedReq);
};
```

This is the correct pattern: the server must be reachable at the exact path the client is configured to use, per the MCP Streamable HTTP transport specification.

**mcp-cli** (https://github.com/philschmid/mcp-cli): The reference client implementation POSTs directly to the configured URL without modification. When a server's routing does not match that exact path, the connection fails. This is the expected and spec-compliant client behavior.

## Testing

After this fix:

- `mcp-cli -d supermemory-mcp` successfully connects, completes the MCP initialize handshake, and lists available tools
- Existing clients using sub-paths under `/mcp/*` continue to work without changes
- Authentication behavior is unchanged: 401 without a token, 401 with an invalid token, normal flow with a valid token
