### PR TITLE
hoist EMPTY_SET default in MemoriesGrid

### DIFF
--- a/apps/web/components/memories-grid.tsx
+++ b/apps/web/components/memories-grid.tsx
@@ -120,6 +120,7 @@ function fetchOgData(url: string): Promise<OgData | null> {
 
 const PAGE_SIZE = 100
 const MAX_TOTAL = 1000
+const EMPTY_SET = new Set<string>()
 
 const MEMORIES_LOADING_LABELS = [
 	"Getting your supermemories…",
@@ -214,7 +215,7 @@ export function MemoriesGrid({
 	isChatOpen,
 	onOpenDocument,
 	isSelectionMode = false,
-	selectedDocumentIds = new Set(),
+	selectedDocumentIds = EMPTY_SET,
 	onEnterSelectionMode,
 	onToggleSelection,
 	onClearSelection,


### PR DESCRIPTION
## Summary
Hoisted the `new Set()` default parameter in `MemoriesGrid` to a module-level constant named `EMPTY_SET`.

## Details
The `selectedDocumentIds = new Set()` default parameter was causing a performance bottleneck. Because a new `Set` was being instantiated on every render cycle, its reference was never stable. This invalidated the `React.memo` optimization on the `DocumentCard` components, forcing every visible card to re-render whenever the parent `MemoriesGrid` updated.

## Use
- **Component Efficiency:** Restores the effectiveness of `memo()` for the masonry item rendering.
- **Render Cost:** Prevents cascading re-renders of 100+ cards during common actions like opening the chat sidebar or space navigation.

@Dhravya please have a look