### PR TITLE
fix: added chat history button on mobile view

### DIFF
--- a/apps/web/components/chat/index.tsx
+++ b/apps/web/components/chat/index.tsx
@@ -660,31 +660,30 @@ export function ChatSidebar({
 							onModelChange={setSelectedModel}
 						/>
 						<div className="flex items-center gap-2">
-							{!isMobile && (
-								<Dialog
-									open={isHistoryOpen}
-									onOpenChange={(open) => {
-										setIsHistoryOpen(open)
-										if (open) {
-											fetchThreads()
-											analytics.chatHistoryViewed?.()
-										} else {
-											setConfirmingDeleteId(null)
-										}
-									}}
-								>
-									<DialogTrigger asChild>
-										<Button
-											variant="headers"
-											className="rounded-full text-base gap-2 h-10! border-[#73737333] bg-[#0D121A] cursor-pointer"
-											style={{
-												boxShadow:
-													"1.5px 1.5px 4.5px 0 rgba(0, 0, 0, 0.70) inset",
-											}}
-										>
-											<HistoryIcon className="size-4 text-[#737373]" />
-										</Button>
-									</DialogTrigger>
+							<Dialog
+								open={isHistoryOpen}
+								onOpenChange={(open) => {
+									setIsHistoryOpen(open)
+									if (open) {
+										fetchThreads()
+										analytics.chatHistoryViewed?.()
+									} else {
+										setConfirmingDeleteId(null)
+									}
+								}}
+							>
+								<DialogTrigger asChild>
+									<Button
+										variant="headers"
+										className="rounded-full text-base gap-2 h-10! border-[#73737333] bg-[#0D121A] cursor-pointer"
+										style={{
+											boxShadow:
+												"1.5px 1.5px 4.5px 0 rgba(0, 0, 0, 0.70) inset",
+										}}
+									>
+										<HistoryIcon className="size-4 text-[#737373]" />
+									</Button>
+								</DialogTrigger>
 									<DialogContent className="sm:max-w-lg bg-[#0A0E14] border-[#17181AB2] text-white">
 										<DialogHeader className="pb-4 border-b border-[#17181AB2]">
 											<DialogTitle>Chat History</DialogTitle>
@@ -783,7 +782,6 @@ export function ChatSidebar({
 										</Button>
 									</DialogContent>
 								</Dialog>
-							)}
 							<Button
 								variant="headers"
 								className="rounded-full text-base gap-3 h-10! border-[#73737333] bg-[#0D121A] cursor-pointer"


### PR DESCRIPTION
## Fixes
Chat history button is now visible on mobile view of Nova chat window

### Before

<img width="454" height="238" alt="before" src="https://github.com/user-attachments/assets/1e5aece7-d860-4042-b06f-e7f0a010ffe4" />

### After

<img width="470" height="398" alt="after2" src="https://github.com/user-attachments/assets/0f4a11ef-6fb4-48ec-a6fa-6f6d7ea5a6c3" />

### PS the changes show 24 add/26 rem but it's just cause of prettier extension refactoring
