### PR TITLE
perf(ui): align React Query cache between memory grid and graph

### DIFF
--- a/apps/web/components/memory-graph/hooks/use-graph-api.ts
+++ b/apps/web/components/memory-graph/hooks/use-graph-api.ts
@@ -104,7 +104,7 @@ export function useGraphApi(options: UseGraphApiOptions = {}) {
 		hasNextPage,
 		fetchNextPage,
 	} = useInfiniteQuery<ApiDocumentsResponse, Error>({
-		queryKey: ["graph-documents", containerTags?.join(",")],
+		queryKey: ["documents-with-memories", containerTags, []],
 		initialPageParam: 1,
 		queryFn: async ({ pageParam }) => {
 			const response = await $fetch("@post/documents/documents", {
@@ -131,7 +131,7 @@ export function useGraphApi(options: UseGraphApiOptions = {}) {
 			}
 			return undefined
 		},
-		staleTime: 30 * 1000,
+		staleTime: 5 * 60 * 1000,
 		enabled,
 	})
 


### PR DESCRIPTION
## Summary
Aligns the React Query caching strategy for the `@post/documents/documents` endpoint between the main Memory Grid and the Memory Graph UI.

Previously, `use-graph-api.ts` used a completely different `queryKey` (`["graph-documents", ...]`) and a short `staleTime` of 30 seconds, while `memories-grid.tsx` cached the same payload for 5 minutes under `["documents-with-memories", ...]`. 

This mismatch resulted in the client ignoring its cache and blindly re-fetching identical document arrays when the user toggled the graph view, wasting network bandwidth and blocking the main thread on parsing duplicate JSON.

## Changes
- Updated the `queryKey` in `apps/web/components/memory-graph/hooks/use-graph-api.ts` to `["documents-with-memories", containerTags, []]`.
- Increased the graph's `staleTime` from 30s to 5m to mirror the grid cache configuration.

## Impact
- **Fewer Network Calls**: Zero redundant API requests when switching back and forth between the grid and the graph.
- **Improved UX**: Faster transition into the graph UI since data is instantly yielded from the cache.
- **Lower CPU Usage**: Avoids heavy main-thread document payload parsing on duplicate requests.