### PR TITLE
fix(mcp): change memories.delete to documents.delete for forget action

### DIFF
--- a/apps/mcp/src/client.ts
+++ b/apps/mcp/src/client.ts
@@ -111,7 +111,7 @@ export class SupermemoryClient {
 
 			// Delete the most similar match
 			const memoryToDelete = searchResult.results[0]
-			await this.client.memories.delete(memoryToDelete.id)
+			await this.client.documents.delete(memoryToDelete.id)
 
 			const memoryText = memoryToDelete.memory || memoryToDelete.content || ""
 			return {


### PR DESCRIPTION
The MCP server's 'forget' action was attempting to call 'this.client.memories.delete', which is not a valid method in the current SDK. Changed to 'this.client.documents.delete' to fix the server-side error: 'this.client.memories.delete is not a function'.