### PR TITLE
perf(ui): precalculate document embeddings for graph similarity

### DIFF
--- a/packages/ui/memory-graph/hooks/use-graph-data.ts
+++ b/packages/ui/memory-graph/hooks/use-graph-data.ts
@@ -270,19 +270,23 @@ export function useGraphData(
 			});
 		});
 
+		// Precompute embeddings to avoid Array.from in the O(n^2) inner loop
+		const docEmbeddings = filteredDocuments.map((doc) =>
+			doc?.summaryEmbedding ? Array.from(doc.summaryEmbedding) : null,
+		);
+
 		// Document-to-document similarity edges
 		for (let i = 0; i < filteredDocuments.length; i++) {
 			const docI = filteredDocuments[i];
 			if (!docI) continue;
+			const embI = docEmbeddings[i];
 
 			for (let j = i + 1; j < filteredDocuments.length; j++) {
 				const docJ = filteredDocuments[j];
 				if (!docJ) continue;
+				const embJ = docEmbeddings[j];
 
-				const sim = calculateSemanticSimilarity(
-					docI.summaryEmbedding ? Array.from(docI.summaryEmbedding) : null,
-					docJ.summaryEmbedding ? Array.from(docJ.summaryEmbedding) : null,
-				);
+				const sim = calculateSemanticSimilarity(embI, embJ);
 				if (sim > 0.725) {
 					allEdges.push({
 						id: `doc-doc-${docI.id}-${docJ.id}`,


### PR DESCRIPTION
Summary:
- Pre-calculates `Array.from(doc.summaryEmbedding)` out of the nested `for` loop in `useGraphData`.
- This converts $O(n^2)$ allocations to $O(n)$, significantly reducing memory GC cycles and improving rendering frame times on large graph datasets.

In `packages/ui/memory-graph/hooks/use-graph-data.ts`, we were calling `Array.from(doc.summaryEmbedding)` repeatedly within an O(n^2) inner loop. This triggered heavy garbage collection and continuous array allocation when iterating over document pairs for semantic similarity.
I pulled the embedding extraction into an O(n) mapping pass before the nested loops:

```
// Precompute embeddings to avoid Array.from in the O(n^2) inner loop
const docEmbeddings = filteredDocuments.map((doc) =>
    doc?.summaryEmbedding ? Array.from(doc.summaryEmbedding) : null,
);
```

Then we simply reference docEmbeddings[i] and docEmbeddings[j] within the $O(n^2)$ loop. This eliminates the heavy GC pressure and directly improves framing times during document selection and graph panning operations.