### PR TITLE
Add 'type' field to supermemory MCP server config

### DIFF
--- a/apps/docs/supermemory-mcp/mcp.mdx
+++ b/apps/docs/supermemory-mcp/mcp.mdx
@@ -22,6 +22,7 @@ Add to your MCP client config:
 {
   "mcpServers": {
     "supermemory": {
+      "type": "sse",
       "url": "https://mcp.supermemory.ai/mcp"
     }
   }
@@ -38,6 +39,7 @@ If you prefer API keys over OAuth, get one from [app.supermemory.ai](https://app
 {
   "mcpServers": {
     "supermemory": {
+      "type": "sse",
       "url": "https://mcp.supermemory.ai/mcp",
       "headers": {
         "Authorization": "Bearer sm_your_api_key_here"
@@ -57,6 +59,7 @@ Scope all operations to a specific project with `x-sm-project`:
 {
   "mcpServers": {
     "supermemory": {
+      "type": "sse",
       "url": "https://mcp.supermemory.ai/mcp",
       "headers": {
         "x-sm-project": "your-project-id"

--- a/apps/docs/supermemory-mcp/setup.mdx
+++ b/apps/docs/supermemory-mcp/setup.mdx
@@ -20,6 +20,7 @@ Add this to your MCP client config (Claude Desktop, Cursor, Windsurf, etc.):
 {
   "mcpServers": {
     "supermemory": {
+      "type": "sse",
       "url": "https://mcp.supermemory.ai/mcp"
     }
   }
@@ -36,6 +37,7 @@ If you prefer to use an API key instead of OAuth, get one from [app.supermemory.
 {
   "mcpServers": {
     "supermemory": {
+      "type": "sse",
       "url": "https://mcp.supermemory.ai/mcp",
       "headers": {
         "Authorization": "Bearer sm_your_api_key_here"
@@ -55,6 +57,7 @@ To scope all operations to a specific project, add the `x-sm-project` header:
 {
   "mcpServers": {
     "supermemory": {
+      "type": "sse",
       "url": "https://mcp.supermemory.ai/mcp",
       "headers": {
         "x-sm-project": "your-project-id"
@@ -76,6 +79,7 @@ Add to `~/Library/Application Support/Claude/claude_desktop_config.json` (macOS)
 {
   "mcpServers": {
     "supermemory": {
+      "type": "sse",
       "url": "https://mcp.supermemory.ai/mcp"
     }
   }


### PR DESCRIPTION
Added 'type' field to supermemory MCP server configuration. Supermemory uses SSE, and if that is not directly specified, the MCP server will error out.