### PR TITLE
perf(ui): convert message pairing to O(n) forward pass in chain-of-thought

### DIFF
--- a/apps/web/components/chat/input/chain-of-thought.tsx
+++ b/apps/web/components/chat/input/chain-of-thought.tsx
@@ -23,18 +23,24 @@ export function ChainOfThought({ messages }: { messages: UIMessage[] }) {
 		agentMessage?: UIMessage
 	}> = []
 
+	let lastUserPair: {
+		userMessage: UIMessage
+		agentMessage?: UIMessage
+	} | null = null
+
 	for (let i = 0; i < messages.length; i++) {
 		const message = messages[i]
 		if (!message) continue
+
 		if (message.role === "user") {
-			// Find the next assistant message after this user message
-			const agentMessage = messages
-				.slice(i + 1)
-				.find((msg) => msg.role === "assistant")
-			messagePairs.push({
-				userMessage: message,
-				agentMessage,
-			})
+			lastUserPair = { userMessage: message }
+			messagePairs.push(lastUserPair)
+		} else if (
+			message.role === "assistant" &&
+			lastUserPair &&
+			!lastUserPair.agentMessage
+		) {
+			lastUserPair.agentMessage = message
 		}
 	}
 


### PR DESCRIPTION
## Summary
Optimizes the message pairing algorithm in the `ChainOfThought` component.

Previously, for every user message in the chat thread, the component created a new sliced array and iterated forward with `.find()` to locate the next assistant message. This resulted in an $O(n^2)$ time complexity and repeated garbage collection, which becomes noticeably sluggish on long conversations.

## Changes
- Removed the `.slice(i + 1).find(...)` nested iteration inside the `for` loop.
- Introduced a `lastUserPair` state tracker to map the first subsequent assistant message directly to the most recent user message in a single $O(n)$ forward pass.