### PR TITLE
perf(lib): optimize subscription status lookup to O(n)

### DIFF
--- a/packages/lib/queries.ts
+++ b/packages/lib/queries.ts
@@ -37,8 +37,11 @@ export function getSubscriptionStatus(
 ): SubscriptionStatusMap {
 	const statusMap: SubscriptionStatusMap = { ...DEFAULT_SUBSCRIPTION_STATUS }
 	if (!products) return statusMap
+
+	const productMap = new Map(products.map((p) => [p.id, p]))
+
 	for (const tier of PLAN_TIERS) {
-		const product = products.find((p) => p.id === tier)
+		const product = productMap.get(tier)
 		statusMap[tier] = {
 			allowed: product?.status === "active",
 			status: product?.status ?? null,


### PR DESCRIPTION
## Summary
Optimizes the `getSubscriptionStatus` utility function in `packages/lib/queries.ts` by converting a quadratic $O(n^2)$ lookup into a linear $O(n)$ map lookup.

Previously, the function iterated over `PLAN_TIERS` and inside that loop, it called `products.find((p) => p.id === tier)`. This caused redundant full-array scans on the products array for every tier check.

## Changes
- Created a `productMap` using `new Map(products.map((p) => [p.id, p]))` before iterating over `PLAN_TIERS`.
- Replaced the inner `products.find(...)` with `productMap.get(tier)`.

## Impact
- **CPU Performance**: Transforms the algorithmic complexity from $O(n \times m)$ to $O(n + m)$, eliminating redundant array scans during subscription verification checks. This makes subscription status checks slightly faster, especially on pages or operations checking permissions against multiple tiers.