### PR TITLE
perf: scope message equality check to content+parts instead of full object

### DIFF
--- a/apps/web/stores/chat.ts
+++ b/apps/web/stores/chat.ts
@@ -27,9 +27,9 @@ export function areUIMessageArraysEqual(
 			return false
 		}
 
-		// Compare the entire message using JSON serialization as a fallback
-		// This handles all properties including parts, toolInvocations, etc.
-		if (JSON.stringify(msgA) !== JSON.stringify(msgB)) {
+		if (msgA.content !== msgB.content) return false
+
+		if (JSON.stringify(msgA.parts) !== JSON.stringify(msgB.parts)) {
 			return false
 		}
 	}


### PR DESCRIPTION
## Summary
- Replace `JSON.stringify(entireMessage)` with targeted field comparisons in `areUIMessageArraysEqual`
- First compare `content` string directly (O(n) on string length, no allocation)
- Fall back to `JSON.stringify(parts)` only  skips metadata fields (`createdAt`, `annotations`, `experimental_attachments`) that never change during streaming

## Why
`areUIMessageArraysEqual` is called on every message state update during chat streaming. Serializing the entire `UIMessage` object (including all metadata) on every comparison is expensive especially for messages with large tool invocations.

@MaheshtheDev please have a look