### PR TITLE
perf(middleware): await background task cancellation on timeout

### DIFF
--- a/packages/openai-sdk-python/pyproject.toml
+++ b/packages/openai-sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "supermemory-openai-sdk"
-version = "1.0.2"
+version = "1.0.3"
 description = "Memory tools for OpenAI function calling with supermemory"
 readme = "README.md"
 license = "MIT"

--- a/packages/openai-sdk-python/src/supermemory_openai/middleware.py
+++ b/packages/openai-sdk-python/src/supermemory_openai/middleware.py
@@ -554,9 +554,12 @@ class SupermemoryOpenAIWrapper:
                 f"Background tasks did not complete within {timeout}s timeout"
             )
             # Cancel remaining tasks
-            for task in self._background_tasks:
-                if not task.done():
-                    task.cancel()
+            tasks_to_cancel = [task for task in self._background_tasks if not task.done()]
+            for task in tasks_to_cancel:
+                task.cancel()
+
+            if tasks_to_cancel:
+                await asyncio.gather(*tasks_to_cancel, return_exceptions=True)
             raise
 
     def cancel_background_tasks(self) -> None:

--- a/packages/openai-sdk-python/uv.lock
+++ b/packages/openai-sdk-python/uv.lock
@@ -2427,7 +2427,7 @@ wheels = [
 
 [[package]]
 name = "supermemory-openai-sdk"
-version = "1.0.2"
+version = "1.0.3"
 source = { editable = "." }
 dependencies = [
     { name = "openai" },


### PR DESCRIPTION
**Summary**
Added an await asyncio.gather(*tasks_to_cancel, return_exceptions=True) call inside the except asyncio.TimeoutError: block of wait_for_background_tasks 

Previously, when the wait_for_background_tasks method timed out, it iterated over unfinished tasks and called task.cancel(). However, calling cancel() only requests cancellation; it doesn't wait for the task's cleanup logic (e.g., except asyncio.CancelledError:) to actually complete. This created orphaned tasks running asynchronously in the background.
Failing to await cancelled tasks leads to "Task was destroyed but it is pending!" errors at shutdown. More importantly, it leaks memory and limits scalability because background cleanup continues executing unbounded. 