### PR TITLE
perf: Execute Claude memory tool calls concurrently

### DIFF
--- a/packages/tools/test/claude-memory-real-example.ts
+++ b/packages/tools/test/claude-memory-real-example.ts
@@ -119,25 +119,25 @@ export async function realClaudeMemoryExample() {
 	const toolResults = []
 
 	if (responseData.content) {
-		for (const block of responseData.content) {
-			if (block.type === "tool_use" && block.name === "memory") {
-				console.log("\\n🔧 Processing memory tool call:")
+    const memoryToolCalls = responseData.content.filter(
+      (block: any): block is { type: 'tool_use'; id: string; name: 'memory'; input: { command: MemoryCommand; path: string } } =>
+        block.type === "tool_use" && block.name === "memory",
+    )
+
+		const results = await Promise.all(
+			memoryToolCalls.map((block: any) => {
+				console.log("\n🔧 Processing memory tool call:")
 				console.log(`Command: ${block.input.command}`)
 				console.log(`Path: ${block.input.path}`)
 
-				// Handle the memory tool call
-				const toolResult = await handleClaudeMemoryToolCall(
-					block,
-					SUPERMEMORY_API_KEY,
-					{
-						projectId: "python-scraper-help",
-						memoryContainerTag: "claude_memory_debug",
-					},
-				)
+				return handleClaudeMemoryToolCall(block, SUPERMEMORY_API_KEY, {
+					projectId: "python-scraper-help",
+					memoryContainerTag: "claude_memory_debug",
+				})
+			}),
+		)
 
-				toolResults.push(toolResult)
-			}
-		}
+		toolResults.push(...results)
 	}
 
 	// Step 3: Send tool results back to Claude if there were any
@@ -196,16 +196,18 @@ export async function processClaudeResponse(
 	const toolResults = []
 
 	if (claudeResponseData.content) {
-		for (const block of claudeResponseData.content) {
-			if (block.type === "tool_use" && block.name === "memory") {
-				const toolResult = await handleClaudeMemoryToolCall(
-					block,
-					supermemoryApiKey,
-					config,
-				)
-				toolResults.push(toolResult)
-			}
-		}
+    const memoryToolCalls = claudeResponseData.content.filter(
+      (block: any): block is { type: 'tool_use'; id: string; name: 'memory'; input: { command: MemoryCommand; path: string } } =>
+        block.type === "tool_use" && block.name === "memory",
+    )
+
+		const results = await Promise.all(
+			memoryToolCalls.map((block: any) =>
+				handleClaudeMemoryToolCall(block, supermemoryApiKey, config),
+			),
+		)
+
+		toolResults.push(...results)
 	}
 
 	return toolResults


### PR DESCRIPTION
This PR refactores the` realClaudeMemoryExample` and `processClaudeResponse` functions inside `packages/tools/test/claude-memory-real-example.ts` to use Promise.all() to process incoming tool calls in parallel instead of sequentially via a for...of loop.

Claude API often sends multiple independent tool calls (like reading multiple distinct paths from memory in a single block). Iterating through and awaiting them individually causes an N+1 problem.
