### PR TITLE
Optimize onboarding chat document creation with Promise.all

### DIFF
--- a/apps/web/components/onboarding/setup/chat-sidebar.tsx
+++ b/apps/web/components/onboarding/setup/chat-sidebar.tsx
@@ -40,6 +40,10 @@ interface DraftDoc {
 }
 
 export function ChatSidebar({ formData }: ChatSidebarProps) {
+	const isValidDocId = (
+		id: string | null | undefined,
+	): id is string => !!id
+
 	const { user } = useAuth()
 	const { selectedProject } = useProject()
 	const isMobile = useIsMobile()
@@ -397,7 +401,7 @@ export function ChatSidebar({ formData }: ChatSidebarProps) {
 						},
 					})
 
-					if (docResponse.data?.id) {
+					if (isValidDocId(docResponse.data?.id)) {
 						documentIds.push(docResponse.data.id)
 					}
 				} catch (error) {

--- a/apps/web/components/onboarding/setup/chat-sidebar.tsx
+++ b/apps/web/components/onboarding/setup/chat-sidebar.tsx
@@ -40,10 +40,6 @@ interface DraftDoc {
 }
 
 export function ChatSidebar({ formData }: ChatSidebarProps) {
-	const isValidDocId = (
-		id: string | null | undefined,
-	): id is string => !!id
-
 	const { user } = useAuth()
 	const { selectedProject } = useProject()
 	const isMobile = useIsMobile()
@@ -385,11 +381,9 @@ export function ChatSidebar({ formData }: ChatSidebarProps) {
 		setIsLoading(true)
 
 		try {
-			const documentIds: string[] = []
-
-			for (const draft of draftDocs) {
+			const promises = draftDocs.map(async (draft) => {
 				if (draft.kind === "x_research" && xResearchStatus !== "correct") {
-					continue
+					return null
 				}
 
 				try {
@@ -401,13 +395,17 @@ export function ChatSidebar({ formData }: ChatSidebarProps) {
 						},
 					})
 
-					if (isValidDocId(docResponse.data?.id)) {
-						documentIds.push(docResponse.data.id)
-					}
+					return docResponse.data?.id
 				} catch (error) {
 					console.warn("Error creating document:", error)
+					return null
 				}
-			}
+			})
+
+			const results = await Promise.all(promises)
+			const documentIds = results.filter(
+				(id): id is string => id !== null && id !== undefined,
+			)
 
 			if (documentIds.length > 0) {
 				await pollForMemories(documentIds)


### PR DESCRIPTION
Replaced the sequential for loop that calls $fetch for document creation with an asynchronous draftDocs.map logic resolving via Promise.all.
The setup side-bar execution was blocked by N+1 consecutive API fetch calls. Running them concurrently improves wait-time during the onboarding experience.