### PR TITLE
fix(mcp): default container to authenticated userId when x-sm-project is absent (#792)

### DIFF
--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -113,7 +113,7 @@ const mcpHandler = SupermemoryMCP.serve("/mcp", {
 const handleMcpRequest = async (c: Context<{ Bindings: Bindings }>) => {
 	const authHeader = c.req.header("Authorization")
 	const token = authHeader?.replace(/^Bearer\s+/i, "")
-	const containerTag = c.req.header("x-sm-project")
+	const headerContainerTag = c.req.header("x-sm-project")
 	const apiUrl = c.env.API_URL || DEFAULT_API_URL
 
 	const reqHost = c.req.header("x-forwarded-host") || c.req.header("host") || ""
@@ -173,6 +173,14 @@ const handleMcpRequest = async (c: Context<{ Bindings: Bindings }>) => {
 			},
 		)
 	}
+
+	// Default to the authenticated user's id when no explicit project header is
+	// provided. Without this fallback all MCP sessions share the hard-coded
+	// `sm_project_default` container inside SupermemoryClient, which is not the
+	// container the user's direct /v3 and /v4 API calls query — causing writes
+	// via MCP to be invisible to reads via the REST API and MCP `recall` when
+	// the client doesn't forward x-sm-project. See issue #792.
+	const containerTag = headerContainerTag || authUser.userId
 
 	// Create execution context with authenticated user props
 	const ctx = {


### PR DESCRIPTION
## Summary

Fixes #792. MCP sessions previously fell back to the hardcoded `sm_project_default` container inside `SupermemoryClient` when clients did not forward the `x-sm-project` header. Users who query their own container directly via `/v3` and `/v4` search (the userId-as-containerTag pattern documented in `apps/docs/install.md`) therefore could not see memories written through MCP — producing the empty-results symptom reported in the issue (direct API searches, MCP `recall` over OAuth, and hybrid `searchMode` all returning nothing while MCP writes succeeded).

MCP reads and writes are already symmetric through `getClient(containerTag)` in `server.ts`, so the divergence was purely in the default. This PR shifts the default for MCP sessions to `authUser.userId`, while still honoring an explicit `x-sm-project` header when clients do forward one.

## Changes

- `apps/mcp/src/index.ts`: rename the header capture to `headerContainerTag`; after auth validation, compute `const containerTag = headerContainerTag || authUser.userId` and thread it through `ctx.props` before handing off to the MCP handler. Comment added explaining the rationale and linking to #792.

1 file changed, +9 / -1.

## Test plan

- [x] Typecheck: `NODE_OPTIONS="--max-old-space-size=8192" tsc --noEmit` from `apps/mcp/` → zero new errors introduced on `src/index.ts`. Pre-existing errors in `server.ts` (SDK type duplication) and `ui/mcp-app.ts` (DOM types / `@types/d3-force-3d` missing) are unchanged by this PR.
- [ ] Manual: open an MCP session without forwarding `x-sm-project`, write a memory via the `memory` tool, then query `/v3/search` with `containerTag: <userId>` — the write should now be visible. Same memory should also be returned by MCP `recall` inside the session.
- [ ] Manual: open an MCP session **with** `x-sm-project: my-project` — behavior should be unchanged (writes and reads land in `my-project`).