### PR TITLE
perf: wrap list/grid components in React.memo to skip unnecessary re-renders

### DIFF
--- a/apps/web/components/chat/message/user-message.tsx
+++ b/apps/web/components/chat/message/user-message.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { memo } from "react"
 import { Copy, Check } from "lucide-react"
 import type { UIMessage } from "@ai-sdk/react"
 
@@ -9,7 +10,7 @@ interface UserMessageProps {
 	onCopy: (messageId: string, text: string) => void
 }
 
-export function UserMessage({
+export const UserMessage = memo(function UserMessage({
 	message,
 	copiedMessageId,
 	onCopy,
@@ -38,4 +39,4 @@ export function UserMessage({
 			</button>
 		</div>
 	)
-}
+})

--- a/apps/web/components/document-cards/file-preview.tsx
+++ b/apps/web/components/document-cards/file-preview.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { memo, useState } from "react"
 import type { DocumentsWithMemoriesResponseSchema } from "@repo/validation/api"
 import type { z } from "zod"
 import { dmSansClassName } from "@/lib/fonts"
@@ -43,7 +43,7 @@ function getFileTypeInfo(document: DocumentWithMemories): {
 	}
 }
 
-export function FilePreview({ document }: { document: DocumentWithMemories }) {
+export const FilePreview = memo(function FilePreview({ document }: { document: DocumentWithMemories }) {
 	const [imageError, setImageError] = useState(false)
 	const { extension, color } = getFileTypeInfo(document)
 
@@ -107,4 +107,4 @@ export function FilePreview({ document }: { document: DocumentWithMemories }) {
 			)}
 		</div>
 	)
-}
+})

--- a/apps/web/components/document-cards/file-preview.tsx
+++ b/apps/web/components/document-cards/file-preview.tsx
@@ -43,7 +43,11 @@ function getFileTypeInfo(document: DocumentWithMemories): {
 	}
 }
 
-export const FilePreview = memo(function FilePreview({ document }: { document: DocumentWithMemories }) {
+export const FilePreview = memo(function FilePreview({
+	document,
+}: {
+	document: DocumentWithMemories
+}) {
 	const [imageError, setImageError] = useState(false)
 	const { extension, color } = getFileTypeInfo(document)
 

--- a/apps/web/components/document-cards/website-preview.tsx
+++ b/apps/web/components/document-cards/website-preview.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState } from "react"
+import { memo, useState } from "react"
 import type { DocumentsWithMemoriesResponseSchema } from "@repo/validation/api"
 import type { z } from "zod"
 
@@ -12,7 +12,7 @@ type OgData = {
 	image?: string
 }
 
-export function WebsitePreview({
+export const WebsitePreview = memo(function WebsitePreview({
 	document,
 	ogData,
 }: {
@@ -40,4 +40,4 @@ export function WebsitePreview({
 			) : null}
 		</div>
 	)
-}
+})

--- a/apps/web/components/document-cards/youtube-preview.tsx
+++ b/apps/web/components/document-cards/youtube-preview.tsx
@@ -1,5 +1,6 @@
 "use client"
 
+import { memo } from "react"
 import type { DocumentsWithMemoriesResponseSchema } from "@repo/validation/api"
 import type { z } from "zod"
 import { dmSansClassName } from "@/lib/fonts"
@@ -9,7 +10,7 @@ import { extractYouTubeVideoId } from "../utils"
 type DocumentsResponse = z.infer<typeof DocumentsWithMemoriesResponseSchema>
 type DocumentWithMemories = DocumentsResponse["documents"][0]
 
-export function YoutubePreview({
+export const YoutubePreview = memo(function YoutubePreview({
 	document,
 }: {
 	document: DocumentWithMemories
@@ -49,4 +50,4 @@ export function YoutubePreview({
 			</div>
 		</div>
 	)
-}
+})


### PR DESCRIPTION
## Summary
- Wrap `UserMessage`, `WebsitePreview`, `YoutubePreview`, and `FilePreview` in `React.memo()` to prevent unnecessary re renders
- No behavioral or visual changes

## Why
These components render inside lists/grids that can have 50+ items. Any parent state change (eg new streaming token in chat, selection toggle in grid) causes all of them to re render even though their props have not changed.

## Impact
- **Skips re-renders** for unchanged user messages during assistant streaming
- **Skips re-renders** for unchanged preview cards in the document masonry grid
- Particularly noticeable in long conversations and large document grids

