### PR TITLE
feat(mcp): add export-memories tool for data portability

### DIFF
--- a/apps/mcp/src/client.ts
+++ b/apps/mcp/src/client.ts
@@ -384,6 +384,33 @@ export class SupermemoryClient {
 		}
 	}
 
+	// Export all memories via the graph viewport endpoint.
+	// Returns documents with their extracted memories for backup/migration.
+	async exportMemories(containerTags?: string[]): Promise<{
+		documents: GraphApiDocument[]
+		totalCount: number
+	}> {
+		try {
+			// Get bounds first to know the full coordinate range
+			const bounds = await this.getGraphBounds(containerTags)
+			const { minX, maxX, minY, maxY } = bounds.bounds
+
+			// Fetch all documents within the full bounds, high limit
+			const viewport = await this.getGraphViewport(
+				{ minX, maxX, minY, maxY },
+				containerTags,
+				10000,
+			)
+
+			return {
+				documents: viewport.documents,
+				totalCount: viewport.totalCount,
+			}
+		} catch (error) {
+			this.handleError(error)
+		}
+	}
+
 	private handleError(error: unknown): never {
 		// Handle network/fetch errors
 		if (error instanceof TypeError) {

--- a/apps/mcp/src/server.ts
+++ b/apps/mcp/src/server.ts
@@ -242,6 +242,74 @@ export class SupermemoryMCP extends McpAgent<Env, unknown, Props> {
 			},
 		)
 
+		// Register export-memories tool
+		const exportSchema = z.object({
+			...(hasRootContainerTag ? {} : containerTagField),
+			format: z
+				.enum(["json", "jsonl"])
+				.optional()
+				.default("json")
+				.describe("Output format: json (single array) or jsonl (one document per line)"),
+		})
+
+		type ExportArgs = z.infer<typeof exportSchema>
+
+		this.server.registerTool(
+			"export-memories",
+			{
+				description:
+					"Export all memories as structured data for backup or migration. Returns documents with their extracted memories.",
+				inputSchema: exportSchema,
+			},
+			// @ts-expect-error - zod type inference issue with MCP SDK
+			async (args: ExportArgs) => {
+				try {
+					const effectiveContainerTag =
+						(args as { containerTag?: string }).containerTag ||
+						this.props?.containerTag
+					const client = this.getClient(effectiveContainerTag)
+					const containerTags = effectiveContainerTag
+						? [effectiveContainerTag]
+						: undefined
+
+					const result = await client.exportMemories(containerTags)
+
+					const isJsonl = args.format === "jsonl"
+					const output = isJsonl
+						? result.documents.map((d) => JSON.stringify(d)).join("\n")
+						: JSON.stringify(result.documents, null, 2)
+
+					const memoryCount = result.documents.reduce(
+						(sum, d) => sum + d.memories.length,
+						0,
+					)
+
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: `Exported ${result.documents.length} documents with ${memoryCount} memories (${result.totalCount} total).${effectiveContainerTag ? ` Project: ${effectiveContainerTag}` : ""}\n\n${output}`,
+							},
+						],
+					}
+				} catch (error) {
+					const message =
+						error instanceof Error
+							? error.message
+							: "An unexpected error occurred"
+					return {
+						content: [
+							{
+								type: "text" as const,
+								text: `Error exporting memories: ${message}`,
+							},
+						],
+						isError: true,
+					}
+				}
+			},
+		)
+
 		// Register whoAmI tool
 		this.server.registerTool(
 			"whoAmI",


### PR DESCRIPTION
## Summary

Adds an `export-memories` MCP tool that lets users export all their documents and extracted memories as structured JSON or JSONL.

## Why this matters

There is no way to export data from Supermemory. Users cannot back up their memories, migrate between accounts, or analyze their data offline. For a memory SaaS, data portability is table stakes - especially for enterprise users with sovereignty requirements.

The MCP server is the natural place for this since power users already interact via MCP, and it can be built entirely client-side using existing API endpoints.

## Changes

2 files modified, 95 lines added:

**`apps/mcp/src/client.ts`** - New `exportMemories()` method on `SupermemoryClient`:
- Fetches graph bounds to get the full coordinate range
- Retrieves all documents + memories via `getGraphViewport()` with a high limit
- Returns `{ documents, totalCount }`

**`apps/mcp/src/server.ts`** - New `export-memories` tool registration:
- Accepts optional `containerTag` for per-project export
- Accepts `format` parameter: `json` (single array, default) or `jsonl` (one doc per line)
- Returns document count, memory count, and the full data

**Usage:**
```
export-memories                           # Export all memories as JSON
export-memories containerTag="my-project" # Export one project
export-memories format="jsonl"            # JSONL for streaming
```

No new dependencies. Uses existing graph viewport API endpoints.

## Testing

Manual testing with MCP client. The `exportMemories()` method chains two existing methods (`getGraphBounds` + `getGraphViewport`), both of which are already used by the `memory-graph` tool.

This contribution was developed with AI assistance (Claude Code).

## Video Demo
![Demo](https://files.catbox.moe/nxx8c8.gif)