### PR TITLE
docs: SMFS documentation — providers, Python bash tool, examples

### DIFF
--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -163,7 +163,8 @@
 									"smfs/providers/vercel",
 									"smfs/providers/cloudflare"
 								]
-							}
+							},
+							"smfs/examples"
 						]
 					}
 				],

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -153,6 +153,7 @@
 							"smfs/install",
 							"smfs/mount",
 							"smfs/bash-tool",
+							"smfs/bash-tool-python",
 							{
 								"group": "Providers",
 								"icon": "cloud",

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -152,7 +152,17 @@
 							"smfs/overview",
 							"smfs/install",
 							"smfs/mount",
-							"smfs/bash-tool"
+							"smfs/bash-tool",
+							{
+								"group": "Providers",
+								"icon": "cloud",
+								"pages": [
+									"smfs/providers/daytona",
+									"smfs/providers/e2b",
+									"smfs/providers/vercel",
+									"smfs/providers/cloudflare"
+								]
+							}
 						]
 					}
 				],

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -144,6 +144,16 @@
 								"pages": ["supermemory-mcp/claude-desktop"]
 							}
 						]
+					},
+					{
+						"anchor": "SMFS",
+						"icon": "database",
+						"pages": [
+							"smfs/overview",
+							"smfs/install",
+							"smfs/mount",
+							"smfs/bash-tool"
+						]
 					}
 				],
 				"tab": "Developer Platform"

--- a/apps/docs/smfs/bash-tool-python.mdx
+++ b/apps/docs/smfs/bash-tool-python.mdx
@@ -24,25 +24,30 @@ uv add supermemory-bash
 ## Quickstart
 
 ```python
+import asyncio
 import os
 from supermemory_bash import create_bash
 
-result = await create_bash(
-    api_key=os.environ["SUPERMEMORY_API_KEY"],
-    container_tag="user_42",
-)
-bash = result.bash
-r = await bash.exec("ls /")
-print(r.stdout)
+
+async def main() -> None:
+    result = await create_bash(
+        api_key=os.environ["SUPERMEMORY_API_KEY"],
+        container_tag="user_42",
+    )
+    bash = result.bash
+    r = await bash.exec("ls /")
+    print(r.stdout)
+
+
+asyncio.run(main())
 ```
 
 `create_bash` returns a `CreateBashResult` with:
 
 - `bash`: a `Shell` instance with `.exec(cmd)`
-- `volume`: the underlying `SupermemoryVolume`
-- `tool_description`: a pre-written tool description (`str`) ready to hand to the model
-- `configure_memory_paths(paths)`: async callable to scope which paths get extracted into Supermemory
-- `refresh()`: async callable to re-prime the path index after external writes
+- `tool_description`: a pre-written tool description ready to hand to the model
+- `configure_memory_paths(paths)`: scope which paths get extracted into Supermemory
+- `refresh()`: re-prime the path index after external writes
 
 ## Use it as a model tool
 
@@ -80,7 +85,7 @@ async def run_agent(user_message: str) -> str:
         }
     ]
 
-    messages: list[dict] = [{"role": "user", "content": user_message}]
+    messages = [{"role": "user", "content": user_message}]
 
     for _ in range(10):
         response = client.messages.create(
@@ -158,7 +163,7 @@ async def run_agent(user_message: str) -> str:
         }
     ]
 
-    messages: list[dict] = [{"role": "user", "content": user_message}]
+    messages = [{"role": "user", "content": user_message}]
 
     for _ in range(10):
         response = client.chat.completions.create(
@@ -206,6 +211,7 @@ The Bash Tool inherits SMFS memory semantics. By default, files named `user.md` 
 
 ```python
 result = await create_bash(api_key=api_key, container_tag=container_tag)
+bash = result.bash
 await result.configure_memory_paths(["/notes/", "/journal.md"])
 ```
 
@@ -214,7 +220,7 @@ Trailing `/` matches recursively. No slash matches an exact file. Pass `[]` to d
 The container also exposes a virtual `profile.md` at the root: a live digest of everything in the container. Read it once at the start of a session to give the model context without walking every file.
 
 ```python
-r = await result.bash.exec("cat /profile.md")
+r = await bash.exec("cat /profile.md")
 print(r.stdout)
 ```
 

--- a/apps/docs/smfs/bash-tool-python.mdx
+++ b/apps/docs/smfs/bash-tool-python.mdx
@@ -1,0 +1,246 @@
+---
+title: "Bash Tool (Python)"
+sidebarTitle: "Bash Tool (Python)"
+description: "supermemory-bash. The SMFS idea wrapped as a single agent tool, for Python agents and serverless runtimes."
+icon: "terminal"
+---
+
+`supermemory-bash` is the SMFS idea wrapped as a single agent tool: `run_bash(command)`. The "filesystem" is your Supermemory container. Runs anywhere Python runs. AWS Lambda, Modal, Fly Machines, Cloud Run, your laptop. No mount, no FUSE, no local disk.
+
+Reach for the Bash Tool when your agent runs somewhere it can't mount a real filesystem.
+
+## Install
+
+```bash
+pip install supermemory-bash
+```
+
+Or with uv:
+
+```bash
+uv add supermemory-bash
+```
+
+## Quickstart
+
+```python
+import os
+from supermemory_bash import create_bash
+
+result = await create_bash(
+    api_key=os.environ["SUPERMEMORY_API_KEY"],
+    container_tag="user_42",
+)
+bash = result.bash
+r = await bash.exec("ls /")
+print(r.stdout)
+```
+
+`create_bash` returns a `CreateBashResult` with:
+
+- `bash`: a `Shell` instance with `.exec(cmd)`
+- `volume`: the underlying `SupermemoryVolume`
+- `tool_description`: a pre-written tool description (`str`) ready to hand to the model
+- `configure_memory_paths(paths)`: async callable to scope which paths get extracted into Supermemory
+- `refresh()`: async callable to re-prime the path index after external writes
+
+## Use it as a model tool
+
+### Anthropic SDK
+
+Pass `tool_description` straight into Claude's tool definition and run a normal agent loop. Each `tool_use` block calls `bash.exec` and the result goes back as a `tool_result`.
+
+```python
+import asyncio
+import os
+
+import anthropic
+from supermemory_bash import create_bash
+
+
+async def run_agent(user_message: str) -> str:
+    result = await create_bash(
+        api_key=os.environ["SUPERMEMORY_API_KEY"],
+        container_tag="user_42",
+    )
+    bash = result.bash
+
+    client = anthropic.Anthropic(api_key=os.environ["ANTHROPIC_API_KEY"])
+    tools = [
+        {
+            "name": "bash",
+            "description": result.tool_description,
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "cmd": {"type": "string", "description": "The bash command to run."}
+                },
+                "required": ["cmd"],
+            },
+        }
+    ]
+
+    messages: list[dict] = [{"role": "user", "content": user_message}]
+
+    for _ in range(10):
+        response = client.messages.create(
+            model="claude-sonnet-4-20250514",
+            max_tokens=4096,
+            tools=tools,
+            messages=messages,
+        )
+
+        if response.stop_reason == "end_turn":
+            for block in response.content:
+                if hasattr(block, "text"):
+                    return block.text
+            return ""
+
+        messages.append({"role": "assistant", "content": response.content})
+        tool_results = []
+        for block in response.content:
+            if block.type == "tool_use":
+                cmd = block.input.get("cmd", "")
+                r = await bash.exec(cmd)
+                output = r.stdout
+                if r.stderr:
+                    output += f"\n[stderr]: {r.stderr}"
+                if r.exit_code != 0:
+                    output += f"\n[exit_code]: {r.exit_code}"
+                tool_results.append(
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": block.id,
+                        "content": output or "(no output)",
+                    }
+                )
+        messages.append({"role": "user", "content": tool_results})
+
+    return "(max steps reached)"
+
+
+asyncio.run(run_agent("What's in my notes about the Q3 launch?"))
+```
+
+### OpenAI SDK
+
+Same idea with OpenAI's function-calling format. Define a single `bash` function, dispatch each `tool_calls` entry to `bash.exec`, and feed the output back as a `tool` message.
+
+```python
+import asyncio
+import json
+import os
+
+from openai import OpenAI
+from supermemory_bash import create_bash
+
+
+async def run_agent(user_message: str) -> str:
+    result = await create_bash(
+        api_key=os.environ["SUPERMEMORY_API_KEY"],
+        container_tag="user_42",
+    )
+    bash = result.bash
+
+    client = OpenAI()
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": "bash",
+                "description": result.tool_description,
+                "parameters": {
+                    "type": "object",
+                    "properties": {"cmd": {"type": "string"}},
+                    "required": ["cmd"],
+                },
+            },
+        }
+    ]
+
+    messages: list[dict] = [{"role": "user", "content": user_message}]
+
+    for _ in range(10):
+        response = client.chat.completions.create(
+            model="gpt-4o",
+            messages=messages,
+            tools=tools,
+        )
+        message = response.choices[0].message
+
+        if not message.tool_calls:
+            return message.content or ""
+
+        messages.append(message.model_dump(exclude_none=True))
+        for call in message.tool_calls:
+            args = json.loads(call.function.arguments or "{}")
+            r = await bash.exec(args.get("cmd", ""))
+            output = r.stdout
+            if r.stderr:
+                output += f"\n[stderr]: {r.stderr}"
+            if r.exit_code != 0:
+                output += f"\n[exit_code]: {r.exit_code}"
+            messages.append(
+                {
+                    "role": "tool",
+                    "tool_call_id": call.id,
+                    "content": output or "(no output)",
+                }
+            )
+
+    return "(max steps reached)"
+
+
+asyncio.run(run_agent("List my notes"))
+```
+
+### Claude Agent SDK
+
+The [Claude Agent SDK](https://docs.claude.com/en/api/agent-sdk/overview) ships with built-in `Bash`, `Read`, and `Write` tools. If your agent runs somewhere SMFS can be mounted (a long-lived process on macOS or Linux), point those built-ins at an SMFS mount and you don't need `supermemory-bash` at all — the agent just sees your container as a directory.
+
+See [Mount SMFS](/smfs/mount) for setup, or the [provider guides](/smfs/overview#use-smfs-with-your-sandbox-provider) for sandbox-specific instructions.
+
+## Memory
+
+The Bash Tool inherits SMFS memory semantics. By default, files named `user.md` or `memory.md` are extracted as memories. Configure additional memory paths after construction:
+
+```python
+result = await create_bash(api_key=api_key, container_tag=container_tag)
+await result.configure_memory_paths(["/notes/", "/journal.md"])
+```
+
+Trailing `/` matches recursively. No slash matches an exact file. Pass `[]` to disable memory generation.
+
+The container also exposes a virtual `profile.md` at the root: a live digest of everything in the container. Read it once at the start of a session to give the model context without walking every file.
+
+```python
+r = await result.bash.exec("cat /profile.md")
+print(r.stdout)
+```
+
+## Commands the agent can run
+
+The Python tool exposes the same command surface as the TypeScript version: standard Unix builtins (`pwd`, `cd`, `ls`, `cat`, `stat`, `mkdir`, `rm`, `mv`, `cp`, `echo`), search and text utilities (`grep`, `find`, `head`, `tail`, `wc`, `sort`, `sed`, `awk`), plus the custom `sgrep <query> [path]` for semantic search across the container. Pipes, redirects, conditionals, loops, and file tests all work.
+
+See the [TypeScript Bash Tool reference](/smfs/bash-tool#commands-the-agent-can-run) for the full list.
+
+## Configuration
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `api_key` | required | Supermemory API key |
+| `container_tag` | required | Container to expose as the filesystem |
+| `base_url` | `None` | Override the API endpoint |
+| `eager_load` | `True` | Warm the path index when the instance starts |
+| `eager_content` | `True` | Also warm the content cache during eager load |
+| `cwd` | `"/home/user"` | Initial working directory |
+| `env` | `None` | Extra environment variables |
+| `cache_ttl_ms` | `150_000` | Content cache TTL in ms. `None` = never expires (single-writer). `0` = no cache. |
+
+The container is what defines the filesystem; setting `cwd` or extra `env` from the host doesn't change the files the agent sees.
+
+## Limitations
+
+- `chmod`, `utimes`, and symlinks (`ln -s`, `readlink`) raise `ENOSYS`.
+- `/dev/null` as a redirect target isn't supported. Write to `/tmp/discard.log` instead.
+- Binary uploads aren't supported. Text is extracted server-side.

--- a/apps/docs/smfs/bash-tool.mdx
+++ b/apps/docs/smfs/bash-tool.mdx
@@ -1,0 +1,203 @@
+---
+title: "Bash Tool"
+sidebarTitle: "Bash Tool"
+description: "@supermemory/bash. The SMFS idea wrapped as a single agent tool, for serverless and edge runtimes."
+icon: "terminal"
+---
+
+`@supermemory/bash` is the SMFS idea wrapped as a single agent tool: `run_bash(command)`. The "filesystem" is your Supermemory container. Runs anywhere TypeScript runs. Cloudflare Workers, AWS Lambda, Vercel, Node, the browser. No mount, no FUSE, no local disk.
+
+Reach for the Bash Tool when your agent runs somewhere it can't mount a real filesystem.
+
+## Install
+
+```bash
+npm install @supermemory/bash
+```
+
+Or with bun:
+
+```bash
+bun add @supermemory/bash
+```
+
+## Quickstart
+
+```typescript
+import { createBash } from "@supermemory/bash";
+
+const { bash, toolDescription } = await createBash({
+  apiKey: process.env.SUPERMEMORY_API_KEY!,
+  containerTag: "user_42",
+});
+
+const result = await bash.exec("ls /");
+console.log(result.stdout);
+```
+
+`createBash` returns:
+
+- `bash`: the instance with `.exec(cmd)`
+- `toolDescription`: a pre-written tool description ready to hand to the model
+- `configureMemoryPaths(paths)`: scope which paths get extracted into Supermemory
+- `refresh()`: re-prime the path index after external writes
+
+## Use it as a model tool
+
+### Vercel AI SDK
+
+```typescript
+import { generateText, tool } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { z } from "zod";
+
+const { bash, toolDescription } = await createBash({
+  apiKey: process.env.SUPERMEMORY_API_KEY!,
+  containerTag: "user_42",
+});
+
+const result = await generateText({
+  model: openai("gpt-4o"),
+  tools: {
+    bash: tool({
+      description: toolDescription,
+      inputSchema: z.object({ cmd: z.string() }),
+      execute: async ({ cmd }) => bash.exec(cmd),
+    }),
+  },
+  prompt: "What's in my notes about the Q3 launch?",
+});
+```
+
+### Anthropic SDK
+
+```typescript
+import Anthropic from "@anthropic-ai/sdk";
+
+const client = new Anthropic({ apiKey: process.env.ANTHROPIC_API_KEY! });
+const { bash, toolDescription } = await createBash({
+  apiKey: process.env.SUPERMEMORY_API_KEY!,
+  containerTag: "user_42",
+});
+
+const response = await client.messages.create({
+  model: "claude-opus-4-7",
+  max_tokens: 4096,
+  tools: [
+    {
+      name: "bash",
+      description: toolDescription,
+      input_schema: {
+        type: "object",
+        properties: { cmd: { type: "string" } },
+        required: ["cmd"],
+      },
+    },
+  ],
+  messages: [{ role: "user", content: "List my notes" }],
+});
+```
+
+### OpenAI SDK
+
+```typescript
+import OpenAI from "openai";
+
+const client = new OpenAI();
+const { bash, toolDescription } = await createBash({
+  apiKey: process.env.SUPERMEMORY_API_KEY!,
+  containerTag: "user_42",
+});
+
+const response = await client.chat.completions.create({
+  model: "gpt-4o",
+  messages: [{ role: "user", content: "List my notes" }],
+  tools: [
+    {
+      type: "function",
+      function: {
+        name: "bash",
+        description: toolDescription,
+        parameters: {
+          type: "object",
+          properties: { cmd: { type: "string" } },
+          required: ["cmd"],
+        },
+      },
+    },
+  ],
+});
+```
+
+## Memory
+
+The Bash Tool inherits SMFS memory semantics. By default, files named `user.md` or `memory.md` are extracted as memories. Configure additional memory paths after construction:
+
+```typescript
+const { configureMemoryPaths } = await createBash({ apiKey, containerTag });
+
+await configureMemoryPaths(["/notes/", "/journal.md"]);
+```
+
+Trailing `/` matches recursively. No slash matches an exact file. Pass `[]` to disable memory generation.
+
+The container also exposes a virtual `profile.md` at the root: a live digest of everything in the container. Read it once at the start of a session to give the model context without walking every file.
+
+```typescript
+const { stdout } = await bash.exec("cat /profile.md");
+```
+
+## Commands the agent can run
+
+Standard Unix surface, plus one custom command. Each does what you'd expect.
+
+### Filesystem
+
+- `pwd`: print working directory
+- `cd`: change directory
+- `ls`, `ls -la`: list
+- `cat`: read a file
+- `stat`: file metadata
+- `mkdir`: create directory
+- `rm`, `rm -rf`: delete
+- `rmdir`: delete empty directory
+- `mv`: move or rename
+- `cp`: copy
+- `echo`: write or append (`echo "x" > file`, `echo "x" >> file`)
+
+### Search and text
+
+- `grep`: literal substring match against a known path
+- `sgrep <query> [path]`: **semantic** search across the container. Trailing `/` on path scopes to a directory. No path searches everything.
+- `find`: search by name or properties
+- `head`, `tail`: first or last N lines
+- `wc`: word, line, byte counts
+- `sort`: sort lines
+- `sed`, `awk`: text transformation
+
+### Shell features
+
+- Pipes (`|`)
+- Redirects (`>`, `>>`)
+- Conditionals (`&&`, `||`)
+- Loops (`for`, `while`)
+- File tests (`[ -f ]`, `[ -d ]`, `[ -e ]`)
+
+## Configuration
+
+| Option | Default | Purpose |
+| --- | --- | --- |
+| `apiKey` | required | Supermemory API key |
+| `containerTag` | required | Container to expose as the filesystem |
+| `baseURL` | SDK default | Override the API endpoint |
+| `eagerLoad` | `true` | Warm the path index when the instance starts |
+| `eagerContent` | `true` | Also warm the content cache during eager load |
+| `cacheTtlMs` | `150_000` | Content cache TTL in ms. `null` = never expires (single-writer). `0` = no cache. |
+
+Other options (`customCommands`, `logger`, plus `just-bash` pass-throughs like `executionLimits`, `network`, `python`, `javascript`, `cwd`, `env`) exist but aren't part of the supported surface for the SMFS use case. The container is what defines the filesystem; setting `cwd` or extra `env` from the host doesn't change that.
+
+## Limitations
+
+- `chmod`, `utimes`, and symlinks (`ln -s`, `readlink`) throw `ENOSYS`.
+- `/dev/null` as a redirect target isn't supported. Write to `/tmp/discard.log` instead.
+- Binary uploads aren't supported. Text is extracted server-side.

--- a/apps/docs/smfs/examples.mdx
+++ b/apps/docs/smfs/examples.mdx
@@ -1,0 +1,47 @@
+---
+title: "Examples"
+sidebarTitle: "Examples"
+description: "Full working apps you can clone and run."
+icon: "code"
+---
+
+Standalone example apps showing SMFS in realistic use cases. Each one is a
+complete project with its own README, dependencies, and sample data.
+
+<CardGroup cols={2}>
+  <Card
+    title="Legal Docs Assistant"
+    icon="scale-balanced"
+    href="https://github.com/supermemoryai/examples/tree/main/legal-docs-assistant"
+  >
+    Ingest contracts into a Supermemory container, then query them with
+    semantic search. Python + Anthropic SDK.
+  </Card>
+  <Card
+    title="Docs Answering Agent"
+    icon="book"
+    href="https://github.com/supermemoryai/examples/tree/main/docs-answering-agent"
+  >
+    Ingest documentation, answer questions about it. TypeScript + Vercel AI
+    SDK.
+  </Card>
+  <Card
+    title="Customer Support Agent"
+    icon="headset"
+    href="https://github.com/supermemoryai/examples/tree/main/customer-support-agent"
+  >
+    Per-customer memory for support ticket drafting. Each customer gets their
+    own container. Python + Anthropic SDK.
+  </Card>
+</CardGroup>
+
+All examples use the [Bash Tool](/smfs/bash-tool) — the serverless-friendly
+way to give an agent a Supermemory-backed filesystem. No mount or FUSE
+required.
+
+## Running an example
+
+1. Clone the [examples repo](https://github.com/supermemoryai/examples)
+2. `cd` into the example you want
+3. Follow the README — typically: install deps, copy `.env.example` to `.env`,
+   fill in your API keys, run the ingest script, then run the agent

--- a/apps/docs/smfs/examples.mdx
+++ b/apps/docs/smfs/examples.mdx
@@ -30,15 +30,15 @@ complete project with its own README, dependencies, and a working UI.
     icon="terminal"
     href="https://github.com/supermemoryai/examples/tree/main/code-sandbox"
   >
-    Write and run code in a Daytona sandbox with persistent AI memory.
-    Next.js + Daytona SDK + SMFS mount.
+    Write and run code in an E2B sandbox with persistent AI memory.
+    Next.js + E2B SDK + SMFS mount.
   </Card>
 </CardGroup>
 
 The Research Assistant and Knowledge Base examples use the
 [Bash Tool](/smfs/bash-tool) — the serverless-friendly way to give an agent a
-Supermemory-backed filesystem. The Code Sandbox example uses a
-[Daytona](/smfs/providers/daytona) sandbox with a real SMFS mount.
+Supermemory-backed filesystem. The Code Sandbox example uses an
+[E2B](/smfs/providers/e2b) sandbox with a real SMFS mount.
 
 ## Running an example
 

--- a/apps/docs/smfs/examples.mdx
+++ b/apps/docs/smfs/examples.mdx
@@ -1,47 +1,48 @@
 ---
 title: "Examples"
 sidebarTitle: "Examples"
-description: "Full working apps you can clone and run."
+description: "Full web-based demo apps you can clone and run."
 icon: "code"
 ---
 
-Standalone example apps showing SMFS in realistic use cases. Each one is a
-complete project with its own README, dependencies, and sample data.
+Web-based example apps showing SMFS in realistic use cases. Each one is a
+complete project with its own README, dependencies, and a working UI.
 
 <CardGroup cols={2}>
   <Card
-    title="Legal Docs Assistant"
-    icon="scale-balanced"
-    href="https://github.com/supermemoryai/examples/tree/main/legal-docs-assistant"
+    title="Research Assistant"
+    icon="magnifying-glass"
+    href="https://github.com/supermemoryai/examples/tree/main/research-assistant"
   >
-    Ingest contracts into a Supermemory container, then query them with
-    semantic search. Python + Anthropic SDK.
+    Upload documents and chat with an AI that can search and cite them.
+    Next.js + TypeScript + `@supermemory/bash`.
   </Card>
   <Card
-    title="Docs Answering Agent"
+    title="Knowledge Base"
     icon="book"
-    href="https://github.com/supermemoryai/examples/tree/main/docs-answering-agent"
+    href="https://github.com/supermemoryai/examples/tree/main/knowledge-base"
   >
-    Ingest documentation, answer questions about it. TypeScript + Vercel AI
-    SDK.
+    Add notes and chat with an AI that can search your knowledge base.
+    FastAPI + Python + `supermemory-bash`.
   </Card>
   <Card
-    title="Customer Support Agent"
-    icon="headset"
-    href="https://github.com/supermemoryai/examples/tree/main/customer-support-agent"
+    title="Code Sandbox"
+    icon="terminal"
+    href="https://github.com/supermemoryai/examples/tree/main/code-sandbox"
   >
-    Per-customer memory for support ticket drafting. Each customer gets their
-    own container. Python + Anthropic SDK.
+    Write and run code in a Daytona sandbox with persistent AI memory.
+    Next.js + Daytona SDK + SMFS mount.
   </Card>
 </CardGroup>
 
-All examples use the [Bash Tool](/smfs/bash-tool) — the serverless-friendly
-way to give an agent a Supermemory-backed filesystem. No mount or FUSE
-required.
+The Research Assistant and Knowledge Base examples use the
+[Bash Tool](/smfs/bash-tool) — the serverless-friendly way to give an agent a
+Supermemory-backed filesystem. The Code Sandbox example uses a
+[Daytona](/smfs/providers/daytona) sandbox with a real SMFS mount.
 
 ## Running an example
 
 1. Clone the [examples repo](https://github.com/supermemoryai/examples)
 2. `cd` into the example you want
 3. Follow the README — typically: install deps, copy `.env.example` to `.env`,
-   fill in your API keys, run the ingest script, then run the agent
+   fill in your API keys, and start the dev server

--- a/apps/docs/smfs/install.mdx
+++ b/apps/docs/smfs/install.mdx
@@ -8,7 +8,7 @@ icon: "download"
 ## 1. Install the binary
 
 ```bash
-curl -fsSL smfs.ai/install | sh
+curl -fsSL https://smfs.ai/install | bash
 ```
 
 Drops `smfs` into `~/.local/bin`. Works on macOS (arm64, x64) and Linux (arm64, x64).

--- a/apps/docs/smfs/install.mdx
+++ b/apps/docs/smfs/install.mdx
@@ -1,0 +1,68 @@
+---
+title: "Install SMFS"
+sidebarTitle: "Install"
+description: "Install, log in, mount."
+icon: "download"
+---
+
+## 1. Install the binary
+
+```bash
+curl -fsSL smfs.ai/install | sh
+```
+
+Drops `smfs` into `~/.local/bin`. Works on macOS (arm64, x64) and Linux (arm64, x64).
+
+If `smfs` isn't on your `PATH` after install, add `~/.local/bin` to your shell profile and reopen the terminal.
+
+## 2. Log in
+
+```bash
+smfs login
+```
+
+One-time. Prompts you for your Supermemory API key and stores it in your global credentials. Get a key at [console.supermemory.ai](https://console.supermemory.ai).
+
+You can also pass the key directly:
+
+```bash
+smfs login --key sm_...
+```
+
+## 3. Mount a container
+
+```bash
+smfs mount agent_memory
+```
+
+`agent_memory` is your container tag. SMFS creates a folder named `agent_memory/` in the current directory and mounts the container there.
+
+That's it. Read it with `ls`, `cat`, `grep`. See [Mount](/smfs/mount) for memory paths, sync modes, flags, and every subcommand.
+
+To mount somewhere else, pass `--path`:
+
+```bash
+smfs mount agent_memory --path ~/memory
+```
+
+## Optional: refresh the semantic grep wrapper
+
+`smfs mount` installs the shell wrapper automatically the first time you mount. If you ever need to force a clean reinstall (after upgrading the binary, for example):
+
+```bash
+smfs init
+```
+
+It writes the wrapper into your `~/.zshrc` directly. Then reopen your terminal (or `source ~/.zshrc`) so the new shell picks it up.
+
+Inside any mount, plain `grep` becomes semantic. Outside a mount, your normal `grep` is untouched. Pass any flag (`grep -r`, `grep -i`, anything) and you get the real `grep` back.
+
+## Refresh the binary
+
+If anything ever feels broken:
+
+```bash
+smfs install
+```
+
+Re-copies the binary into `~/.local/bin` and resets permissions.

--- a/apps/docs/smfs/mount.mdx
+++ b/apps/docs/smfs/mount.mdx
@@ -1,0 +1,289 @@
+---
+title: "Mount"
+sidebarTitle: "Mount"
+description: "Mount a Supermemory container, generate memories, and sync."
+icon: "hard-drive"
+---
+
+A mount turns a Supermemory container into a directory on your machine. macOS uses NFSv3, Linux uses FUSE. Both are handled for you.
+
+```bash
+smfs mount <container-tag>
+```
+
+Example:
+
+```bash
+smfs mount agent_memory
+```
+
+`agent_memory` is the container tag. SMFS creates a folder named `agent_memory/` in the current directory and mounts the container there. The mount runs as a background daemon. A marker file `.smfs` is written at the mount root so other tools (and the semantic `grep` wrapper from `smfs init`) can find the mount.
+
+To mount at a different path:
+
+```bash
+smfs mount agent_memory --path ~/memory
+```
+
+## Memory
+
+This is the part most people miss. SMFS isn't a normal filesystem. It generates **memories** from files at specific paths. Memories are extracted, summarized, and indexed by Supermemory.
+
+Files outside those paths are still semantically searchable; they're indexed through **SuperRAG** by default. Nothing in the mount is dead weight.
+
+### Defaults
+
+By default, files named `user.md` or `memory.md` are treated as memory paths. Drop those files anywhere in your mount and Supermemory generates memories from them automatically.
+
+### Configure your own memory paths
+
+Pass `--memory-paths` at mount time to control which files become memories:
+
+```bash
+smfs mount agent_memory --memory-paths "/notes/,/journal.md"
+```
+
+Rules:
+
+- Paths are **absolute**, anchored at the mount root. Always start with `/`.
+- Trailing `/` matches every file inside that folder, recursively (`/notes/` covers `/notes/foo.md`, `/notes/2026/march.md`, etc.).
+- No trailing slash matches one exact file (`/journal.md`).
+- Comma-separated. Multiple paths are fine.
+- Empty string disables memory generation entirely (`--memory-paths ""`).
+- Omit the flag and Supermemory keeps whatever the container tag already has, falling back to `user.md` and `memory.md`.
+
+### profile.md
+
+Every mount has a virtual file at the root called `profile.md`. It's auto-generated, read-only, and backed by Supermemory. The model can `cat profile.md` to get a live digest of everything in the container without walking every file. Useful as a first call at the start of a session.
+
+```bash
+cat agent_memory/profile.md
+```
+
+You can't write to it. As the underlying memories change, Supermemory regenerates it.
+
+## Sync modes
+
+Three modes plus a force-sync command. Pick by what your agent actually needs.
+
+### Bidirectional (default)
+
+Local reads hit the cache. Local writes queue and push to Supermemory in the background. Remote changes are pulled on a poll. This is what you get if you pass no flags.
+
+```bash
+smfs mount agent_memory
+```
+
+Use this when more than one writer (you, another agent, the dashboard) might touch the container.
+
+### No-sync
+
+Writes still push to Supermemory. Polling for remote changes is off. The agent sees a view that doesn't shift under it mid-task.
+
+```bash
+smfs mount agent_memory --no-sync
+```
+
+Use this when your agent is the only writer, or when you want predictable reads.
+
+### Ephemeral
+
+Cache is in memory only. Nothing persists after unmount. Writes still push.
+
+```bash
+smfs mount agent_memory --ephemeral
+```
+
+Use this for short-lived sandboxes. CI jobs, throwaway containers, one-shot agent runs.
+
+### Force a sync now
+
+```bash
+smfs sync
+```
+
+Pushes pending writes and pulls remote changes immediately. Useful right before tearing down a sandbox.
+
+## All mount flags
+
+| Flag | What it does |
+| --- | --- |
+| `--path <path>` | Override the default mount path (`./<container-tag>/`). |
+| `--memory-paths <paths>` | Scope which files become memories. See [Memory](#memory). |
+| `--no-sync` | Stop polling for remote changes. Writes still push. |
+| `--clean` | Wipe local cache before mounting. Pulls fresh from the API. |
+| `--ephemeral` | In-memory cache. Nothing persists after unmount. |
+| `--sync-interval <secs>` | Remote-change poll interval. Default `30`. |
+| `--drain-timeout <secs>` | Max time to flush pending writes during unmount. Default `30`. |
+| `--foreground` | Run the daemon inline instead of detaching. |
+| `--backend <name>` | Linux only. `fuse` (default) or `nfs`. |
+| `--key <key>` | Pass an API key explicitly. Saved to project credentials. |
+
+## Multiple agents and multiple containers
+
+- **Different devices, same container tag**: fully supported. Many agents can mount the same container concurrently from different machines.
+- **Same device, same container tag, mounted twice**: not supported. Use one mount per container per device.
+- **Same device, different containers**: mount as many as you want in parallel.
+
+## Commands
+
+Every `smfs` subcommand. Click any one to expand.
+
+<AccordionGroup>
+  <Accordion title="smfs mount" icon="play">
+    Mount a container. Defaults to `./<container-tag>/`; pass `--path` to mount elsewhere.
+
+    ```bash
+    smfs mount agent_memory
+    smfs mount agent_memory --path ~/memory
+    ```
+
+    See the flags table above for everything you can pass.
+  </Accordion>
+
+  <Accordion title="smfs unmount" icon="square">
+    Unmount a running mount. Drains pending writes up to `--drain-timeout`, then exits the daemon. Anything not drained resumes on the next mount.
+
+    ```bash
+    smfs unmount agent_memory
+    ```
+
+    Inside the mount, you can omit the tag and let SMFS resolve it from the nearest `.smfs` marker.
+
+    ```bash
+    smfs unmount
+    smfs unmount --force
+    ```
+  </Accordion>
+
+  <Accordion title="smfs list" icon="list">
+    List every SMFS mount running on this machine.
+
+    ```bash
+    smfs list
+    ```
+  </Accordion>
+
+  <Accordion title="smfs status" icon="activity">
+    Show daemon status for a mount: connectivity, queue depth, last sync. Auto-detects the tag via the nearest `.smfs` marker.
+
+    ```bash
+    smfs status
+    smfs status agent_memory
+    smfs status --json
+    ```
+  </Accordion>
+
+  <Accordion title="smfs logs" icon="scroll-text">
+    Tail the daemon log for a mount. Auto-detects the tag via the nearest `.smfs` marker.
+
+    ```bash
+    smfs logs
+    smfs logs -f
+    smfs logs -n 500
+    ```
+  </Accordion>
+
+  <Accordion title="smfs sync" icon="refresh-cw">
+    Force an immediate sync cycle. Push pending writes, pull remote changes.
+
+    ```bash
+    smfs sync agent_memory
+    ```
+
+    Inside the mount, the tag is optional (resolved from the nearest `.smfs` marker).
+
+    ```bash
+    smfs sync
+    ```
+  </Accordion>
+
+  <Accordion title="smfs grep" icon="search">
+    Semantic search across a container without being inside the mount. The optional second argument scopes the search to a subpath inside the container. Inside a mount, plain `grep` already does this; `smfs grep` is the explicit form for scripts.
+
+    ```bash
+    smfs grep "deadline"
+    smfs grep "deadline" /notes/
+    ```
+  </Accordion>
+
+  <Accordion title="smfs login" icon="log-in">
+    One-time auth. Prompts for your Supermemory API key and stores it in your global credentials. You can also pass it directly with `--key`.
+
+    ```bash
+    smfs login
+    smfs login --key sm_...
+    ```
+  </Accordion>
+
+  <Accordion title="smfs whoami" icon="user">
+    Print the currently-authenticated user, organization, and API endpoint.
+
+    ```bash
+    smfs whoami
+    ```
+  </Accordion>
+
+  <Accordion title="smfs logout" icon="log-out">
+    Remove stored credentials. Active mounts keep running until you `smfs unmount` them.
+
+    ```bash
+    smfs logout
+    ```
+  </Accordion>
+
+  <Accordion title="smfs init" icon="terminal">
+    Force-installs the shell wrapper that makes plain `grep` semantic inside mounts. Writes directly to `~/.zshrc`. `smfs mount` also installs it automatically the first time, so you only need this to refresh after an upgrade.
+
+    ```bash
+    smfs init
+    ```
+
+    Reopen your terminal (or `source ~/.zshrc`) after running it.
+  </Accordion>
+
+  <Accordion title="smfs install" icon="download">
+    Self-install. Copies the running binary to `~/.local/bin` and resets permissions. Run this if your `smfs` install ever feels broken.
+
+    ```bash
+    smfs install
+    ```
+  </Accordion>
+</AccordionGroup>
+
+## FAQ
+
+<AccordionGroup>
+  <Accordion title="Semantic grep isn't working inside my mount" icon="circle-help">
+    Run `smfs init` to force-install the shell wrapper. It writes directly to `~/.zshrc`. Then reopen your terminal so the new shell picks it up.
+
+    The wrapper only triggers when you're inside a mount (it looks for the `.smfs` marker file at the mount root). Outside a mount, `grep` stays normal. Inside a mount, any flag you pass falls through to the real `grep`.
+  </Accordion>
+
+  <Accordion title="Can I install SMFS on Windows?" icon="circle-help">
+    Not yet. SMFS supports macOS (arm64, x64) and Linux (arm64, x64) for now. Windows isn't on the v0 roadmap.
+
+    On Windows, use the [Bash Tool](/smfs/bash-tool) instead. It runs anywhere TypeScript runs and gives your agent the same `ls`, `cat`, `grep`, `sgrep` surface without needing a mount.
+  </Accordion>
+
+  <Accordion title="My cache feels stale or out of sync" icon="circle-help">
+    Re-mount with `--clean` to wipe the local cache and pull everything fresh from the API:
+
+    ```bash
+    smfs unmount agent_memory
+    smfs mount agent_memory --clean
+    ```
+
+    Nothing on the server changes; only the local SQLite cache gets reset.
+  </Accordion>
+
+  <Accordion title="Can two agents on the same machine share a mount?" icon="circle-help">
+    Yes. Once a container is mounted, anything on that machine can read and write through the mount path. The constraint is one mount per container tag per device. Mount it once, point both agents at the same folder.
+  </Accordion>
+
+  <Accordion title="Can two separate sandboxes use the same container?" icon="circle-help">
+    Yes, absolutely. Mount the same container tag from each sandbox. Bidirectional sync keeps everything in step as either side writes, so Agent A in sandbox 1 sees Agent B's writes from sandbox 2 within a sync interval.
+
+    To avoid stepping on each other, give each agent its own subdirectory (`/agent_a/`, `/agent_b/`, etc.). They can still read across the whole mount, cross-reference each other's findings, and build on each other's work. The shared container is the point.
+  </Accordion>
+</AccordionGroup>

--- a/apps/docs/smfs/overview.mdx
+++ b/apps/docs/smfs/overview.mdx
@@ -1,0 +1,49 @@
+---
+title: "SMFS"
+sidebarTitle: "Overview"
+description: "Memory your agent can grep."
+icon: "database"
+---
+
+**SMFS** mounts your Supermemory container as a real directory. Agents read it with `ls`, `cat`, and `grep`. No SDK to learn, no client to wire up, no embeddings to think about.
+
+SMFS is open source and free for everyone.
+
+## Why a filesystem
+
+Every model already knows how a filesystem works. It can `ls`, `cat`, `grep`, `find`, redirect with `>`, pipe with `|`. You don't have to teach it a new API surface, and the grammar carries across runtimes.
+
+The catch: a filesystem on its own isn't great for memory. Search means walking the tree. Long files burn through context. The model has to hold the directory structure in its head. None of that scales as memory grows.
+
+SMFS fixes the catch. The shell is real, but underneath:
+
+- **Semantic `grep` by default.** One call surfaces what matters across the whole container, ranked by meaning. Pass any flag and you fall through to the real `grep` for exact matches.
+- **Memory paths get distilled.** Files marked as memory paths are extracted and indexed by Supermemory. They don't bloat the model's context.
+- **Virtual `profile.md`.** A live digest of the container at the mount root. The model can `cat profile.md` for a one-shot summary instead of walking every file.
+- **Bidirectional sync** runs in the background. Local reads hit cache; writes push to Supermemory.
+
+You get filesystem ergonomics without paying the filesystem tax in tokens.
+
+## Two ways to use SMFS
+
+Pick by where your agent runs.
+
+<CardGroup cols={2}>
+  <Card title="Mount (smfs binary)" icon="hard-drive" href="/smfs/install">
+    For agents and tools with a real filesystem. Claude Code, Cursor, devcontainers, Docker, Codespaces. NFSv3 on macOS, FUSE on Linux.
+  </Card>
+  <Card title="Bash Tool (@supermemory/bash)" icon="terminal" href="/smfs/bash-tool">
+    For agents running serverless or at the edge. Cloudflare Workers, AWS Lambda, Vercel. A virtual bash where the filesystem is your container.
+  </Card>
+</CardGroup>
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Install SMFS" icon="download" href="/smfs/install">
+    One curl, one mount, you're done.
+  </Card>
+  <Card title="Use the Bash Tool" icon="terminal" href="/smfs/bash-tool">
+    Drop SMFS into a TypeScript agent without mounting anything.
+  </Card>
+</CardGroup>

--- a/apps/docs/smfs/overview.mdx
+++ b/apps/docs/smfs/overview.mdx
@@ -32,8 +32,8 @@ Pick by where your agent runs.
   <Card title="Mount (smfs binary)" icon="hard-drive" href="/smfs/install">
     For agents and tools with a real filesystem. Claude Code, Cursor, devcontainers, Docker, Codespaces. NFSv3 on macOS, FUSE on Linux.
   </Card>
-  <Card title="Bash Tool (@supermemory/bash)" icon="terminal" href="/smfs/bash-tool">
-    For agents running serverless or at the edge. Cloudflare Workers, AWS Lambda, Vercel. A virtual bash where the filesystem is your container.
+  <Card title="Bash Tool (TypeScript & Python)" icon="terminal" href="/smfs/bash-tool">
+    For agents running serverless or at the edge. Cloudflare Workers, AWS Lambda, Vercel, Modal. A virtual bash where the filesystem is your container. Available as [`@supermemory/bash`](/smfs/bash-tool) for TypeScript and [`supermemory-bash`](/smfs/bash-tool-python) for Python.
   </Card>
 </CardGroup>
 

--- a/apps/docs/smfs/overview.mdx
+++ b/apps/docs/smfs/overview.mdx
@@ -37,6 +37,25 @@ Pick by where your agent runs.
   </Card>
 </CardGroup>
 
+## Use SMFS with your sandbox provider
+
+Already using a sandbox or agent platform? Jump straight to the guide for your provider.
+
+<CardGroup cols={2}>
+  <Card title="Daytona" icon="server" href="/smfs/providers/daytona">
+    Isolated Linux sandboxes with millisecond boot times. Mount SMFS inside or use the bash tool from your orchestrating code.
+  </Card>
+  <Card title="E2B" icon="cube" href="/smfs/providers/e2b">
+    Firecracker microVMs for AI code execution. Install SMFS directly or use a custom template with it pre-installed.
+  </Card>
+  <Card title="Vercel AI SDK" icon="triangle" href="/smfs/providers/vercel">
+    The most popular TypeScript agent framework. Add memory as a tool with one function call.
+  </Card>
+  <Card title="Cloudflare Workers" icon="cloud" href="/smfs/providers/cloudflare">
+    Edge-first agents. Use the bash tool in Workers, or mount SMFS in Cloudflare Containers.
+  </Card>
+</CardGroup>
+
 ## Next steps
 
 <CardGroup cols={2}>

--- a/apps/docs/smfs/overview.mdx
+++ b/apps/docs/smfs/overview.mdx
@@ -63,6 +63,9 @@ Already using a sandbox or agent platform? Jump straight to the guide for your p
     One curl, one mount, you're done.
   </Card>
   <Card title="Use the Bash Tool" icon="terminal" href="/smfs/bash-tool">
-    Drop SMFS into a TypeScript agent without mounting anything.
+    Drop SMFS into a TypeScript or Python agent without mounting anything.
+  </Card>
+  <Card title="Examples" icon="code" href="/smfs/examples">
+    Full working apps you can clone and run — legal docs, support agents, and more.
   </Card>
 </CardGroup>

--- a/apps/docs/smfs/providers/cloudflare.mdx
+++ b/apps/docs/smfs/providers/cloudflare.mdx
@@ -1,205 +1,122 @@
 ---
 title: "Cloudflare"
-sidebarTitle: "Cloudflare"
-description: "Add persistent memory to Cloudflare Workers agents with SMFS."
-icon: "cloud"
+description: "Give your AI agent persistent memory inside a Cloudflare Container using SMFS"
 ---
 
-[Cloudflare Workers](https://workers.cloudflare.com) run at the edge in V8 isolates — no filesystem, no shell. That's exactly what `@supermemory/bash` is built for. It gives your Worker a virtual bash environment backed by Supermemory, so your agent can `ls`, `cat`, `grep`, and write to a persistent memory container without needing a real filesystem.
+Mount a Supermemory container inside a
+[Cloudflare Container](https://developers.cloudflare.com/containers/) so your
+agent can read and write memory with plain bash commands.
 
-## Architecture
+## How it works
 
-Cloudflare Workers can't mount SMFS (no FUSE, no disk). Instead, use `@supermemory/bash` as a tool for your agent. The bash tool runs entirely in-process — no child processes, no disk I/O, no native dependencies.
-
-```
-Request → Worker → LLM → calls bash tool → @supermemory/bash → Supermemory API
-```
-
-<Note>
-  If you're using [Cloudflare Containers](https://developers.cloudflare.com/containers/) (full Linux containers at the edge), you can install the `smfs` binary directly. See [Alternative: Cloudflare Containers](#alternative-cloudflare-containers) below.
-</Note>
+1. Build a container image with SMFS pre-installed
+2. Deploy it as a Cloudflare Container
+3. On startup, mount a Supermemory container inside the container
+4. Run a Claude agent with bash access — it reads/writes the SMFS mount naturally
 
 ## Prerequisites
 
-- A [Supermemory](https://console.supermemory.ai) account and API key
-- A [Cloudflare](https://dash.cloudflare.com) account
-- Node.js 18+ and Wrangler CLI
+- A [Supermemory API key](https://supermemory.ai)
+- An [Anthropic API key](https://console.anthropic.com)
+- A [Cloudflare account](https://dash.cloudflare.com) with Containers enabled
+- [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/)
 
-## 1. Set up a Worker
+## Container setup
 
-```bash
-npm create cloudflare@latest -- my-memory-agent
-cd my-memory-agent
-npm install @supermemory/bash
-```
-
-Add your Supermemory API key as a secret:
-
-```bash
-npx wrangler secret put SUPERMEMORY_API_KEY
-```
-
-## 2. Build an agent with memory
-
-```typescript src/index.ts
-import { createBash } from "@supermemory/bash";
-
-export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
-    const { bash, toolDescription } = await createBash({
-      apiKey: env.SUPERMEMORY_API_KEY,
-      containerTag: "user_42",
-    });
-
-    // Read the user's profile
-    const profile = await bash.exec("cat /profile.md");
-
-    // Search memory semantically
-    const results = await bash.exec("sgrep 'project deadlines'");
-
-    // Write new memory
-    await bash.exec('echo "Met with client on April 27" >> /notes.md');
-
-    return new Response(JSON.stringify({
-      profile: profile.stdout,
-      search: results.stdout,
-    }));
-  },
-};
-```
-
-## 3. Full agent with tool calling
-
-Wire `@supermemory/bash` as a tool for an LLM. This example uses the OpenAI API, but any provider works:
-
-```typescript src/index.ts
-import { createBash } from "@supermemory/bash";
-
-interface Env {
-  SUPERMEMORY_API_KEY: string;
-  OPENAI_API_KEY: string;
-}
-
-export default {
-  async fetch(request: Request, env: Env): Promise<Response> {
-    const { messages, userId } = await request.json() as {
-      messages: any[];
-      userId: string;
-    };
-
-    const { bash, toolDescription } = await createBash({
-      apiKey: env.SUPERMEMORY_API_KEY,
-      containerTag: `user_${userId}`,
-    });
-
-    // Call the LLM with the bash tool
-    const response = await fetch("https://api.openai.com/v1/chat/completions", {
-      method: "POST",
-      headers: {
-        "Authorization": `Bearer ${env.OPENAI_API_KEY}`,
-        "Content-Type": "application/json",
-      },
-      body: JSON.stringify({
-        model: "gpt-4o",
-        messages: [
-          {
-            role: "system",
-            content: `You have persistent memory via a bash tool.
-Use it to remember things about the user.
-Start by reading /profile.md for context.`,
-          },
-          ...messages,
-        ],
-        tools: [{
-          type: "function",
-          function: {
-            name: "bash",
-            description: toolDescription,
-            parameters: {
-              type: "object",
-              properties: { cmd: { type: "string" } },
-              required: ["cmd"],
-            },
-          },
-        }],
-      }),
-    });
-
-    const data = await response.json() as any;
-
-    // Handle tool calls
-    if (data.choices[0].message.tool_calls) {
-      const toolCall = data.choices[0].message.tool_calls[0];
-      const cmd = JSON.parse(toolCall.function.arguments).cmd;
-      const result = await bash.exec(cmd);
-
-      // Send the result back to the LLM
-      const followUp = await fetch("https://api.openai.com/v1/chat/completions", {
-        method: "POST",
-        headers: {
-          "Authorization": `Bearer ${env.OPENAI_API_KEY}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({
-          model: "gpt-4o",
-          messages: [
-            ...messages,
-            data.choices[0].message,
-            {
-              role: "tool",
-              tool_call_id: toolCall.id,
-              content: JSON.stringify(result),
-            },
-          ],
-        }),
-      });
-
-      const followUpData = await followUp.json() as any;
-      return new Response(followUpData.choices[0].message.content);
-    }
-
-    return new Response(data.choices[0].message.content);
-  },
-};
-```
-
-## Alternative: Cloudflare Containers
-
-[Cloudflare Containers](https://developers.cloudflare.com/containers/) give you full Linux environments at the edge. Unlike Workers, containers have a real filesystem and shell — so you can install and mount SMFS directly.
+### Dockerfile
 
 ```dockerfile Dockerfile
 FROM node:20-slim
 
+# Install FUSE and bash
+RUN apt-get update && apt-get install -y fuse3 curl bash && rm -rf /var/lib/apt/lists/*
+RUN echo 'user_allow_other' >> /etc/fuse.conf
+
 # Install SMFS
 RUN curl -fsSL https://smfs.ai/install | bash
 
-# Your agent code
-COPY . /app
-WORKDIR /app
-RUN npm install
+# Install the Claude Agent SDK
+RUN npm install -g @anthropic-ai/claude-agent-sdk
 
-CMD ["node", "agent.js"]
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
 ```
 
-Inside the container, mount SMFS as you would on any Linux machine:
+### Entrypoint
 
-```bash
-smfs login --key $SUPERMEMORY_API_KEY
-smfs mount agent_memory --ephemeral --path /memory
+```bash entrypoint.sh
+#!/bin/bash
+set -e
+
+# Log in and mount
+smfs login --key "$SUPERMEMORY_API_KEY"
+smfs mount my_agent --ephemeral --path /memory --foreground &
+sleep 5
+
+# Run the agent
+node agent.js
 ```
 
-Your agent can then use standard Unix commands to interact with memory.
+### Agent
+
+```typescript agent.ts
+import { query } from "@anthropic-ai/claude-agent-sdk";
+
+async function main() {
+  for await (const message of query({
+    prompt: `You have access to a persistent memory filesystem mounted at /memory.
+Use bash commands to explore it (ls, cat) and write notes to it (echo "..." > file).
+
+Read /memory/profile.md to learn about the user.
+Then create /memory/session_notes.md with a summary of what you found.`,
+    options: {
+      allowedTools: ["Bash", "Read", "Write"],
+    },
+  })) {
+    if (message.type === "text") console.log(message.text);
+  }
+}
+
+main();
+```
+
+## Worker + Container pattern
+
+Use a Cloudflare Worker as the HTTP frontend that triggers the container:
+
+```typescript worker.ts
+export default {
+  async fetch(request: Request, env: any) {
+    // Start the container (it runs the agent with SMFS mounted)
+    const container = await env.MY_CONTAINER.start();
+
+    // The container runs the agent and writes results to SMFS
+    // Read the result back
+    const response = await container.fetch("/result");
+    return response;
+  },
+};
+```
+
+```toml wrangler.toml
+name = "memory-agent"
+main = "worker.ts"
+
+[[containers]]
+class_name = "MY_CONTAINER"
+image = "./Dockerfile"
+max_instances = 5
+```
 
 ## Tips
 
-- **Workers have a 30-second CPU time limit.** Keep tool call chains short. If your agent needs many steps, consider using Durable Objects for longer-running workflows.
-- **One container tag per user.** Use the user's ID as the container tag for isolated memory per user.
-- **`sgrep` for semantic search.** Inside the bash tool, `sgrep "query"` searches by meaning. Regular `grep` does literal matching.
-- **Cache-friendly.** `@supermemory/bash` warms its path index on `createBash`. For Workers that handle many requests, consider caching the instance in a Durable Object.
-
-## Resources
-
-- [Cloudflare Workers docs](https://developers.cloudflare.com/workers/)
-- [Cloudflare Containers docs](https://developers.cloudflare.com/containers/)
-- [SMFS Bash Tool reference](/smfs/bash-tool)
-- [Supermemory quickstart](/quickstart)
+- Use `--ephemeral` when mounting inside containers — it keeps the cache in memory
+  only, but writes still push to Supermemory
+- Use `smfs grep 'query'` for semantic search across all files in the container
+- Set `SUPERMEMORY_API_KEY` and `ANTHROPIC_API_KEY` as Cloudflare secrets:
+  ```bash
+  wrangler secret put SUPERMEMORY_API_KEY
+  wrangler secret put ANTHROPIC_API_KEY
+  ```

--- a/apps/docs/smfs/providers/cloudflare.mdx
+++ b/apps/docs/smfs/providers/cloudflare.mdx
@@ -5,14 +5,28 @@ description: "Give your AI agent persistent memory inside a Cloudflare Container
 
 Mount a Supermemory container inside a
 [Cloudflare Container](https://developers.cloudflare.com/containers/) so your
-agent can read and write memory with plain bash commands.
+agent can read and write memory using standard filesystem commands.
 
 ## How it works
 
-1. Build a container image with SMFS and the Claude Agent SDK pre-installed
-2. Deploy it as a Cloudflare Container
-3. On startup, mount a Supermemory container and run the agent
-4. The agent uses `cat`, `ls`, `echo`, etc. on the mount — everything persists to Supermemory
+```
+┌──────────────────────────────────────────┐
+│  Cloudflare Container                    │
+│                                          │
+│  ┌──────────┐    ┌────────────────────┐  │
+│  │  Claude   │───▶│  /memory           │  │
+│  │  Agent    │    │  (SMFS mount)      │  │
+│  └──────────┘    └────────┬───────────┘  │
+│                           │              │
+└───────────────────────────┼──────────────┘
+                            │
+                    ┌───────▼───────┐
+                    │  Supermemory  │
+                    └───────────────┘
+```
+
+SMFS and the Claude Agent SDK are baked into the container image. On startup,
+the entrypoint mounts memory and runs the agent.
 
 ## Prerequisites
 
@@ -21,9 +35,7 @@ agent can read and write memory with plain bash commands.
 - A [Cloudflare account](https://dash.cloudflare.com) with Containers enabled
 - [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/)
 
-## Container setup
-
-### Dockerfile
+## 1. Dockerfile
 
 ```dockerfile Dockerfile
 FROM python:3.12-slim
@@ -31,7 +43,8 @@ FROM python:3.12-slim
 RUN apt-get update && apt-get install -y fuse3 curl bash && rm -rf /var/lib/apt/lists/*
 RUN echo 'user_allow_other' >> /etc/fuse.conf
 
-RUN curl -fsSL https://smfs.ai/install | bash
+RUN curl -fsSL https://smfs.ai/install | bash -s -- 0.0.1-rc2
+ENV PATH="/root/.local/bin:$PATH"
 RUN pip install claude-agent-sdk
 
 COPY agent.py /app/agent.py
@@ -41,7 +54,7 @@ RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 ```
 
-### Entrypoint
+## 2. Entrypoint
 
 ```bash entrypoint.sh
 #!/bin/bash
@@ -49,12 +62,12 @@ set -e
 
 smfs login --key "$SUPERMEMORY_API_KEY"
 smfs mount my_agent --ephemeral --path /memory --foreground &
-sleep 5
+sleep 3
 
-python3 /app/agent.py
+exec python3 /app/agent.py
 ```
 
-### Agent
+## 3. Agent
 
 ```python agent.py
 import asyncio
@@ -62,13 +75,12 @@ from claude_agent_sdk import query, ClaudeAgentOptions
 
 async def main():
     async for message in query(
-        prompt="""You have a persistent memory filesystem at /memory.
-Use bash to explore it (ls, cat) and write notes (echo "..." > file).
-
-Read /memory/profile.md to learn about the user.
-Then create /memory/session_notes.md summarizing what you found.""",
+        prompt="You have a persistent memory filesystem at /memory. "
+               "Read profile.md to learn about the user, then create "
+               "session_notes.md summarizing what you found.",
         options=ClaudeAgentOptions(
             allowed_tools=["Bash", "Read", "Write"],
+            cwd="/memory",
         ),
     ):
         print(message)
@@ -76,19 +88,7 @@ Then create /memory/session_notes.md summarizing what you found.""",
 asyncio.run(main())
 ```
 
-## Worker + Container pattern
-
-Use a Cloudflare Worker as the HTTP frontend that triggers the container:
-
-```typescript worker.ts
-export default {
-  async fetch(request: Request, env: any) {
-    const container = await env.MY_CONTAINER.start();
-    const response = await container.fetch("/result");
-    return response;
-  },
-};
-```
+## 4. Deploy
 
 ```toml wrangler.toml
 name = "memory-agent"
@@ -100,13 +100,27 @@ image = "./Dockerfile"
 max_instances = 5
 ```
 
+```bash
+wrangler secret put SUPERMEMORY_API_KEY
+wrangler secret put ANTHROPIC_API_KEY
+wrangler deploy
+```
+
+## Worker frontend (optional)
+
+Use a Worker as the HTTP frontend that triggers the container:
+
+```typescript worker.ts
+export default {
+  async fetch(request: Request, env: any) {
+    const container = await env.MY_CONTAINER.start();
+    return container.fetch("/result");
+  },
+};
+```
+
 ## Tips
 
-- Use `--ephemeral` when mounting inside containers — keeps the cache in memory
-  only, but writes still push to Supermemory
-- Use `smfs grep 'query'` for semantic search across all files in the container
-- Set secrets via Wrangler:
-  ```bash
-  wrangler secret put SUPERMEMORY_API_KEY
-  wrangler secret put ANTHROPIC_API_KEY
-  ```
+- Use `--ephemeral` for container mounts — keeps the cache in memory only, but
+  writes still push to Supermemory
+- Use `smfs grep 'query'` for semantic search across all files

--- a/apps/docs/smfs/providers/cloudflare.mdx
+++ b/apps/docs/smfs/providers/cloudflare.mdx
@@ -9,10 +9,10 @@ agent can read and write memory with plain bash commands.
 
 ## How it works
 
-1. Build a container image with SMFS pre-installed
+1. Build a container image with SMFS and the Claude Agent SDK pre-installed
 2. Deploy it as a Cloudflare Container
-3. On startup, mount a Supermemory container inside the container
-4. Run a Claude agent with bash access — it reads/writes the SMFS mount naturally
+3. On startup, mount a Supermemory container and run the agent
+4. The agent uses `cat`, `ls`, `echo`, etc. on the mount — everything persists to Supermemory
 
 ## Prerequisites
 
@@ -26,18 +26,15 @@ agent can read and write memory with plain bash commands.
 ### Dockerfile
 
 ```dockerfile Dockerfile
-FROM node:20-slim
+FROM python:3.12-slim
 
-# Install FUSE and bash
 RUN apt-get update && apt-get install -y fuse3 curl bash && rm -rf /var/lib/apt/lists/*
 RUN echo 'user_allow_other' >> /etc/fuse.conf
 
-# Install SMFS
 RUN curl -fsSL https://smfs.ai/install | bash
+RUN pip install claude-agent-sdk
 
-# Install the Claude Agent SDK
-RUN npm install -g @anthropic-ai/claude-agent-sdk
-
+COPY agent.py /app/agent.py
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
@@ -50,36 +47,33 @@ ENTRYPOINT ["/entrypoint.sh"]
 #!/bin/bash
 set -e
 
-# Log in and mount
 smfs login --key "$SUPERMEMORY_API_KEY"
 smfs mount my_agent --ephemeral --path /memory --foreground &
 sleep 5
 
-# Run the agent
-node agent.js
+python3 /app/agent.py
 ```
 
 ### Agent
 
-```typescript agent.ts
-import { query } from "@anthropic-ai/claude-agent-sdk";
+```python agent.py
+import asyncio
+from claude_agent_sdk import query, ClaudeAgentOptions
 
-async function main() {
-  for await (const message of query({
-    prompt: `You have access to a persistent memory filesystem mounted at /memory.
-Use bash commands to explore it (ls, cat) and write notes to it (echo "..." > file).
+async def main():
+    async for message in query(
+        prompt="""You have a persistent memory filesystem at /memory.
+Use bash to explore it (ls, cat) and write notes (echo "..." > file).
 
 Read /memory/profile.md to learn about the user.
-Then create /memory/session_notes.md with a summary of what you found.`,
-    options: {
-      allowedTools: ["Bash", "Read", "Write"],
-    },
-  })) {
-    if (message.type === "text") console.log(message.text);
-  }
-}
+Then create /memory/session_notes.md summarizing what you found.""",
+        options=ClaudeAgentOptions(
+            allowed_tools=["Bash", "Read", "Write"],
+        ),
+    ):
+        print(message)
 
-main();
+asyncio.run(main())
 ```
 
 ## Worker + Container pattern
@@ -89,11 +83,7 @@ Use a Cloudflare Worker as the HTTP frontend that triggers the container:
 ```typescript worker.ts
 export default {
   async fetch(request: Request, env: any) {
-    // Start the container (it runs the agent with SMFS mounted)
     const container = await env.MY_CONTAINER.start();
-
-    // The container runs the agent and writes results to SMFS
-    // Read the result back
     const response = await container.fetch("/result");
     return response;
   },
@@ -112,10 +102,10 @@ max_instances = 5
 
 ## Tips
 
-- Use `--ephemeral` when mounting inside containers — it keeps the cache in memory
+- Use `--ephemeral` when mounting inside containers — keeps the cache in memory
   only, but writes still push to Supermemory
 - Use `smfs grep 'query'` for semantic search across all files in the container
-- Set `SUPERMEMORY_API_KEY` and `ANTHROPIC_API_KEY` as Cloudflare secrets:
+- Set secrets via Wrangler:
   ```bash
   wrangler secret put SUPERMEMORY_API_KEY
   wrangler secret put ANTHROPIC_API_KEY

--- a/apps/docs/smfs/providers/cloudflare.mdx
+++ b/apps/docs/smfs/providers/cloudflare.mdx
@@ -9,24 +9,35 @@ agent can read and write memory using standard filesystem commands.
 
 ## How it works
 
-```
-┌──────────────────────────────────────────┐
-│  Cloudflare Container                    │
-│                                          │
-│  ┌──────────┐    ┌────────────────────┐  │
-│  │  Claude   │───▶│  /memory           │  │
-│  │  Agent    │    │  (SMFS mount)      │  │
-│  └──────────┘    └────────┬───────────┘  │
-│                           │              │
-└───────────────────────────┼──────────────┘
-                            │
-                    ┌───────▼───────┐
-                    │  Supermemory  │
-                    └───────────────┘
+There are two ways to wire SMFS into a Cloudflare Container — pick the one that
+fits your architecture.
+
+### Agent inside the container
+
+The agent process runs inside the container with direct access to the SMFS
+mount. The entrypoint sets up the mount and starts the agent.
+
+```mermaid
+graph LR
+    subgraph Cloudflare Container
+        Agent["Claude Agent"] -->|"cat, ls, echo"| Mount["/memory\n(SMFS mount)"]
+    end
+    Mount -->|sync| SM["Supermemory"]
 ```
 
-SMFS and the Claude Agent SDK are baked into the container image. On startup,
-the entrypoint mounts memory and runs the agent.
+### Agent outside the container
+
+The agent runs in a Cloudflare Worker and sends commands to the container over
+HTTP. The container exposes a simple exec endpoint.
+
+```mermaid
+graph LR
+    Agent["Worker\n(agent logic)"] -->|"fetch('/exec')"| Container
+    subgraph Container ["Cloudflare Container"]
+        Mount["/memory\n(SMFS mount)"]
+    end
+    Mount -->|sync| SM["Supermemory"]
+```
 
 ## Prerequisites
 
@@ -35,7 +46,14 @@ the entrypoint mounts memory and runs the agent.
 - A [Cloudflare account](https://dash.cloudflare.com) with Containers enabled
 - [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/)
 
-## 1. Dockerfile
+---
+
+## Pattern A: Agent inside the container
+
+SMFS and the Claude Agent SDK are baked into the container image. On startup,
+the entrypoint mounts memory and runs the agent.
+
+### Dockerfile
 
 ```dockerfile Dockerfile
 FROM python:3.12-slim
@@ -54,7 +72,7 @@ RUN chmod +x /entrypoint.sh
 ENTRYPOINT ["/entrypoint.sh"]
 ```
 
-## 2. Entrypoint
+### Entrypoint
 
 ```bash entrypoint.sh
 #!/bin/bash
@@ -67,20 +85,22 @@ sleep 3
 exec python3 /app/agent.py
 ```
 
-## 3. Agent
+### Agent code
 
 ```python agent.py
 import asyncio
 from claude_agent_sdk import query, ClaudeAgentOptions
 
+MEMORY = "/memory"
+
 async def main():
     async for message in query(
-        prompt="You have a persistent memory filesystem at /memory. "
+        prompt=f"You have a persistent memory filesystem at {MEMORY}. "
                "Read profile.md to learn about the user, then create "
                "session_notes.md summarizing what you found.",
         options=ClaudeAgentOptions(
             allowed_tools=["Bash", "Read", "Write"],
-            cwd="/memory",
+            cwd=MEMORY,
         ),
     ):
         print(message)
@@ -88,7 +108,7 @@ async def main():
 asyncio.run(main())
 ```
 
-## 4. Deploy
+### Deploy
 
 ```toml wrangler.toml
 name = "memory-agent"
@@ -106,18 +126,81 @@ wrangler secret put ANTHROPIC_API_KEY
 wrangler deploy
 ```
 
-## Worker frontend (optional)
+---
 
-Use a Worker as the HTTP frontend that triggers the container:
+## Pattern B: Agent outside the container
+
+The agent logic lives in a Worker. The container just runs SMFS and exposes an
+HTTP endpoint for executing commands against the mount.
+
+### Container (exec server)
+
+```dockerfile Dockerfile
+FROM python:3.12-slim
+
+RUN apt-get update && apt-get install -y fuse3 curl bash && rm -rf /var/lib/apt/lists/*
+RUN echo 'user_allow_other' >> /etc/fuse.conf
+
+RUN curl -fsSL https://smfs.ai/install | bash -s -- 0.0.1-rc2
+ENV PATH="/root/.local/bin:$PATH"
+RUN pip install flask
+
+COPY server.py /app/server.py
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]
+```
+
+```bash entrypoint.sh
+#!/bin/bash
+set -e
+
+smfs login --key "$SUPERMEMORY_API_KEY"
+smfs mount my_agent --ephemeral --path /memory --foreground &
+sleep 3
+
+exec python3 /app/server.py
+```
+
+```python server.py
+import subprocess
+from flask import Flask, request, jsonify
+
+app = Flask(__name__)
+
+@app.route("/exec", methods=["POST"])
+def exec_command():
+    cmd = request.json["command"]
+    result = subprocess.run(
+        cmd, shell=True, capture_output=True, text=True, cwd="/memory", timeout=10
+    )
+    return jsonify(stdout=result.stdout, stderr=result.stderr, code=result.returncode)
+
+app.run(host="0.0.0.0", port=8080)
+```
+
+### Worker (agent logic)
 
 ```typescript worker.ts
 export default {
   async fetch(request: Request, env: any) {
     const container = await env.MY_CONTAINER.start();
-    return container.fetch("/result");
+
+    const profile = await container
+      .fetch("/exec", {
+        method: "POST",
+        body: JSON.stringify({ command: "cat /memory/profile.md" }),
+        headers: { "Content-Type": "application/json" },
+      })
+      .then((r: Response) => r.json());
+
+    return Response.json({ profile: profile.stdout });
   },
 };
 ```
+
+---
 
 ## Tips
 

--- a/apps/docs/smfs/providers/cloudflare.mdx
+++ b/apps/docs/smfs/providers/cloudflare.mdx
@@ -1,0 +1,205 @@
+---
+title: "Cloudflare"
+sidebarTitle: "Cloudflare"
+description: "Add persistent memory to Cloudflare Workers agents with SMFS."
+icon: "cloud"
+---
+
+[Cloudflare Workers](https://workers.cloudflare.com) run at the edge in V8 isolates — no filesystem, no shell. That's exactly what `@supermemory/bash` is built for. It gives your Worker a virtual bash environment backed by Supermemory, so your agent can `ls`, `cat`, `grep`, and write to a persistent memory container without needing a real filesystem.
+
+## Architecture
+
+Cloudflare Workers can't mount SMFS (no FUSE, no disk). Instead, use `@supermemory/bash` as a tool for your agent. The bash tool runs entirely in-process — no child processes, no disk I/O, no native dependencies.
+
+```
+Request → Worker → LLM → calls bash tool → @supermemory/bash → Supermemory API
+```
+
+<Note>
+  If you're using [Cloudflare Containers](https://developers.cloudflare.com/containers/) (full Linux containers at the edge), you can install the `smfs` binary directly. See [Alternative: Cloudflare Containers](#alternative-cloudflare-containers) below.
+</Note>
+
+## Prerequisites
+
+- A [Supermemory](https://console.supermemory.ai) account and API key
+- A [Cloudflare](https://dash.cloudflare.com) account
+- Node.js 18+ and Wrangler CLI
+
+## 1. Set up a Worker
+
+```bash
+npm create cloudflare@latest -- my-memory-agent
+cd my-memory-agent
+npm install @supermemory/bash
+```
+
+Add your Supermemory API key as a secret:
+
+```bash
+npx wrangler secret put SUPERMEMORY_API_KEY
+```
+
+## 2. Build an agent with memory
+
+```typescript src/index.ts
+import { createBash } from "@supermemory/bash";
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const { bash, toolDescription } = await createBash({
+      apiKey: env.SUPERMEMORY_API_KEY,
+      containerTag: "user_42",
+    });
+
+    // Read the user's profile
+    const profile = await bash.exec("cat /profile.md");
+
+    // Search memory semantically
+    const results = await bash.exec("sgrep 'project deadlines'");
+
+    // Write new memory
+    await bash.exec('echo "Met with client on April 27" >> /notes.md');
+
+    return new Response(JSON.stringify({
+      profile: profile.stdout,
+      search: results.stdout,
+    }));
+  },
+};
+```
+
+## 3. Full agent with tool calling
+
+Wire `@supermemory/bash` as a tool for an LLM. This example uses the OpenAI API, but any provider works:
+
+```typescript src/index.ts
+import { createBash } from "@supermemory/bash";
+
+interface Env {
+  SUPERMEMORY_API_KEY: string;
+  OPENAI_API_KEY: string;
+}
+
+export default {
+  async fetch(request: Request, env: Env): Promise<Response> {
+    const { messages, userId } = await request.json() as {
+      messages: any[];
+      userId: string;
+    };
+
+    const { bash, toolDescription } = await createBash({
+      apiKey: env.SUPERMEMORY_API_KEY,
+      containerTag: `user_${userId}`,
+    });
+
+    // Call the LLM with the bash tool
+    const response = await fetch("https://api.openai.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Authorization": `Bearer ${env.OPENAI_API_KEY}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({
+        model: "gpt-4o",
+        messages: [
+          {
+            role: "system",
+            content: `You have persistent memory via a bash tool.
+Use it to remember things about the user.
+Start by reading /profile.md for context.`,
+          },
+          ...messages,
+        ],
+        tools: [{
+          type: "function",
+          function: {
+            name: "bash",
+            description: toolDescription,
+            parameters: {
+              type: "object",
+              properties: { cmd: { type: "string" } },
+              required: ["cmd"],
+            },
+          },
+        }],
+      }),
+    });
+
+    const data = await response.json() as any;
+
+    // Handle tool calls
+    if (data.choices[0].message.tool_calls) {
+      const toolCall = data.choices[0].message.tool_calls[0];
+      const cmd = JSON.parse(toolCall.function.arguments).cmd;
+      const result = await bash.exec(cmd);
+
+      // Send the result back to the LLM
+      const followUp = await fetch("https://api.openai.com/v1/chat/completions", {
+        method: "POST",
+        headers: {
+          "Authorization": `Bearer ${env.OPENAI_API_KEY}`,
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          model: "gpt-4o",
+          messages: [
+            ...messages,
+            data.choices[0].message,
+            {
+              role: "tool",
+              tool_call_id: toolCall.id,
+              content: JSON.stringify(result),
+            },
+          ],
+        }),
+      });
+
+      const followUpData = await followUp.json() as any;
+      return new Response(followUpData.choices[0].message.content);
+    }
+
+    return new Response(data.choices[0].message.content);
+  },
+};
+```
+
+## Alternative: Cloudflare Containers
+
+[Cloudflare Containers](https://developers.cloudflare.com/containers/) give you full Linux environments at the edge. Unlike Workers, containers have a real filesystem and shell — so you can install and mount SMFS directly.
+
+```dockerfile Dockerfile
+FROM node:20-slim
+
+# Install SMFS
+RUN curl -fsSL https://smfs.ai/install | sh
+
+# Your agent code
+COPY . /app
+WORKDIR /app
+RUN npm install
+
+CMD ["node", "agent.js"]
+```
+
+Inside the container, mount SMFS as you would on any Linux machine:
+
+```bash
+smfs login --key $SUPERMEMORY_API_KEY
+smfs mount agent_memory --ephemeral --path /memory
+```
+
+Your agent can then use standard Unix commands to interact with memory.
+
+## Tips
+
+- **Workers have a 30-second CPU time limit.** Keep tool call chains short. If your agent needs many steps, consider using Durable Objects for longer-running workflows.
+- **One container tag per user.** Use the user's ID as the container tag for isolated memory per user.
+- **`sgrep` for semantic search.** Inside the bash tool, `sgrep "query"` searches by meaning. Regular `grep` does literal matching.
+- **Cache-friendly.** `@supermemory/bash` warms its path index on `createBash`. For Workers that handle many requests, consider caching the instance in a Durable Object.
+
+## Resources
+
+- [Cloudflare Workers docs](https://developers.cloudflare.com/workers/)
+- [Cloudflare Containers docs](https://developers.cloudflare.com/containers/)
+- [SMFS Bash Tool reference](/smfs/bash-tool)
+- [Supermemory quickstart](/quickstart)

--- a/apps/docs/smfs/providers/cloudflare.mdx
+++ b/apps/docs/smfs/providers/cloudflare.mdx
@@ -171,7 +171,7 @@ Start by reading /profile.md for context.`,
 FROM node:20-slim
 
 # Install SMFS
-RUN curl -fsSL https://smfs.ai/install | sh
+RUN curl -fsSL https://smfs.ai/install | bash
 
 # Your agent code
 COPY . /app

--- a/apps/docs/smfs/providers/cloudflare.mdx
+++ b/apps/docs/smfs/providers/cloudflare.mdx
@@ -20,7 +20,7 @@ mount. The entrypoint sets up the mount and starts the agent.
 ```mermaid
 graph LR
     subgraph Cloudflare Container
-        Agent["Claude Agent"] -->|"cat, ls, echo"| Mount["/memory\n(SMFS mount)"]
+        Agent["Claude Agent"] -->|"cat, ls, echo"| Mount["/memory<br/>(SMFS mount)"]
     end
     Mount -->|sync| SM["Supermemory"]
 ```
@@ -32,9 +32,9 @@ HTTP. The container exposes a simple exec endpoint.
 
 ```mermaid
 graph LR
-    Agent["Worker\n(agent logic)"] -->|"fetch('/exec')"| Container
+    Agent["Worker<br/>(agent logic)"] -->|"containerFetch('/exec')"| Container
     subgraph Container ["Cloudflare Container"]
-        Mount["/memory\n(SMFS mount)"]
+        Mount["/memory<br/>(SMFS mount)"]
     end
     Mount -->|sync| SM["Supermemory"]
 ```
@@ -43,8 +43,17 @@ graph LR
 
 - A [Supermemory API key](https://supermemory.ai)
 - An [Anthropic API key](https://console.anthropic.com)
-- A [Cloudflare account](https://dash.cloudflare.com) with Containers enabled
+- A [Cloudflare account](https://dash.cloudflare.com) with Containers enabled (Workers Paid plan)
 - [Wrangler CLI](https://developers.cloudflare.com/workers/wrangler/install-and-update/)
+- The [`@cloudflare/containers`](https://www.npmjs.com/package/@cloudflare/containers) package: `npm install @cloudflare/containers`
+
+<Note>
+  Cloudflare Containers are implemented as container-enabled Durable Objects.
+  You declare a `Container` subclass, bind it as a Durable Object, and
+  reference its image in the `containers` array. Worker secrets are **not**
+  automatically visible inside the container — you have to pass them through
+  `envVars` when starting the container (see below).
+</Note>
 
 ---
 
@@ -108,16 +117,63 @@ async def main():
 asyncio.run(main())
 ```
 
-### Deploy
+### Worker
 
-```toml wrangler.toml
-name = "memory-agent"
-main = "worker.ts"
+The Worker defines the `Container` subclass and forwards Worker secrets into
+the container via `envVars`:
 
-[[containers]]
-class_name = "MY_CONTAINER"
-image = "./Dockerfile"
-max_instances = 5
+```typescript worker.ts
+import { Container, getContainer } from "@cloudflare/containers";
+
+export class MyAgentContainer extends Container {
+  defaultPort = 8080;
+  // Forward Worker secrets into the container at start time.
+  // `this.env` is the Worker env object, populated from wrangler secrets.
+  envVars = {
+    SUPERMEMORY_API_KEY: this.env.SUPERMEMORY_API_KEY,
+    ANTHROPIC_API_KEY: this.env.ANTHROPIC_API_KEY,
+  };
+}
+
+export default {
+  async fetch(request: Request, env: Env) {
+    // The container runs the agent and exits; this Worker route just kicks
+    // it off (e.g. on a queue message or scheduled trigger).
+    const container = getContainer(env.MY_CONTAINER, "agent-singleton");
+    return container.fetch(request);
+  },
+};
+
+interface Env {
+  MY_CONTAINER: DurableObjectNamespace<MyAgentContainer>;
+  SUPERMEMORY_API_KEY: string;
+  ANTHROPIC_API_KEY: string;
+}
+```
+
+### Config
+
+```jsonc wrangler.jsonc
+{
+  "name": "memory-agent",
+  "main": "worker.ts",
+  "compatibility_date": "2025-04-03",
+  "containers": [
+    {
+      "class_name": "MyAgentContainer",
+      "image": "./Dockerfile",
+      "max_instances": 5
+    }
+  ],
+  "durable_objects": {
+    "bindings": [
+      { "name": "MY_CONTAINER", "class_name": "MyAgentContainer" }
+    ]
+  },
+  "migrations": [
+    { "tag": "v1", "new_sqlite_classes": ["MyAgentContainer"] }
+  ]
+}
 ```
 
 ```bash
@@ -133,7 +189,20 @@ wrangler deploy
 The agent logic lives in a Worker. The container just runs SMFS and exposes an
 HTTP endpoint for executing commands against the mount.
 
+<Warning>
+  The `/exec` endpoint below runs arbitrary shell commands inside the
+  container. **Only call it from your Worker** — never expose it publicly,
+  and never pass user input straight into `command` without validation.
+  Cloudflare Containers are addressable only through their Worker by default,
+  so this is safe as long as you don't add a public route that proxies to
+  `/exec`.
+</Warning>
+
 ### Container (exec server)
+
+The Dockerfile and entrypoint are nearly identical to Pattern A — the only
+differences are the Python deps (`flask` instead of `claude-agent-sdk`) and
+the file we exec at the end.
 
 ```dockerfile Dockerfile
 FROM python:3.12-slim
@@ -143,7 +212,7 @@ RUN echo 'user_allow_other' >> /etc/fuse.conf
 
 RUN curl -fsSL https://smfs.ai/install | bash -s -- 0.0.1-rc2
 ENV PATH="/root/.local/bin:$PATH"
-RUN pip install flask
+RUN pip install flask gunicorn
 
 COPY server.py /app/server.py
 COPY entrypoint.sh /entrypoint.sh
@@ -151,6 +220,9 @@ RUN chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]
 ```
+
+The entrypoint differs from Pattern A only in the final `exec` line — we run
+gunicorn against the Flask app instead of `python3 agent.py`:
 
 ```bash entrypoint.sh
 #!/bin/bash
@@ -160,7 +232,7 @@ smfs login --key "$SUPERMEMORY_API_KEY"
 smfs mount my_agent --ephemeral --path /memory --foreground &
 sleep 3
 
-exec python3 /app/server.py
+exec gunicorn -b 0.0.0.0:8080 --chdir /app server:app
 ```
 
 ```python server.py
@@ -176,28 +248,78 @@ def exec_command():
         cmd, shell=True, capture_output=True, text=True, cwd="/memory", timeout=10
     )
     return jsonify(stdout=result.stdout, stderr=result.stderr, code=result.returncode)
-
-app.run(host="0.0.0.0", port=8080)
 ```
+
+<Note>
+  We use gunicorn instead of `app.run(...)` because Flask's built-in dev
+  server isn't meant for production traffic. If you'd rather just see it
+  work, you can replace the `exec` line with
+  `exec python3 /app/server.py` and add `app.run(host="0.0.0.0", port=8080)`
+  to `server.py` — but switch back to gunicorn before you ship.
+</Note>
 
 ### Worker (agent logic)
 
 ```typescript worker.ts
+import { Container, getContainer } from "@cloudflare/containers";
+
+export class ExecContainer extends Container {
+  defaultPort = 8080;
+  envVars = {
+    SUPERMEMORY_API_KEY: this.env.SUPERMEMORY_API_KEY,
+  };
+}
+
 export default {
-  async fetch(request: Request, env: any) {
-    const container = await env.MY_CONTAINER.start();
+  async fetch(_request: Request, env: Env) {
+    const container = getContainer(env.MY_CONTAINER, "agent-singleton");
 
     const profile = await container
-      .fetch("/exec", {
+      .fetch(new Request("http://container/exec", {
         method: "POST",
         body: JSON.stringify({ command: "cat /memory/profile.md" }),
         headers: { "Content-Type": "application/json" },
-      })
-      .then((r: Response) => r.json());
+      }))
+      .then((r) => r.json<{ stdout: string }>());
 
     return Response.json({ profile: profile.stdout });
   },
 };
+
+interface Env {
+  MY_CONTAINER: DurableObjectNamespace<ExecContainer>;
+  SUPERMEMORY_API_KEY: string;
+}
+```
+
+### Config
+
+```jsonc wrangler.jsonc
+{
+  "name": "memory-exec",
+  "main": "worker.ts",
+  "compatibility_date": "2025-04-03",
+  "containers": [
+    {
+      "class_name": "ExecContainer",
+      "image": "./Dockerfile",
+      "max_instances": 5
+    }
+  ],
+  "durable_objects": {
+    "bindings": [
+      { "name": "MY_CONTAINER", "class_name": "ExecContainer" }
+    ]
+  },
+  "migrations": [
+    { "tag": "v1", "new_sqlite_classes": ["ExecContainer"] }
+  ]
+}
+```
+
+```bash
+wrangler secret put SUPERMEMORY_API_KEY
+wrangler deploy
 ```
 
 ---
@@ -207,3 +329,9 @@ export default {
 - Use `--ephemeral` for container mounts — keeps the cache in memory only, but
   writes still push to Supermemory
 - Use `smfs grep 'query'` for semantic search across all files
+- Worker secrets aren't automatically visible inside the container. Pass each
+  one through the `envVars` field on your `Container` subclass (see the Worker
+  snippets above)
+- Use `containerFetch` from within a Container class method (e.g., lifecycle
+  hooks) to call the container's own HTTP server. From the Worker, use the
+  stub's `.fetch()` method instead

--- a/apps/docs/smfs/providers/daytona.mdx
+++ b/apps/docs/smfs/providers/daytona.mdx
@@ -1,121 +1,71 @@
 ---
 title: "Daytona"
-sidebarTitle: "Daytona"
-description: "Give your Daytona sandboxes persistent memory with SMFS."
-icon: "server"
+description: "Give your AI agent persistent memory inside a Daytona sandbox using SMFS"
 ---
 
-[Daytona](https://www.daytona.io) gives AI agents isolated Linux sandboxes that boot in milliseconds. Pair it with SMFS and your agent gets both safe code execution **and** persistent memory it can `ls`, `cat`, and `grep`.
+Mount a Supermemory container inside a [Daytona](https://daytona.io) sandbox so
+your agent can read and write memory with plain bash commands.
 
-## Architecture
+## How it works
 
-Daytona sandboxes run full Linux with shell access, filesystem, and network. There are two ways to wire SMFS in:
-
-<CardGroup cols={2}>
-  <Card title="Bash Tool in your agent code" icon="terminal">
-    Use `@supermemory/bash` in the code that **orchestrates** the sandbox. The agent reads memory via the bash tool, then sends code to Daytona for execution. Works everywhere.
-  </Card>
-  <Card title="Mount inside the sandbox" icon="hard-drive">
-    Install the `smfs` binary inside the sandbox and mount a container directly. Requires unrestricted outbound HTTPS from the sandbox.
-  </Card>
-</CardGroup>
-
-<Note>
-  Some Daytona sandbox configurations may restrict outbound TLS to certain hosts. If `smfs mount` or `smfs login` fails with connection errors, use the Bash Tool pattern instead — it runs in your orchestrating code, not inside the sandbox.
-</Note>
+1. Create a Daytona sandbox
+2. Install SMFS and mount a Supermemory container inside it
+3. Run a Claude agent inside the sandbox — it uses `cat`, `ls`, `echo`, etc. on the mount
+4. Everything the agent writes is persisted to Supermemory automatically
 
 ## Prerequisites
 
-- A [Supermemory](https://console.supermemory.ai) account and API key
-- A [Daytona](https://app.daytona.io) account and API key
-- Node.js 18+ or Python 3.10+
+- A [Supermemory API key](https://supermemory.ai)
+- A [Daytona API key](https://app.daytona.io) — go to **API Keys** in the sidebar
+- An [Anthropic API key](https://console.anthropic.com)
 
-## 1. Get your API keys
-
-### Supermemory
-
-1. Go to [console.supermemory.ai](https://console.supermemory.ai)
-2. Navigate to **Settings → API Keys**
-3. Create a new key and copy it
-
-### Daytona
-
-1. Go to [app.daytona.io](https://app.daytona.io)
-2. Sign up and verify your email
-3. Set your default region (US or EU)
-4. Navigate to **API Keys** in the sidebar
-5. Click **Create Key**, give it a name, and copy the key
-
-<Warning>
-  You can only view a Daytona API key once. Store it somewhere safe immediately after creation.
-</Warning>
-
-## 2. Install the SDKs
+## Quick start
 
 <Tabs>
   <Tab title="TypeScript">
     ```bash
-    npm install @supermemory/bash @daytonaio/sdk
+    npm install @anthropic-ai/claude-agent-sdk @daytonaio/sdk
     ```
-  </Tab>
-  <Tab title="Python">
-    ```bash
-    pip install daytona-sdk
-    ```
-  </Tab>
-</Tabs>
-
-## 3. Build an agent with memory + code execution
-
-<Tabs>
-  <Tab title="TypeScript">
-    The recommended TypeScript pattern: use `@supermemory/bash` for memory in your orchestrating code and the Daytona SDK for code execution. The LLM gets both as tools.
 
     ```typescript agent.ts
-    import { createBash } from "@supermemory/bash";
     import { Daytona } from "@daytonaio/sdk";
-    import { generateText, tool } from "ai";
-    import { openai } from "@ai-sdk/openai";
-    import { z } from "zod";
+    import { query } from "@anthropic-ai/claude-agent-sdk";
 
     async function main() {
-      // 1. Set up memory (SMFS bash tool)
-      const { bash, toolDescription } = await createBash({
-        apiKey: process.env.SUPERMEMORY_API_KEY!,
-        containerTag: "agent_memory",
-      });
-
-      // 2. Set up code execution (Daytona sandbox)
+      // 1. Create a Daytona sandbox
       const daytona = new Daytona({
         apiKey: process.env.DAYTONA_API_KEY!,
         apiUrl: "https://app.daytona.io/api",
       });
       const sandbox = await daytona.create();
 
-      // 3. Give the LLM both tools
-      const result = await generateText({
-        model: openai("gpt-4o"),
-        tools: {
-          memory: tool({
-            description: toolDescription,
-            parameters: z.object({ cmd: z.string() }),
-            execute: async ({ cmd }) => bash.exec(cmd),
-          }),
-          execute_code: tool({
-            description: "Run code in an isolated sandbox",
-            parameters: z.object({ code: z.string() }),
-            execute: async ({ code }) => {
-              const res = await sandbox.process.exec(code);
-              return res.result;
-            },
-          }),
-        },
-        prompt: "Check my memory for the user's preferred language, then write and run a hello world in that language.",
-      });
+      // 2. Install SMFS, log in, and mount
+      await sandbox.process.exec("curl -fsSL https://smfs.ai/install | bash");
+      await sandbox.process.exec(
+        `~/.local/bin/smfs login --key ${process.env.SUPERMEMORY_API_KEY}`
+      );
+      await sandbox.process.exec(
+        "~/.local/bin/smfs mount my_agent --ephemeral --path /home/daytona/memory"
+      );
 
-      console.log(result.text);
+      // 3. Run a Claude agent inside the sandbox with bash access
+      for await (const message of query({
+        prompt: `You have access to a persistent memory filesystem mounted at /home/daytona/memory.
+    Use bash commands to explore it (ls, cat) and write notes to it (echo "..." > file).
+
+    First, read /home/daytona/memory/profile.md to learn about the user.
+    Then create /home/daytona/memory/session_notes.md with a summary of what you found.`,
+        options: {
+          allowedTools: ["Bash", "Read", "Write"],
+        },
+      })) {
+        if (message.type === "text") console.log(message.text);
+      }
 
       // 4. Clean up
+      await sandbox.process.exec(
+        "~/.local/bin/smfs unmount my_agent 2>/dev/null"
+      );
       await daytona.delete(sandbox);
     }
 
@@ -123,64 +73,66 @@ Daytona sandboxes run full Linux with shell access, filesystem, and network. The
     ```
   </Tab>
   <Tab title="Python">
-    In Python, install and mount SMFS inside the Daytona sandbox. The agent reads and writes memory via standard shell commands.
-
-    <Warning>
-      This requires unrestricted outbound HTTPS from the sandbox. If `smfs login` fails with a connection error, see the note at the top of this page.
-    </Warning>
+    ```bash
+    pip install claude-agent-sdk daytona-sdk
+    ```
 
     ```python agent.py
+    import asyncio
     import os
+    from claude_agent_sdk import query, ClaudeAgentOptions
     from daytona_sdk import Daytona, DaytonaConfig
 
-    # 1. Set up code execution (Daytona sandbox)
-    config = DaytonaConfig(
-        api_key=os.environ["DAYTONA_API_KEY"],
-        api_url="https://app.daytona.io/api",
-    )
-    daytona = Daytona(config)
-    sandbox = daytona.create()
+    async def main():
+        # 1. Create a Daytona sandbox
+        config = DaytonaConfig(
+            api_key=os.environ["DAYTONA_API_KEY"],
+            api_url="https://app.daytona.io/api",
+        )
+        daytona = Daytona(config)
+        sandbox = daytona.create()
 
-    # 2. Install SMFS inside the sandbox
-    sandbox.process.exec(
-        "curl -fsSL https://smfs.ai/install | bash"
-    )
+        # 2. Install SMFS, log in, and mount
+        sandbox.process.exec("curl -fsSL https://smfs.ai/install | bash")
+        sandbox.process.exec(
+            f"~/.local/bin/smfs login --key {os.environ['SUPERMEMORY_API_KEY']}"
+        )
+        sandbox.process.exec(
+            "~/.local/bin/smfs mount my_agent --ephemeral --path /home/daytona/memory"
+        )
 
-    # 3. Log in and mount
-    sandbox.process.exec(
-        f"~/.local/bin/smfs login --key {os.environ['SUPERMEMORY_API_KEY']}"
-    )
-    sandbox.process.exec(
-        "~/.local/bin/smfs mount agent_memory --ephemeral"
-    )
+        # 3. Run a Claude agent inside the sandbox with bash access
+        async for message in query(
+            prompt="""You have access to a persistent memory filesystem mounted at /home/daytona/memory.
+    Use bash commands to explore it (ls, cat) and write notes to it.
 
-    # 4. Read the auto-generated profile
-    response = sandbox.process.exec("cat agent_memory/profile.md")
-    print(response.result)
+    First, read /home/daytona/memory/profile.md to learn about the user.
+    Then create /home/daytona/memory/session_notes.md with a summary of what you found.""",
+            options=ClaudeAgentOptions(
+                allowed_tools=["Bash", "Read", "Write"],
+            ),
+        ):
+            print(message)
 
-    # 5. Semantic search
-    response = sandbox.process.exec(
-        "~/.local/bin/smfs grep 'preferred language'"
-    )
-    print(response.result)
+        # 4. Clean up
+        sandbox.process.exec("~/.local/bin/smfs unmount my_agent 2>/dev/null")
+        daytona.delete(sandbox)
 
-    # 6. Clean up
-    sandbox.process.exec("~/.local/bin/smfs unmount agent_memory")
-    daytona.delete(sandbox)
+    asyncio.run(main())
     ```
   </Tab>
 </Tabs>
 
+<Note>
+  Some Daytona datacenter IPs may be blocked by upstream firewalls. If
+  `smfs login` or `smfs mount` fails with a TLS connection error, check
+  that outbound HTTPS to `api.supermemory.ai` is not restricted.
+</Note>
+
 ## Tips
 
-- **Use `--ephemeral` for sandboxes.** Sandbox filesystems are temporary. Ephemeral mode avoids writing a local SQLite cache that will be thrown away.
-- **One container, many sandboxes.** Mount the same container tag from multiple sandboxes. Bidirectional sync keeps them in step.
-- **Give each agent a subdirectory.** If multiple agents share a container, scope them to `/agent_a/`, `/agent_b/`, etc. They can still read across the whole mount.
-- **Clean up sandboxes.** Call `daytona.delete(sandbox)` when done to avoid burning through free credits.
-
-## Resources
-
-- [Daytona docs](https://www.daytona.io/docs)
-- [Daytona SDK reference](https://www.daytona.io/docs/en/tools/api/)
-- [SMFS Mount reference](/smfs/mount)
-- [SMFS Bash Tool reference](/smfs/bash-tool)
+- Use `--ephemeral` when mounting inside sandboxes — it keeps the cache in memory
+  only, but writes still push to Supermemory
+- Use `smfs grep 'query'` for semantic search across all files in the container
+- The agent can write structured data (JSON, markdown) to the mount and it
+  persists across sandbox sessions via Supermemory

--- a/apps/docs/smfs/providers/daytona.mdx
+++ b/apps/docs/smfs/providers/daytona.mdx
@@ -125,9 +125,16 @@ The recommended pattern: your agent code uses `@supermemory/bash` for memory and
   <Tab title="Python">
     ```python agent.py
     import os
+    from supermemory import create_bash
     from daytona_sdk import Daytona, DaytonaConfig
 
-    # 1. Set up code execution (Daytona sandbox)
+    # 1. Set up memory (SMFS bash tool — runs in your code, not the sandbox)
+    bash = create_bash(
+        api_key=os.environ["SUPERMEMORY_API_KEY"],
+        container_tag="agent_memory",
+    )
+
+    # 2. Set up code execution (Daytona sandbox)
     config = DaytonaConfig(
         api_key=os.environ["DAYTONA_API_KEY"],
         api_url="https://app.daytona.io/api",
@@ -135,31 +142,19 @@ The recommended pattern: your agent code uses `@supermemory/bash` for memory and
     daytona = Daytona(config)
     sandbox = daytona.create()
 
-    # 2. Install SMFS inside the sandbox
-    sandbox.process.exec(
-        "curl -fsSL https://smfs.ai/install | sh"
-    )
+    # 3. Read memory from your orchestrating code
+    profile = bash.exec("cat /profile.md")
+    print(profile.stdout)
 
-    # 3. Log in and mount
-    sandbox.process.exec(
-        f"~/.local/bin/smfs login --key {os.environ['SUPERMEMORY_API_KEY']}"
-    )
-    sandbox.process.exec(
-        "~/.local/bin/smfs mount agent_memory --ephemeral"
-    )
-
-    # 4. Your agent can now use the filesystem
-    response = sandbox.process.exec("cat agent_memory/profile.md")
+    # 4. Execute code in the sandbox
+    response = sandbox.process.exec("python3 -c 'print(\"Hello from Daytona!\")'")
     print(response.result)
 
-    # 5. Semantic search
-    response = sandbox.process.exec(
-        "~/.local/bin/smfs grep 'preferred language'"
-    )
-    print(response.result)
+    # 5. Semantic search across memory
+    results = bash.exec("sgrep 'preferred language'")
+    print(results.stdout)
 
     # 6. Clean up
-    sandbox.process.exec("~/.local/bin/smfs unmount agent_memory")
     daytona.delete(sandbox)
     ```
   </Tab>
@@ -168,6 +163,10 @@ The recommended pattern: your agent code uses `@supermemory/bash` for memory and
 ## Alternative: Mount SMFS inside the sandbox
 
 If your Daytona sandbox has unrestricted network access, you can install and mount SMFS directly inside it. This gives the agent a real filesystem it can navigate with standard Unix commands.
+
+<Warning>
+  Some Daytona datacenter IPs are blocked by upstream firewalls. If `smfs login` or `smfs mount` fails with a TLS connection error from inside the sandbox, switch to the **Bash Tool** pattern above — it runs in your orchestrating code where network access is unrestricted.
+</Warning>
 
 ```python
 from daytona_sdk import Daytona, DaytonaConfig

--- a/apps/docs/smfs/providers/daytona.mdx
+++ b/apps/docs/smfs/providers/daytona.mdx
@@ -7,11 +7,12 @@ Mount a Supermemory container inside a [Daytona](https://daytona.io) sandbox so
 your agent can read and write memory using standard filesystem commands.
 
 <Warning>
-  Daytona sandboxes currently cannot reach `api.supermemory.ai` due to network
-  restrictions from their datacenter IPs. The SMFS binary installs and the FUSE
-  mount starts, but it cannot sync data. We're working with Daytona to resolve
-  this. In the meantime, use [E2B](/smfs/providers/e2b) or a
-  [local mount](/smfs/providers/vercel) instead.
+  Daytona sandboxes currently cannot reach `api.supermemory.ai` from their
+  datacenter IPs. The SMFS binary still installs (we download it directly from
+  GitHub Releases), the FUSE mount still starts, and `pip install
+  claude-agent-sdk` still works — but the runtime sync to Supermemory fails. We're
+  working with Daytona to resolve this. In the meantime, use
+  [E2B](/smfs/providers/e2b) or a [self-hosted mount](/smfs/providers/vercel).
 </Warning>
 
 ## How it works
@@ -26,7 +27,7 @@ The agent process runs inside the sandbox and accesses the SMFS mount directly.
 ```mermaid
 graph LR
     subgraph Daytona Sandbox
-        Agent["Claude Agent"] -->|"cat, ls, echo"| Mount["/home/daytona/memory\n(SMFS mount)"]
+        Agent["Claude Agent"] -->|"cat, ls, echo"| Mount["/home/daytona/memory<br/>(SMFS mount)"]
     end
     Mount -->|sync| SM["Supermemory"]
 ```
@@ -38,9 +39,9 @@ sandbox remotely.
 
 ```mermaid
 graph LR
-    Agent["Claude Agent\n(your server)"] -->|"sandbox.process.exec()"| Sandbox
+    Agent["Claude Agent<br/>(your server)"] -->|"sandbox.process.exec()"| Sandbox
     subgraph Sandbox ["Daytona Sandbox"]
-        Mount["/home/daytona/memory\n(SMFS mount)"]
+        Mount["/home/daytona/memory<br/>(SMFS mount)"]
     end
     Mount -->|sync| SM["Supermemory"]
 ```
@@ -50,6 +51,40 @@ graph LR
 - A [Supermemory API key](https://supermemory.ai)
 - A [Daytona API key](https://app.daytona.io) — go to **API Keys** in the sidebar
 - An [Anthropic API key](https://console.anthropic.com)
+
+---
+
+## Install SMFS in a Daytona sandbox
+
+Both patterns below run the same setup snippet inside the sandbox before
+mounting. Daytona can't reach `smfs.ai`, so we download the binary directly
+from GitHub Releases and add `~/.local/bin` to PATH.
+
+<Tabs>
+  <Tab title="Python">
+    ```python
+    SMFS_INSTALL = (
+        "mkdir -p $HOME/.local/bin && "
+        "curl -sL https://github.com/supermemoryai/smfs/releases/download/"
+        "v0.0.1-rc2/smfs-linux-x64 -o $HOME/.local/bin/smfs && "
+        "chmod +x $HOME/.local/bin/smfs && "
+        "echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null && "
+        "pip install claude-agent-sdk"
+    )
+    ```
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript
+    const SMFS_INSTALL =
+      "mkdir -p $HOME/.local/bin && " +
+      "curl -sL https://github.com/supermemoryai/smfs/releases/download/" +
+      "v0.0.1-rc2/smfs-linux-x64 -o $HOME/.local/bin/smfs && " +
+      "chmod +x $HOME/.local/bin/smfs && " +
+      "echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null && " +
+      "pip install claude-agent-sdk";
+    ```
+  </Tab>
+</Tabs>
 
 ---
 
@@ -84,6 +119,7 @@ asyncio.run(main())
   <Tab title="Python">
     ```python run.py
     import os
+    from pathlib import Path
     from daytona_sdk import Daytona, DaytonaConfig
 
     daytona = Daytona(DaytonaConfig(
@@ -96,19 +132,8 @@ asyncio.run(main())
         },
     )
 
-    # Install SMFS (from GitHub releases — smfs.ai is unreachable from Daytona)
-    sandbox.process.exec(
-        "mkdir -p $HOME/.local/bin && "
-        "curl -sL https://github.com/supermemoryai/smfs/releases/download/"
-        "v0.0.1-rc2/smfs-linux-x64 -o $HOME/.local/bin/smfs && "
-        "chmod +x $HOME/.local/bin/smfs"
-    )
-
-    # Fix FUSE config and install agent SDK
-    sandbox.process.exec(
-        "echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null"
-    )
-    sandbox.process.exec("pip install claude-agent-sdk")
+    # See "Install SMFS in a Daytona sandbox" above
+    sandbox.process.exec(SMFS_INSTALL)
 
     # Mount memory
     sandbox.process.exec("$HOME/.local/bin/smfs login --key $SUPERMEMORY_API_KEY")
@@ -117,7 +142,8 @@ asyncio.run(main())
         " --path /home/daytona/memory --foreground &' && sleep 3"
     )
 
-    # Run the agent
+    # Upload and run the agent
+    sandbox.fs.upload_file(Path("agent.py").read_bytes(), "agent.py")
     result = sandbox.process.exec("python3 agent.py")
     print(result.result)
 
@@ -127,6 +153,7 @@ asyncio.run(main())
   <Tab title="TypeScript">
     ```typescript run.ts
     import { Daytona } from "@daytonaio/sdk";
+    import { readFileSync } from "fs";
 
     const daytona = new Daytona({
       apiKey: process.env.DAYTONA_API_KEY!,
@@ -138,19 +165,8 @@ asyncio.run(main())
       },
     });
 
-    // Install SMFS (from GitHub releases — smfs.ai is unreachable from Daytona)
-    await sandbox.process.exec(
-      "mkdir -p $HOME/.local/bin && " +
-      "curl -sL https://github.com/supermemoryai/smfs/releases/download/" +
-      "v0.0.1-rc2/smfs-linux-x64 -o $HOME/.local/bin/smfs && " +
-      "chmod +x $HOME/.local/bin/smfs"
-    );
-
-    // Fix FUSE config and install agent SDK
-    await sandbox.process.exec(
-      "echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null"
-    );
-    await sandbox.process.exec("pip install claude-agent-sdk");
+    // See "Install SMFS in a Daytona sandbox" above
+    await sandbox.process.exec(SMFS_INSTALL);
 
     // Mount memory
     await sandbox.process.exec(
@@ -162,6 +178,7 @@ asyncio.run(main())
     );
 
     // Upload and run the agent
+    await sandbox.fs.uploadFile(readFileSync("agent.py"), "agent.py");
     const result = await sandbox.process.exec("python3 agent.py");
     console.log(result.result);
 
@@ -192,16 +209,8 @@ remotely via `sandbox.process.exec()`.
         },
     )
 
-    # Install and mount SMFS
-    sandbox.process.exec(
-        "mkdir -p $HOME/.local/bin && "
-        "curl -sL https://github.com/supermemoryai/smfs/releases/download/"
-        "v0.0.1-rc2/smfs-linux-x64 -o $HOME/.local/bin/smfs && "
-        "chmod +x $HOME/.local/bin/smfs"
-    )
-    sandbox.process.exec(
-        "echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null"
-    )
+    # See "Install SMFS in a Daytona sandbox" above
+    sandbox.process.exec(SMFS_INSTALL)
     sandbox.process.exec("$HOME/.local/bin/smfs login --key $SUPERMEMORY_API_KEY")
     sandbox.process.exec(
         "bash -c '$HOME/.local/bin/smfs mount my_agent --ephemeral"
@@ -235,16 +244,8 @@ remotely via `sandbox.process.exec()`.
       },
     });
 
-    // Install and mount SMFS
-    await sandbox.process.exec(
-      "mkdir -p $HOME/.local/bin && " +
-      "curl -sL https://github.com/supermemoryai/smfs/releases/download/" +
-      "v0.0.1-rc2/smfs-linux-x64 -o $HOME/.local/bin/smfs && " +
-      "chmod +x $HOME/.local/bin/smfs"
-    );
-    await sandbox.process.exec(
-      "echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null"
-    );
+    // See "Install SMFS in a Daytona sandbox" above
+    await sandbox.process.exec(SMFS_INSTALL);
     await sandbox.process.exec(
       "$HOME/.local/bin/smfs login --key $SUPERMEMORY_API_KEY"
     );
@@ -275,12 +276,7 @@ remotely via `sandbox.process.exec()`.
 
 - FUSE is available in Daytona sandboxes but `user_allow_other` needs to be
   added to `/etc/fuse.conf`
-- The binary installs to `~/.local/bin/` which isn't on PATH by default in
-  Daytona's zsh — use the full path or `export PATH=$HOME/.local/bin:$PATH`
+- We invoke SMFS as `$HOME/.local/bin/smfs` in the examples because Daytona's
+  default zsh PATH doesn't include `~/.local/bin`. Alternatively, prepend it
+  once with `export PATH=$HOME/.local/bin:$PATH`
 - Use `pip install claude-agent-sdk` to install the agent SDK (PyPI is reachable)
-
-<Note>
-  Daytona sandboxes can't reach `smfs.ai`, so the install downloads the binary
-  directly from GitHub releases. The SMFS binary and Claude Agent SDK both
-  install successfully — only the Supermemory API connection is blocked.
-</Note>

--- a/apps/docs/smfs/providers/daytona.mdx
+++ b/apps/docs/smfs/providers/daytona.mdx
@@ -4,14 +4,34 @@ description: "Give your AI agent persistent memory inside a Daytona sandbox usin
 ---
 
 Mount a Supermemory container inside a [Daytona](https://daytona.io) sandbox so
-your agent can read and write memory with plain bash commands.
+your agent can read and write memory using standard filesystem commands.
 
-## How it works
+<Warning>
+  Daytona sandboxes currently cannot reach `api.supermemory.ai` due to network
+  restrictions from their datacenter IPs. The SMFS binary installs and the FUSE
+  mount starts, but it cannot sync data. We're working with Daytona to resolve
+  this. In the meantime, use [E2B](/smfs/providers/e2b) or a
+  [local mount](/smfs/providers/vercel) instead.
+</Warning>
 
-1. Create a Daytona sandbox
-2. Install SMFS and mount a Supermemory container inside it
-3. Install the Claude Agent SDK inside the sandbox and run the agent there
-4. The agent uses `cat`, `ls`, `echo`, etc. on the mount — everything persists to Supermemory
+## How it works (once network is resolved)
+
+```
+┌──────────────────────────────────────────┐
+│  Daytona Sandbox                         │
+│                                          │
+│  ┌──────────┐    ┌────────────────────┐  │
+│  │  Claude   │───▶│  /home/daytona/    │  │
+│  │  Agent    │    │  memory            │  │
+│  │          │    │  (SMFS mount)      │  │
+│  └──────────┘    └────────┬───────────┘  │
+│                           │              │
+└───────────────────────────┼──────────────┘
+                            │
+                    ┌───────▼───────┐
+                    │  Supermemory  │
+                    └───────────────┘
+```
 
 ## Prerequisites
 
@@ -19,147 +39,128 @@ your agent can read and write memory with plain bash commands.
 - A [Daytona API key](https://app.daytona.io) — go to **API Keys** in the sidebar
 - An [Anthropic API key](https://console.anthropic.com)
 
-## Quick start
+## 1. Write your agent
 
-<Tabs>
-  <Tab title="TypeScript">
-    ```bash
-    npm install @daytonaio/sdk
-    ```
-
-    ```typescript agent.ts
-    import { Daytona } from "@daytonaio/sdk";
-
-    async function main() {
-      const daytona = new Daytona({
-        apiKey: process.env.DAYTONA_API_KEY!,
-        apiUrl: "https://app.daytona.io/api",
-      });
-      const sandbox = await daytona.create();
-
-      // Install SMFS, log in, and mount
-      await sandbox.process.exec("curl -fsSL https://smfs.ai/install | bash");
-      await sandbox.process.exec(
-        `~/.local/bin/smfs login --key ${process.env.SUPERMEMORY_API_KEY}`
-      );
-      await sandbox.process.exec(
-        "~/.local/bin/smfs mount my_agent --ephemeral --path /home/daytona/memory"
-      );
-
-      // Install Claude Agent SDK inside the sandbox
-      await sandbox.process.exec("pip install claude-agent-sdk");
-
-      // Write the agent script into the sandbox
-      await sandbox.fs.uploadFile(
-        "/home/daytona/agent.py",
-        new TextEncoder().encode(`
+```python agent.py
 import asyncio
 from claude_agent_sdk import query, ClaudeAgentOptions
-import os
+
+MEMORY = "/home/daytona/memory"
 
 async def main():
     async for message in query(
-        prompt="""You have a persistent memory filesystem at /home/daytona/memory.
-Use bash to explore it (ls, cat) and write notes (echo "..." > file).
-
-Read /home/daytona/memory/profile.md to learn about the user.
-Then create /home/daytona/memory/session_notes.md summarizing what you found.""",
+        prompt=f"You have a persistent memory filesystem at {MEMORY}. "
+               "Read profile.md to learn about the user, then create "
+               "session_notes.md summarizing what you found.",
         options=ClaudeAgentOptions(
             allowed_tools=["Bash", "Read", "Write"],
+            cwd=MEMORY,
         ),
     ):
         print(message)
 
 asyncio.run(main())
-`)
-      );
+```
 
-      // Run the agent inside the sandbox
-      const result = await sandbox.process.exec(
-        `ANTHROPIC_API_KEY=${process.env.ANTHROPIC_API_KEY} python3 /home/daytona/agent.py`
-      );
-      console.log(result.result);
+## 2. Run it
 
-      await daytona.delete(sandbox);
-    }
-
-    main();
-    ```
-  </Tab>
+<Tabs>
   <Tab title="Python">
-    ```bash
-    pip install daytona-sdk
-    ```
-
-    ```python agent.py
+    ```python run.py
     import os
     from daytona_sdk import Daytona, DaytonaConfig
 
-    config = DaytonaConfig(
+    daytona = Daytona(DaytonaConfig(
         api_key=os.environ["DAYTONA_API_KEY"],
-        api_url="https://app.daytona.io/api",
+    ))
+    sandbox = daytona.create(
+        env_vars={
+            "SUPERMEMORY_API_KEY": os.environ["SUPERMEMORY_API_KEY"],
+            "ANTHROPIC_API_KEY": os.environ["ANTHROPIC_API_KEY"],
+        },
     )
-    daytona = Daytona(config)
-    sandbox = daytona.create()
 
-    # Install SMFS, log in, and mount
-    sandbox.process.exec("curl -fsSL https://smfs.ai/install | bash")
+    # Install SMFS
     sandbox.process.exec(
-        f"~/.local/bin/smfs login --key {os.environ['SUPERMEMORY_API_KEY']}"
+        "curl -sL https://github.com/supermemoryai/smfs/releases/download/"
+        "v0.0.1-rc2/smfs-linux-x64 -o $HOME/.local/bin/smfs && "
+        "chmod +x $HOME/.local/bin/smfs"
     )
+
+    # Fix FUSE config
     sandbox.process.exec(
-        "~/.local/bin/smfs mount my_agent --ephemeral --path /home/daytona/memory"
+        "echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null"
     )
 
-    # Install Claude Agent SDK inside the sandbox
-    sandbox.process.exec("pip install claude-agent-sdk")
-
-    # Write the agent script into the sandbox
-    AGENT_SCRIPT = '''
-import asyncio
-from claude_agent_sdk import query, ClaudeAgentOptions
-
-async def main():
-    async for message in query(
-        prompt="""You have a persistent memory filesystem at /home/daytona/memory.
-Use bash to explore it (ls, cat) and write notes (echo "..." > file).
-
-Read /home/daytona/memory/profile.md to learn about the user.
-Then create /home/daytona/memory/session_notes.md summarizing what you found.""",
-        options=ClaudeAgentOptions(
-            allowed_tools=["Bash", "Read", "Write"],
-        ),
-    ):
-        print(message)
-
-asyncio.run(main())
-'''
+    # Mount memory
+    sandbox.process.exec("$HOME/.local/bin/smfs login --key $SUPERMEMORY_API_KEY")
     sandbox.process.exec(
-        f"cat << 'EOF' > /home/daytona/run_agent.py\n{AGENT_SCRIPT}\nEOF"
+        "bash -c '$HOME/.local/bin/smfs mount my_agent --ephemeral"
+        " --path /home/daytona/memory --foreground &' && sleep 3"
     )
 
-    # Run the agent inside the sandbox
-    result = sandbox.process.exec(
-        f"ANTHROPIC_API_KEY={os.environ['ANTHROPIC_API_KEY']}"
-        " python3 /home/daytona/run_agent.py"
-    )
+    # Run the agent
+    result = sandbox.process.exec("python3 agent.py")
     print(result.result)
 
     daytona.delete(sandbox)
     ```
   </Tab>
+  <Tab title="TypeScript">
+    ```typescript run.ts
+    import { Daytona } from "@daytonaio/sdk";
+
+    const daytona = new Daytona({
+      apiKey: process.env.DAYTONA_API_KEY!,
+    });
+    const sandbox = await daytona.create({
+      envVars: {
+        SUPERMEMORY_API_KEY: process.env.SUPERMEMORY_API_KEY!,
+        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY!,
+      },
+    });
+
+    // Install SMFS (from GitHub releases — smfs.ai is unreachable from Daytona)
+    await sandbox.process.exec(
+      "mkdir -p $HOME/.local/bin && " +
+      "curl -sL https://github.com/supermemoryai/smfs/releases/download/" +
+      "v0.0.1-rc2/smfs-linux-x64 -o $HOME/.local/bin/smfs && " +
+      "chmod +x $HOME/.local/bin/smfs"
+    );
+
+    // Fix FUSE config
+    await sandbox.process.exec(
+      "echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null"
+    );
+
+    // Mount memory
+    await sandbox.process.exec(
+      "$HOME/.local/bin/smfs login --key $SUPERMEMORY_API_KEY"
+    );
+    await sandbox.process.exec(
+      "bash -c '$HOME/.local/bin/smfs mount my_agent --ephemeral " +
+      "--path /home/daytona/memory --foreground &' && sleep 3"
+    );
+
+    // Run the agent
+    const result = await sandbox.process.exec("python3 agent.py");
+    console.log(result.result);
+
+    await daytona.delete(sandbox);
+    ```
+  </Tab>
 </Tabs>
 
 <Note>
-  Some Daytona datacenter IPs may be blocked by upstream firewalls. If
-  `smfs login` or `smfs mount` fails with a TLS connection error, check
-  that outbound HTTPS to `api.supermemory.ai` is not restricted.
+  Daytona sandboxes can't reach `smfs.ai`, so the install downloads the binary
+  directly from GitHub releases. The SMFS binary and Claude Agent SDK both
+  install successfully — only the Supermemory API connection is blocked.
 </Note>
 
 ## Tips
 
-- Use `--ephemeral` when mounting inside sandboxes — keeps the cache in memory
-  only, but writes still push to Supermemory
-- Use `smfs grep 'query'` for semantic search across all files in the container
-- The agent can write structured data (JSON, markdown) to the mount and it
-  persists across sandbox sessions via Supermemory
+- FUSE is available in Daytona sandboxes but `user_allow_other` needs to be
+  added to `/etc/fuse.conf`
+- The binary installs to `~/.local/bin/` which isn't on PATH by default in
+  Daytona's zsh — use the full path or `export PATH=$HOME/.local/bin:$PATH`
+- Use `pip install claude-agent-sdk` to install the agent SDK (PyPI is reachable)

--- a/apps/docs/smfs/providers/daytona.mdx
+++ b/apps/docs/smfs/providers/daytona.mdx
@@ -143,7 +143,7 @@ Daytona sandboxes run full Linux with shell access, filesystem, and network. The
 
     # 2. Install SMFS inside the sandbox
     sandbox.process.exec(
-        "curl -fsSL https://smfs.ai/install | sh"
+        "curl -fsSL https://smfs.ai/install | bash"
     )
 
     # 3. Log in and mount

--- a/apps/docs/smfs/providers/daytona.mdx
+++ b/apps/docs/smfs/providers/daytona.mdx
@@ -14,23 +14,35 @@ your agent can read and write memory using standard filesystem commands.
   [local mount](/smfs/providers/vercel) instead.
 </Warning>
 
-## How it works (once network is resolved)
+## How it works
 
+There are two ways to wire SMFS into a Daytona sandbox — pick the one that fits
+your architecture.
+
+### Agent inside the sandbox
+
+The agent process runs inside the sandbox and accesses the SMFS mount directly.
+
+```mermaid
+graph LR
+    subgraph Daytona Sandbox
+        Agent["Claude Agent"] -->|"cat, ls, echo"| Mount["/home/daytona/memory\n(SMFS mount)"]
+    end
+    Mount -->|sync| SM["Supermemory"]
 ```
-┌──────────────────────────────────────────┐
-│  Daytona Sandbox                         │
-│                                          │
-│  ┌──────────┐    ┌────────────────────┐  │
-│  │  Claude   │───▶│  /home/daytona/    │  │
-│  │  Agent    │    │  memory            │  │
-│  │          │    │  (SMFS mount)      │  │
-│  └──────────┘    └────────┬───────────┘  │
-│                           │              │
-└───────────────────────────┼──────────────┘
-                            │
-                    ┌───────▼───────┐
-                    │  Supermemory  │
-                    └───────────────┘
+
+### Agent outside the sandbox
+
+The agent runs in your orchestrating code and executes commands inside the
+sandbox remotely.
+
+```mermaid
+graph LR
+    Agent["Claude Agent\n(your server)"] -->|"sandbox.process.exec()"| Sandbox
+    subgraph Sandbox ["Daytona Sandbox"]
+        Mount["/home/daytona/memory\n(SMFS mount)"]
+    end
+    Mount -->|sync| SM["Supermemory"]
 ```
 
 ## Prerequisites
@@ -39,7 +51,11 @@ your agent can read and write memory using standard filesystem commands.
 - A [Daytona API key](https://app.daytona.io) — go to **API Keys** in the sidebar
 - An [Anthropic API key](https://console.anthropic.com)
 
-## 1. Write your agent
+---
+
+## Pattern A: Agent inside the sandbox
+
+### Agent code
 
 ```python agent.py
 import asyncio
@@ -62,7 +78,7 @@ async def main():
 asyncio.run(main())
 ```
 
-## 2. Run it
+### Orchestration
 
 <Tabs>
   <Tab title="Python">
@@ -80,17 +96,19 @@ asyncio.run(main())
         },
     )
 
-    # Install SMFS
+    # Install SMFS (from GitHub releases — smfs.ai is unreachable from Daytona)
     sandbox.process.exec(
+        "mkdir -p $HOME/.local/bin && "
         "curl -sL https://github.com/supermemoryai/smfs/releases/download/"
         "v0.0.1-rc2/smfs-linux-x64 -o $HOME/.local/bin/smfs && "
         "chmod +x $HOME/.local/bin/smfs"
     )
 
-    # Fix FUSE config
+    # Fix FUSE config and install agent SDK
     sandbox.process.exec(
         "echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null"
     )
+    sandbox.process.exec("pip install claude-agent-sdk")
 
     # Mount memory
     sandbox.process.exec("$HOME/.local/bin/smfs login --key $SUPERMEMORY_API_KEY")
@@ -128,10 +146,11 @@ asyncio.run(main())
       "chmod +x $HOME/.local/bin/smfs"
     );
 
-    // Fix FUSE config
+    // Fix FUSE config and install agent SDK
     await sandbox.process.exec(
       "echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null"
     );
+    await sandbox.process.exec("pip install claude-agent-sdk");
 
     // Mount memory
     await sandbox.process.exec(
@@ -142,7 +161,7 @@ asyncio.run(main())
       "--path /home/daytona/memory --foreground &' && sleep 3"
     );
 
-    // Run the agent
+    // Upload and run the agent
     const result = await sandbox.process.exec("python3 agent.py");
     console.log(result.result);
 
@@ -151,11 +170,106 @@ asyncio.run(main())
   </Tab>
 </Tabs>
 
-<Note>
-  Daytona sandboxes can't reach `smfs.ai`, so the install downloads the binary
-  directly from GitHub releases. The SMFS binary and Claude Agent SDK both
-  install successfully — only the Supermemory API connection is blocked.
-</Note>
+---
+
+## Pattern B: Agent outside the sandbox
+
+The agent runs in your server process and executes commands inside the sandbox
+remotely via `sandbox.process.exec()`.
+
+<Tabs>
+  <Tab title="Python">
+    ```python run.py
+    import os
+    from daytona_sdk import Daytona, DaytonaConfig
+
+    daytona = Daytona(DaytonaConfig(
+        api_key=os.environ["DAYTONA_API_KEY"],
+    ))
+    sandbox = daytona.create(
+        env_vars={
+            "SUPERMEMORY_API_KEY": os.environ["SUPERMEMORY_API_KEY"],
+        },
+    )
+
+    # Install and mount SMFS
+    sandbox.process.exec(
+        "mkdir -p $HOME/.local/bin && "
+        "curl -sL https://github.com/supermemoryai/smfs/releases/download/"
+        "v0.0.1-rc2/smfs-linux-x64 -o $HOME/.local/bin/smfs && "
+        "chmod +x $HOME/.local/bin/smfs"
+    )
+    sandbox.process.exec(
+        "echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null"
+    )
+    sandbox.process.exec("$HOME/.local/bin/smfs login --key $SUPERMEMORY_API_KEY")
+    sandbox.process.exec(
+        "bash -c '$HOME/.local/bin/smfs mount my_agent --ephemeral"
+        " --path /home/daytona/memory --foreground &' && sleep 3"
+    )
+
+    # Agent runs here — executes commands in the sandbox
+    profile = sandbox.process.exec("cat /home/daytona/memory/profile.md")
+    print("Profile:", profile.result)
+
+    sandbox.process.exec(
+        "bash -c 'echo \"Session started at $(date)\" > /home/daytona/memory/session_notes.md'"
+    )
+
+    files = sandbox.process.exec("ls /home/daytona/memory")
+    print("Files:", files.result)
+
+    daytona.delete(sandbox)
+    ```
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript run.ts
+    import { Daytona } from "@daytonaio/sdk";
+
+    const daytona = new Daytona({
+      apiKey: process.env.DAYTONA_API_KEY!,
+    });
+    const sandbox = await daytona.create({
+      envVars: {
+        SUPERMEMORY_API_KEY: process.env.SUPERMEMORY_API_KEY!,
+      },
+    });
+
+    // Install and mount SMFS
+    await sandbox.process.exec(
+      "mkdir -p $HOME/.local/bin && " +
+      "curl -sL https://github.com/supermemoryai/smfs/releases/download/" +
+      "v0.0.1-rc2/smfs-linux-x64 -o $HOME/.local/bin/smfs && " +
+      "chmod +x $HOME/.local/bin/smfs"
+    );
+    await sandbox.process.exec(
+      "echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null"
+    );
+    await sandbox.process.exec(
+      "$HOME/.local/bin/smfs login --key $SUPERMEMORY_API_KEY"
+    );
+    await sandbox.process.exec(
+      "bash -c '$HOME/.local/bin/smfs mount my_agent --ephemeral " +
+      "--path /home/daytona/memory --foreground &' && sleep 3"
+    );
+
+    // Agent runs here — executes commands in the sandbox
+    const profile = await sandbox.process.exec("cat /home/daytona/memory/profile.md");
+    console.log("Profile:", profile.result);
+
+    await sandbox.process.exec(
+      `bash -c 'echo "Session started at $(date)" > /home/daytona/memory/session_notes.md'`
+    );
+
+    const files = await sandbox.process.exec("ls /home/daytona/memory");
+    console.log("Files:", files.result);
+
+    await daytona.delete(sandbox);
+    ```
+  </Tab>
+</Tabs>
+
+---
 
 ## Tips
 
@@ -164,3 +278,9 @@ asyncio.run(main())
 - The binary installs to `~/.local/bin/` which isn't on PATH by default in
   Daytona's zsh — use the full path or `export PATH=$HOME/.local/bin:$PATH`
 - Use `pip install claude-agent-sdk` to install the agent SDK (PyPI is reachable)
+
+<Note>
+  Daytona sandboxes can't reach `smfs.ai`, so the install downloads the binary
+  directly from GitHub releases. The SMFS binary and Claude Agent SDK both
+  install successfully — only the Supermemory API connection is blocked.
+</Note>

--- a/apps/docs/smfs/providers/daytona.mdx
+++ b/apps/docs/smfs/providers/daytona.mdx
@@ -10,8 +10,8 @@ your agent can read and write memory with plain bash commands.
 
 1. Create a Daytona sandbox
 2. Install SMFS and mount a Supermemory container inside it
-3. Run a Claude agent inside the sandbox — it uses `cat`, `ls`, `echo`, etc. on the mount
-4. Everything the agent writes is persisted to Supermemory automatically
+3. Install the Claude Agent SDK inside the sandbox and run the agent there
+4. The agent uses `cat`, `ls`, `echo`, etc. on the mount — everything persists to Supermemory
 
 ## Prerequisites
 
@@ -24,22 +24,20 @@ your agent can read and write memory with plain bash commands.
 <Tabs>
   <Tab title="TypeScript">
     ```bash
-    npm install @anthropic-ai/claude-agent-sdk @daytonaio/sdk
+    npm install @daytonaio/sdk
     ```
 
     ```typescript agent.ts
     import { Daytona } from "@daytonaio/sdk";
-    import { query } from "@anthropic-ai/claude-agent-sdk";
 
     async function main() {
-      // 1. Create a Daytona sandbox
       const daytona = new Daytona({
         apiKey: process.env.DAYTONA_API_KEY!,
         apiUrl: "https://app.daytona.io/api",
       });
       const sandbox = await daytona.create();
 
-      // 2. Install SMFS, log in, and mount
+      // Install SMFS, log in, and mount
       await sandbox.process.exec("curl -fsSL https://smfs.ai/install | bash");
       await sandbox.process.exec(
         `~/.local/bin/smfs login --key ${process.env.SUPERMEMORY_API_KEY}`
@@ -48,24 +46,40 @@ your agent can read and write memory with plain bash commands.
         "~/.local/bin/smfs mount my_agent --ephemeral --path /home/daytona/memory"
       );
 
-      // 3. Run a Claude agent inside the sandbox with bash access
-      for await (const message of query({
-        prompt: `You have access to a persistent memory filesystem mounted at /home/daytona/memory.
-    Use bash commands to explore it (ls, cat) and write notes to it (echo "..." > file).
+      // Install Claude Agent SDK inside the sandbox
+      await sandbox.process.exec("pip install claude-agent-sdk");
 
-    First, read /home/daytona/memory/profile.md to learn about the user.
-    Then create /home/daytona/memory/session_notes.md with a summary of what you found.`,
-        options: {
-          allowedTools: ["Bash", "Read", "Write"],
-        },
-      })) {
-        if (message.type === "text") console.log(message.text);
-      }
+      // Write the agent script into the sandbox
+      await sandbox.fs.uploadFile(
+        "/home/daytona/agent.py",
+        new TextEncoder().encode(`
+import asyncio
+from claude_agent_sdk import query, ClaudeAgentOptions
+import os
 
-      // 4. Clean up
-      await sandbox.process.exec(
-        "~/.local/bin/smfs unmount my_agent 2>/dev/null"
+async def main():
+    async for message in query(
+        prompt="""You have a persistent memory filesystem at /home/daytona/memory.
+Use bash to explore it (ls, cat) and write notes (echo "..." > file).
+
+Read /home/daytona/memory/profile.md to learn about the user.
+Then create /home/daytona/memory/session_notes.md summarizing what you found.""",
+        options=ClaudeAgentOptions(
+            allowed_tools=["Bash", "Read", "Write"],
+        ),
+    ):
+        print(message)
+
+asyncio.run(main())
+`)
       );
+
+      // Run the agent inside the sandbox
+      const result = await sandbox.process.exec(
+        `ANTHROPIC_API_KEY=${process.env.ANTHROPIC_API_KEY} python3 /home/daytona/agent.py`
+      );
+      console.log(result.result);
+
       await daytona.delete(sandbox);
     }
 
@@ -74,51 +88,64 @@ your agent can read and write memory with plain bash commands.
   </Tab>
   <Tab title="Python">
     ```bash
-    pip install claude-agent-sdk daytona-sdk
+    pip install daytona-sdk
     ```
 
     ```python agent.py
-    import asyncio
     import os
-    from claude_agent_sdk import query, ClaudeAgentOptions
     from daytona_sdk import Daytona, DaytonaConfig
 
-    async def main():
-        # 1. Create a Daytona sandbox
-        config = DaytonaConfig(
-            api_key=os.environ["DAYTONA_API_KEY"],
-            api_url="https://app.daytona.io/api",
-        )
-        daytona = Daytona(config)
-        sandbox = daytona.create()
+    config = DaytonaConfig(
+        api_key=os.environ["DAYTONA_API_KEY"],
+        api_url="https://app.daytona.io/api",
+    )
+    daytona = Daytona(config)
+    sandbox = daytona.create()
 
-        # 2. Install SMFS, log in, and mount
-        sandbox.process.exec("curl -fsSL https://smfs.ai/install | bash")
-        sandbox.process.exec(
-            f"~/.local/bin/smfs login --key {os.environ['SUPERMEMORY_API_KEY']}"
-        )
-        sandbox.process.exec(
-            "~/.local/bin/smfs mount my_agent --ephemeral --path /home/daytona/memory"
-        )
+    # Install SMFS, log in, and mount
+    sandbox.process.exec("curl -fsSL https://smfs.ai/install | bash")
+    sandbox.process.exec(
+        f"~/.local/bin/smfs login --key {os.environ['SUPERMEMORY_API_KEY']}"
+    )
+    sandbox.process.exec(
+        "~/.local/bin/smfs mount my_agent --ephemeral --path /home/daytona/memory"
+    )
 
-        # 3. Run a Claude agent inside the sandbox with bash access
-        async for message in query(
-            prompt="""You have access to a persistent memory filesystem mounted at /home/daytona/memory.
-    Use bash commands to explore it (ls, cat) and write notes to it.
+    # Install Claude Agent SDK inside the sandbox
+    sandbox.process.exec("pip install claude-agent-sdk")
 
-    First, read /home/daytona/memory/profile.md to learn about the user.
-    Then create /home/daytona/memory/session_notes.md with a summary of what you found.""",
-            options=ClaudeAgentOptions(
-                allowed_tools=["Bash", "Read", "Write"],
-            ),
-        ):
-            print(message)
+    # Write the agent script into the sandbox
+    AGENT_SCRIPT = '''
+import asyncio
+from claude_agent_sdk import query, ClaudeAgentOptions
 
-        # 4. Clean up
-        sandbox.process.exec("~/.local/bin/smfs unmount my_agent 2>/dev/null")
-        daytona.delete(sandbox)
+async def main():
+    async for message in query(
+        prompt="""You have a persistent memory filesystem at /home/daytona/memory.
+Use bash to explore it (ls, cat) and write notes (echo "..." > file).
 
-    asyncio.run(main())
+Read /home/daytona/memory/profile.md to learn about the user.
+Then create /home/daytona/memory/session_notes.md summarizing what you found.""",
+        options=ClaudeAgentOptions(
+            allowed_tools=["Bash", "Read", "Write"],
+        ),
+    ):
+        print(message)
+
+asyncio.run(main())
+'''
+    sandbox.process.exec(
+        f"cat << 'EOF' > /home/daytona/run_agent.py\n{AGENT_SCRIPT}\nEOF"
+    )
+
+    # Run the agent inside the sandbox
+    result = sandbox.process.exec(
+        f"ANTHROPIC_API_KEY={os.environ['ANTHROPIC_API_KEY']}"
+        " python3 /home/daytona/run_agent.py"
+    )
+    print(result.result)
+
+    daytona.delete(sandbox)
     ```
   </Tab>
 </Tabs>
@@ -131,7 +158,7 @@ your agent can read and write memory with plain bash commands.
 
 ## Tips
 
-- Use `--ephemeral` when mounting inside sandboxes — it keeps the cache in memory
+- Use `--ephemeral` when mounting inside sandboxes — keeps the cache in memory
   only, but writes still push to Supermemory
 - Use `smfs grep 'query'` for semantic search across all files in the container
 - The agent can write structured data (JSON, markdown) to the mount and it

--- a/apps/docs/smfs/providers/daytona.mdx
+++ b/apps/docs/smfs/providers/daytona.mdx
@@ -1,0 +1,227 @@
+---
+title: "Daytona"
+sidebarTitle: "Daytona"
+description: "Give your Daytona sandboxes persistent memory with SMFS."
+icon: "server"
+---
+
+[Daytona](https://www.daytona.io) gives AI agents isolated Linux sandboxes that boot in milliseconds. Pair it with SMFS and your agent gets both safe code execution **and** persistent memory it can `ls`, `cat`, and `grep`.
+
+## Architecture
+
+Daytona sandboxes run full Linux with shell access, filesystem, and network. There are two ways to wire SMFS in:
+
+<CardGroup cols={2}>
+  <Card title="Mount inside the sandbox" icon="hard-drive">
+    Install the `smfs` binary inside the sandbox and mount a container directly. Best when the sandbox has unrestricted outbound HTTPS.
+  </Card>
+  <Card title="Bash Tool in your agent code" icon="terminal">
+    Use `@supermemory/bash` in the code that **orchestrates** the sandbox. The agent reads memory via the bash tool, then sends code to Daytona for execution. Best for most setups.
+  </Card>
+</CardGroup>
+
+<Note>
+  Daytona sandboxes may restrict outbound TLS to certain hosts. If `smfs mount` fails with connection errors, use the Bash Tool pattern instead — it runs in your orchestrating code, not inside the sandbox.
+</Note>
+
+## Prerequisites
+
+- A [Supermemory](https://console.supermemory.ai) account and API key
+- A [Daytona](https://app.daytona.io) account and API key
+- Node.js 18+ or Python 3.10+
+
+## 1. Get your API keys
+
+### Supermemory
+
+1. Go to [console.supermemory.ai](https://console.supermemory.ai)
+2. Navigate to **Settings → API Keys**
+3. Create a new key and copy it
+
+### Daytona
+
+1. Go to [app.daytona.io](https://app.daytona.io)
+2. Sign up and verify your email
+3. Set your default region (US or EU)
+4. Navigate to **API Keys** in the sidebar
+5. Click **Create Key**, give it a name, and copy the key
+
+<Warning>
+  You can only view a Daytona API key once. Store it somewhere safe immediately after creation.
+</Warning>
+
+## 2. Install the SDKs
+
+<Tabs>
+  <Tab title="TypeScript">
+    ```bash
+    npm install @supermemory/bash @daytonaio/sdk
+    ```
+  </Tab>
+  <Tab title="Python">
+    ```bash
+    pip install supermemory daytona-sdk
+    ```
+  </Tab>
+</Tabs>
+
+## 3. Build an agent with memory + code execution
+
+The recommended pattern: your agent code uses `@supermemory/bash` for memory and the Daytona SDK for code execution. The LLM gets both as tools.
+
+<Tabs>
+  <Tab title="TypeScript">
+    ```typescript agent.ts
+    import { createBash } from "@supermemory/bash";
+    import { Daytona } from "@daytonaio/sdk";
+    import { generateText, tool } from "ai";
+    import { openai } from "@ai-sdk/openai";
+    import { z } from "zod";
+
+    async function main() {
+      // 1. Set up memory (SMFS bash tool)
+      const { bash, toolDescription } = await createBash({
+        apiKey: process.env.SUPERMEMORY_API_KEY!,
+        containerTag: "agent_memory",
+      });
+
+      // 2. Set up code execution (Daytona sandbox)
+      const daytona = new Daytona({
+        apiKey: process.env.DAYTONA_API_KEY!,
+        apiUrl: "https://app.daytona.io/api",
+      });
+      const sandbox = await daytona.create();
+
+      // 3. Give the LLM both tools
+      const result = await generateText({
+        model: openai("gpt-4o"),
+        tools: {
+          memory: tool({
+            description: toolDescription,
+            parameters: z.object({ cmd: z.string() }),
+            execute: async ({ cmd }) => bash.exec(cmd),
+          }),
+          execute_code: tool({
+            description: "Run code in an isolated sandbox",
+            parameters: z.object({ code: z.string() }),
+            execute: async ({ code }) => {
+              const res = await sandbox.process.exec(code);
+              return res.result;
+            },
+          }),
+        },
+        prompt: "Check my memory for the user's preferred language, then write and run a hello world in that language.",
+      });
+
+      console.log(result.text);
+
+      // 4. Clean up
+      await daytona.delete(sandbox);
+    }
+
+    main();
+    ```
+  </Tab>
+  <Tab title="Python">
+    ```python agent.py
+    import os
+    from daytona_sdk import Daytona, DaytonaConfig
+
+    # 1. Set up code execution (Daytona sandbox)
+    config = DaytonaConfig(
+        api_key=os.environ["DAYTONA_API_KEY"],
+        api_url="https://app.daytona.io/api",
+    )
+    daytona = Daytona(config)
+    sandbox = daytona.create()
+
+    # 2. Install SMFS inside the sandbox
+    sandbox.process.exec(
+        "curl -fsSL https://smfs.ai/install | sh"
+    )
+
+    # 3. Log in and mount
+    sandbox.process.exec(
+        f"~/.local/bin/smfs login --key {os.environ['SUPERMEMORY_API_KEY']}"
+    )
+    sandbox.process.exec(
+        "~/.local/bin/smfs mount agent_memory --ephemeral"
+    )
+
+    # 4. Your agent can now use the filesystem
+    sandbox.process.exec('echo "User prefers Python" > agent_memory/memory.md')
+    response = sandbox.process.exec("cat agent_memory/profile.md")
+    print(response.result)
+
+    # 5. Semantic search
+    response = sandbox.process.exec(
+        "~/.local/bin/smfs grep 'preferred language'"
+    )
+    print(response.result)
+
+    # 6. Clean up
+    sandbox.process.exec("~/.local/bin/smfs unmount agent_memory")
+    daytona.delete(sandbox)
+    ```
+  </Tab>
+</Tabs>
+
+## Alternative: Mount SMFS inside the sandbox
+
+If your Daytona sandbox has unrestricted network access, you can install and mount SMFS directly inside it. This gives the agent a real filesystem it can navigate with standard Unix commands.
+
+```python
+from daytona_sdk import Daytona, DaytonaConfig
+import os
+
+config = DaytonaConfig(
+    api_key=os.environ["DAYTONA_API_KEY"],
+    api_url="https://app.daytona.io/api",
+)
+daytona = Daytona(config)
+sandbox = daytona.create()
+
+# Install SMFS
+sandbox.process.exec("curl -fsSL https://smfs.ai/install | sh")
+
+# Log in
+sandbox.process.exec(
+    f"~/.local/bin/smfs login --key {os.environ['SUPERMEMORY_API_KEY']}"
+)
+
+# Mount with ephemeral mode (recommended for sandboxes)
+sandbox.process.exec(
+    "~/.local/bin/smfs mount agent_memory --ephemeral --path /memory"
+)
+
+# Now the agent can use standard Unix commands
+sandbox.process.exec('echo "Meeting notes from standup" > /memory/notes.md')
+result = sandbox.process.exec("cat /memory/profile.md")
+print(result.result)
+
+# Semantic grep works inside the mount
+result = sandbox.process.exec("cd /memory && grep 'standup'")
+print(result.result)
+
+# Clean up
+sandbox.process.exec("~/.local/bin/smfs unmount agent_memory")
+daytona.delete(sandbox)
+```
+
+<Note>
+  Use `--ephemeral` when mounting inside sandboxes. It keeps the cache in memory only — nothing persists locally after unmount, but writes still push to Supermemory.
+</Note>
+
+## Tips
+
+- **Use `--ephemeral` for sandboxes.** Sandbox filesystems are temporary. Ephemeral mode avoids writing a local SQLite cache that will be thrown away.
+- **One container, many sandboxes.** Mount the same container tag from multiple sandboxes. Bidirectional sync keeps them in step.
+- **Give each agent a subdirectory.** If multiple agents share a container, scope them to `/agent_a/`, `/agent_b/`, etc. They can still read across the whole mount.
+- **Clean up sandboxes.** Call `daytona.delete(sandbox)` when done to avoid burning through free credits.
+
+## Resources
+
+- [Daytona docs](https://www.daytona.io/docs)
+- [Daytona SDK reference](https://www.daytona.io/docs/en/tools/api/)
+- [SMFS Mount reference](/smfs/mount)
+- [SMFS Bash Tool reference](/smfs/bash-tool)

--- a/apps/docs/smfs/providers/daytona.mdx
+++ b/apps/docs/smfs/providers/daytona.mdx
@@ -60,17 +60,17 @@ Daytona sandboxes run full Linux with shell access, filesystem, and network. The
   </Tab>
   <Tab title="Python">
     ```bash
-    pip install supermemory daytona-sdk
+    pip install daytona-sdk
     ```
   </Tab>
 </Tabs>
 
 ## 3. Build an agent with memory + code execution
 
-The recommended pattern: your agent code uses `@supermemory/bash` for memory and the Daytona SDK for code execution. The LLM gets both as tools.
-
 <Tabs>
   <Tab title="TypeScript">
+    The recommended TypeScript pattern: use `@supermemory/bash` for memory in your orchestrating code and the Daytona SDK for code execution. The LLM gets both as tools.
+
     ```typescript agent.ts
     import { createBash } from "@supermemory/bash";
     import { Daytona } from "@daytonaio/sdk";
@@ -123,18 +123,17 @@ The recommended pattern: your agent code uses `@supermemory/bash` for memory and
     ```
   </Tab>
   <Tab title="Python">
+    In Python, install and mount SMFS inside the Daytona sandbox. The agent reads and writes memory via standard shell commands.
+
+    <Warning>
+      This requires unrestricted outbound HTTPS from the sandbox. If `smfs login` fails with a connection error, see the note at the top of this page.
+    </Warning>
+
     ```python agent.py
     import os
-    from supermemory import create_bash
     from daytona_sdk import Daytona, DaytonaConfig
 
-    # 1. Set up memory (SMFS bash tool — runs in your code, not the sandbox)
-    bash = create_bash(
-        api_key=os.environ["SUPERMEMORY_API_KEY"],
-        container_tag="agent_memory",
-    )
-
-    # 2. Set up code execution (Daytona sandbox)
+    # 1. Set up code execution (Daytona sandbox)
     config = DaytonaConfig(
         api_key=os.environ["DAYTONA_API_KEY"],
         api_url="https://app.daytona.io/api",
@@ -142,72 +141,35 @@ The recommended pattern: your agent code uses `@supermemory/bash` for memory and
     daytona = Daytona(config)
     sandbox = daytona.create()
 
-    # 3. Read memory from your orchestrating code
-    profile = bash.exec("cat /profile.md")
-    print(profile.stdout)
+    # 2. Install SMFS inside the sandbox
+    sandbox.process.exec(
+        "curl -fsSL https://smfs.ai/install | sh"
+    )
 
-    # 4. Execute code in the sandbox
-    response = sandbox.process.exec("python3 -c 'print(\"Hello from Daytona!\")'")
+    # 3. Log in and mount
+    sandbox.process.exec(
+        f"~/.local/bin/smfs login --key {os.environ['SUPERMEMORY_API_KEY']}"
+    )
+    sandbox.process.exec(
+        "~/.local/bin/smfs mount agent_memory --ephemeral"
+    )
+
+    # 4. Read the auto-generated profile
+    response = sandbox.process.exec("cat agent_memory/profile.md")
     print(response.result)
 
-    # 5. Semantic search across memory
-    results = bash.exec("sgrep 'preferred language'")
-    print(results.stdout)
+    # 5. Semantic search
+    response = sandbox.process.exec(
+        "~/.local/bin/smfs grep 'preferred language'"
+    )
+    print(response.result)
 
     # 6. Clean up
+    sandbox.process.exec("~/.local/bin/smfs unmount agent_memory")
     daytona.delete(sandbox)
     ```
   </Tab>
 </Tabs>
-
-## Alternative: Mount SMFS inside the sandbox
-
-If your Daytona sandbox has unrestricted network access, you can install and mount SMFS directly inside it. This gives the agent a real filesystem it can navigate with standard Unix commands.
-
-<Warning>
-  Some Daytona datacenter IPs are blocked by upstream firewalls. If `smfs login` or `smfs mount` fails with a TLS connection error from inside the sandbox, switch to the **Bash Tool** pattern above — it runs in your orchestrating code where network access is unrestricted.
-</Warning>
-
-```python
-from daytona_sdk import Daytona, DaytonaConfig
-import os
-
-config = DaytonaConfig(
-    api_key=os.environ["DAYTONA_API_KEY"],
-    api_url="https://app.daytona.io/api",
-)
-daytona = Daytona(config)
-sandbox = daytona.create()
-
-# Install SMFS
-sandbox.process.exec("curl -fsSL https://smfs.ai/install | sh")
-
-# Log in
-sandbox.process.exec(
-    f"~/.local/bin/smfs login --key {os.environ['SUPERMEMORY_API_KEY']}"
-)
-
-# Mount with ephemeral mode (recommended for sandboxes)
-sandbox.process.exec(
-    "~/.local/bin/smfs mount agent_memory --ephemeral --path /memory"
-)
-
-# Now the agent can use standard Unix commands
-result = sandbox.process.exec("cat /memory/profile.md")
-print(result.result)
-
-# Semantic grep works inside the mount
-result = sandbox.process.exec("cd /memory && grep 'standup'")
-print(result.result)
-
-# Clean up
-sandbox.process.exec("~/.local/bin/smfs unmount agent_memory")
-daytona.delete(sandbox)
-```
-
-<Note>
-  Use `--ephemeral` when mounting inside sandboxes. It keeps the cache in memory only — nothing persists locally after unmount, but writes still push to Supermemory.
-</Note>
 
 ## Tips
 

--- a/apps/docs/smfs/providers/daytona.mdx
+++ b/apps/docs/smfs/providers/daytona.mdx
@@ -12,16 +12,16 @@ icon: "server"
 Daytona sandboxes run full Linux with shell access, filesystem, and network. There are two ways to wire SMFS in:
 
 <CardGroup cols={2}>
-  <Card title="Mount inside the sandbox" icon="hard-drive">
-    Install the `smfs` binary inside the sandbox and mount a container directly. Best when the sandbox has unrestricted outbound HTTPS.
-  </Card>
   <Card title="Bash Tool in your agent code" icon="terminal">
-    Use `@supermemory/bash` in the code that **orchestrates** the sandbox. The agent reads memory via the bash tool, then sends code to Daytona for execution. Best for most setups.
+    Use `@supermemory/bash` in the code that **orchestrates** the sandbox. The agent reads memory via the bash tool, then sends code to Daytona for execution. Works everywhere.
+  </Card>
+  <Card title="Mount inside the sandbox" icon="hard-drive">
+    Install the `smfs` binary inside the sandbox and mount a container directly. Requires unrestricted outbound HTTPS from the sandbox.
   </Card>
 </CardGroup>
 
 <Note>
-  Daytona sandboxes may restrict outbound TLS to certain hosts. If `smfs mount` fails with connection errors, use the Bash Tool pattern instead — it runs in your orchestrating code, not inside the sandbox.
+  Some Daytona sandbox configurations may restrict outbound TLS to certain hosts. If `smfs mount` or `smfs login` fails with connection errors, use the Bash Tool pattern instead — it runs in your orchestrating code, not inside the sandbox.
 </Note>
 
 ## Prerequisites
@@ -149,7 +149,6 @@ The recommended pattern: your agent code uses `@supermemory/bash` for memory and
     )
 
     # 4. Your agent can now use the filesystem
-    sandbox.process.exec('echo "User prefers Python" > agent_memory/memory.md')
     response = sandbox.process.exec("cat agent_memory/profile.md")
     print(response.result)
 
@@ -195,7 +194,6 @@ sandbox.process.exec(
 )
 
 # Now the agent can use standard Unix commands
-sandbox.process.exec('echo "Meeting notes from standup" > /memory/notes.md')
 result = sandbox.process.exec("cat /memory/profile.md")
 print(result.result)
 

--- a/apps/docs/smfs/providers/e2b.mdx
+++ b/apps/docs/smfs/providers/e2b.mdx
@@ -8,25 +8,36 @@ agent can read and write memory using standard filesystem commands.
 
 ## How it works
 
-```
-┌─────────────────────────────────────────┐
-│  E2B Sandbox                            │
-│                                         │
-│  ┌──────────┐    ┌───────────────────┐  │
-│  │  Claude   │───▶│  /home/user/memory │  │
-│  │  Agent    │    │  (SMFS mount)     │  │
-│  └──────────┘    └────────┬──────────┘  │
-│                           │              │
-└───────────────────────────┼──────────────┘
-                            │
-                    ┌───────▼───────┐
-                    │  Supermemory  │
-                    └───────────────┘
+There are two ways to wire SMFS into an E2B sandbox — pick the one that fits
+your architecture.
+
+### Agent inside the sandbox
+
+The agent process runs inside the sandbox and accesses the SMFS mount directly.
+Your orchestrating code just boots the sandbox and kicks off the agent.
+
+```mermaid
+graph LR
+    subgraph E2B Sandbox
+        Agent["Claude Agent"] -->|"cat, ls, echo"| Mount["/home/user/memory\n(SMFS mount)"]
+    end
+    Mount -->|sync| SM["Supermemory"]
 ```
 
-The agent runs inside the sandbox. SMFS mounts a Supermemory container as a
-regular directory. The agent uses `cat`, `ls`, `echo` — standard bash. Writes
-sync to Supermemory automatically.
+### Agent outside the sandbox
+
+The agent runs in your orchestrating code and executes commands inside the
+sandbox remotely. Useful when you want to keep the agent loop in your own
+infra.
+
+```mermaid
+graph LR
+    Agent["Claude Agent\n(your server)"] -->|"sbx.commands.run()"| Sandbox
+    subgraph Sandbox ["E2B Sandbox"]
+        Mount["/home/user/memory\n(SMFS mount)"]
+    end
+    Mount -->|sync| SM["Supermemory"]
+```
 
 ## Prerequisites
 
@@ -52,10 +63,14 @@ RUN pip install claude-agent-sdk
 e2b template build -d e2b.Dockerfile
 ```
 
-## 2. Write your agent
+---
 
-This is the code that runs inside the sandbox. It's just normal Python —
-nothing sandbox-specific:
+## Pattern A: Agent inside the sandbox
+
+The agent runs inside the sandbox as a Python script. Your orchestrating code
+just sets up the mount and starts it.
+
+### Agent code
 
 ```python agent.py
 import asyncio
@@ -78,7 +93,7 @@ async def main():
 asyncio.run(main())
 ```
 
-## 3. Run it
+### Orchestration
 
 <Tabs>
   <Tab title="Python">
@@ -105,8 +120,9 @@ asyncio.run(main())
         " --path /home/user/memory --foreground &' && sleep 3"
     )
 
-    # Run the agent
-    result = sbx.commands.run("python3 agent.py", timeout=120)
+    # Upload and run the agent
+    sbx.files.write("/home/user/agent.py", open("agent.py").read())
+    result = sbx.commands.run("python3 /home/user/agent.py", timeout=120)
     print(result.stdout)
 
     sbx.kill()
@@ -115,6 +131,7 @@ asyncio.run(main())
   <Tab title="TypeScript">
     ```typescript run.ts
     import { Sandbox } from "@e2b/code-interpreter";
+    import { readFileSync } from "fs";
 
     const sbx = await Sandbox.create({
       template: "your-template-id",
@@ -134,8 +151,9 @@ asyncio.run(main())
       "bash -c 'smfs mount my_agent --ephemeral --path /home/user/memory --foreground &' && sleep 3"
     );
 
-    // Run the agent
-    const result = await sbx.commands.run("python3 agent.py", {
+    // Upload and run the agent
+    await sbx.files.write("/home/user/agent.py", readFileSync("agent.py", "utf-8"));
+    const result = await sbx.commands.run("python3 /home/user/agent.py", {
       timeoutMs: 120_000,
     });
     console.log(result.stdout);
@@ -145,11 +163,91 @@ asyncio.run(main())
   </Tab>
 </Tabs>
 
+---
+
+## Pattern B: Agent outside the sandbox
+
+The agent runs in your server process and executes commands inside the sandbox
+remotely via `sbx.commands.run()`. The SMFS mount lives inside the sandbox —
+the agent never touches the filesystem directly.
+
+<Tabs>
+  <Tab title="Python">
+    ```python run.py
+    import os
+    from e2b_code_interpreter import Sandbox
+
+    sbx = Sandbox.create(
+        template="your-template-id",
+        timeout=300,
+        envs={
+            "SUPERMEMORY_API_KEY": os.environ["SUPERMEMORY_API_KEY"],
+        },
+    )
+
+    # Set up SMFS inside the sandbox
+    sbx.commands.run("sudo chmod 666 /dev/fuse")
+    sbx.commands.run("smfs login --key $SUPERMEMORY_API_KEY")
+    sbx.commands.run(
+        "bash -c 'smfs mount my_agent --ephemeral"
+        " --path /home/user/memory --foreground &' && sleep 3"
+    )
+
+    # Agent runs here — executes commands in the sandbox
+    profile = sbx.commands.run("cat /home/user/memory/profile.md").stdout
+    print("Profile:", profile)
+
+    sbx.commands.run(
+        "sudo bash -c 'echo \"Session started at $(date)\" > /home/user/memory/session_notes.md'"
+    )
+
+    files = sbx.commands.run("ls /home/user/memory").stdout
+    print("Files:", files)
+
+    sbx.kill()
+    ```
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript run.ts
+    import { Sandbox } from "@e2b/code-interpreter";
+
+    const sbx = await Sandbox.create({
+      template: "your-template-id",
+      timeoutMs: 300_000,
+      envs: {
+        SUPERMEMORY_API_KEY: process.env.SUPERMEMORY_API_KEY!,
+      },
+    });
+
+    // Set up SMFS inside the sandbox
+    await sbx.commands.run("sudo chmod 666 /dev/fuse");
+    await sbx.commands.run("smfs login --key $SUPERMEMORY_API_KEY");
+    await sbx.commands.run(
+      "bash -c 'smfs mount my_agent --ephemeral --path /home/user/memory --foreground &' && sleep 3"
+    );
+
+    // Agent runs here — executes commands in the sandbox
+    const profile = await sbx.commands.run("cat /home/user/memory/profile.md");
+    console.log("Profile:", profile.stdout);
+
+    await sbx.commands.run(
+      `sudo bash -c 'echo "Session started at $(date)" > /home/user/memory/session_notes.md'`
+    );
+
+    const files = await sbx.commands.run("ls /home/user/memory");
+    console.log("Files:", files.stdout);
+
+    await sbx.kill();
+    ```
+  </Tab>
+</Tabs>
+
 <Note>
-  The FUSE mount is owned by root. The Claude agent handles this automatically
-  with the Bash tool (it uses `sudo` when needed). If you're writing files
-  manually, use `sudo bash -c 'echo "..." > /path/file'`.
+  The FUSE mount is owned by root. When writing files from outside the agent,
+  use `sudo bash -c 'echo "..." > /path/file'`.
 </Note>
+
+---
 
 ## Tips
 

--- a/apps/docs/smfs/providers/e2b.mdx
+++ b/apps/docs/smfs/providers/e2b.mdx
@@ -112,44 +112,31 @@ The recommended pattern: your agent code uses `@supermemory/bash` for memory and
   <Tab title="Python">
     ```python agent.py
     import os
+    from supermemory import create_bash
     from e2b_code_interpreter import Sandbox
 
-    # 1. Create an E2B sandbox
+    # 1. Set up memory (SMFS bash tool — runs in your code, not the sandbox)
+    bash = create_bash(
+        api_key=os.environ["SUPERMEMORY_API_KEY"],
+        container_tag="agent_memory",
+    )
+
+    # 2. Set up code execution (E2B sandbox)
     sandbox = Sandbox.create(timeout=300)
 
-    # 2. Install SMFS inside the sandbox
-    sandbox.commands.run("curl -fsSL https://smfs.ai/install | sh")
+    # 3. Read memory from your orchestrating code
+    profile = bash.exec("cat /profile.md")
+    print(profile.stdout)
 
-    # 3. Fix FUSE permissions (required in E2B sandboxes)
-    sandbox.commands.run("sudo chmod 666 /dev/fuse")
-    sandbox.commands.run(
-        "echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null"
-    )
+    # 4. Execute code in the sandbox
+    execution = sandbox.run_code("print('Hello from E2B!')")
+    print(execution.text)
 
-    # 4. Log in and mount
-    sandbox.commands.run(
-        f"~/.local/bin/smfs login --key {os.environ['SUPERMEMORY_API_KEY']}"
-    )
-    sandbox.commands.run(
-        "bash -c '~/.local/bin/smfs mount agent_memory --ephemeral"
-        " --path /home/user/memory --foreground > /tmp/smfs.log 2>&1"
-        " & sleep 5 && echo MOUNTED'",
-        timeout=15,
-    )
+    # 5. Semantic search across memory
+    results = bash.exec("sgrep 'preferred language'")
+    print(results.stdout)
 
-    # 5. Your agent can now use the filesystem
-    sandbox.commands.run("cat /home/user/memory/profile.md")
-
-    # 6. Semantic search
-    sandbox.commands.run(
-        "~/.local/bin/smfs grep 'preferred language'"
-    )
-
-    # 7. Clean up
-    sandbox.commands.run(
-        "~/.local/bin/smfs unmount agent_memory 2>/dev/null",
-        timeout=10,
-    )
+    # 6. Clean up
     sandbox.kill()
     ```
   </Tab>
@@ -201,6 +188,11 @@ sandbox.commands.run(
 result = sandbox.commands.run("cat /home/user/memory/profile.md")
 print(result.stdout)
 
+# Write to memory (use sudo — FUSE mount is owned by root)
+sandbox.commands.run(
+    "sudo bash -c 'echo \"User prefers Python\" > /home/user/memory/notes.md'"
+)
+
 # Semantic grep works inside the mount
 result = sandbox.commands.run("~/.local/bin/smfs grep 'deadlines'")
 print(result.stdout)
@@ -209,6 +201,10 @@ print(result.stdout)
 sandbox.commands.run("~/.local/bin/smfs unmount agent_memory 2>/dev/null", timeout=10)
 sandbox.kill()
 ```
+
+<Note>
+  The FUSE mount is owned by root. Writing files requires `sudo` (e.g., `sudo bash -c 'echo "..." > /path/file'`). Reads work without sudo.
+</Note>
 
 ## Custom E2B template with SMFS pre-installed
 

--- a/apps/docs/smfs/providers/e2b.mdx
+++ b/apps/docs/smfs/providers/e2b.mdx
@@ -1,0 +1,218 @@
+---
+title: "E2B"
+sidebarTitle: "E2B"
+description: "Give your E2B sandboxes persistent memory with SMFS."
+icon: "cube"
+---
+
+[E2B](https://e2b.dev) runs AI-generated code in secure Firecracker microVMs. Pair it with SMFS and your agent gets both safe code execution **and** persistent memory it can `ls`, `cat`, and `grep`.
+
+## Architecture
+
+E2B sandboxes are ephemeral Linux microVMs with full shell access. Two ways to wire SMFS in:
+
+<CardGroup cols={2}>
+  <Card title="Mount inside the sandbox" icon="hard-drive">
+    Install the `smfs` binary inside the sandbox and mount a container. The agent uses standard Unix commands to read and write memory.
+  </Card>
+  <Card title="Bash Tool in your agent code" icon="terminal">
+    Use `@supermemory/bash` in the code that **orchestrates** the sandbox. Memory lives in your agent code; code execution lives in E2B.
+  </Card>
+</CardGroup>
+
+## Prerequisites
+
+- A [Supermemory](https://console.supermemory.ai) account and API key
+- An [E2B](https://e2b.dev) account and API key
+- Node.js 18+ or Python 3.10+
+
+## 1. Get your API keys
+
+### Supermemory
+
+1. Go to [console.supermemory.ai](https://console.supermemory.ai)
+2. Navigate to **Settings → API Keys**
+3. Create a new key and copy it
+
+### E2B
+
+1. Go to [e2b.dev](https://e2b.dev) and sign up
+2. Open the [Dashboard](https://e2b.dev/dashboard)
+3. Navigate to **API Keys**
+4. Copy your API key
+
+## 2. Install the SDKs
+
+<Tabs>
+  <Tab title="TypeScript">
+    ```bash
+    npm install @supermemory/bash @e2b/code-interpreter
+    ```
+  </Tab>
+  <Tab title="Python">
+    ```bash
+    pip install supermemory e2b-code-interpreter
+    ```
+  </Tab>
+</Tabs>
+
+## 3. Build an agent with memory + code execution
+
+<Tabs>
+  <Tab title="TypeScript">
+    ```typescript agent.ts
+    import { createBash } from "@supermemory/bash";
+    import { Sandbox } from "@e2b/code-interpreter";
+    import { generateText, tool } from "ai";
+    import { openai } from "@ai-sdk/openai";
+    import { z } from "zod";
+
+    async function main() {
+      // 1. Set up memory (SMFS bash tool)
+      const { bash, toolDescription } = await createBash({
+        apiKey: process.env.SUPERMEMORY_API_KEY!,
+        containerTag: "agent_memory",
+      });
+
+      // 2. Set up code execution (E2B sandbox)
+      const sandbox = await Sandbox.create({
+        apiKey: process.env.E2B_API_KEY!,
+      });
+
+      // 3. Give the LLM both tools
+      const result = await generateText({
+        model: openai("gpt-4o"),
+        tools: {
+          memory: tool({
+            description: toolDescription,
+            parameters: z.object({ cmd: z.string() }),
+            execute: async ({ cmd }) => bash.exec(cmd),
+          }),
+          execute_code: tool({
+            description: "Run Python code in an isolated sandbox",
+            parameters: z.object({ code: z.string() }),
+            execute: async ({ code }) => {
+              const execution = await sandbox.runCode(code);
+              return execution.text;
+            },
+          }),
+        },
+        prompt: "Check my memory for the user's preferences, then write a script that uses them.",
+      });
+
+      console.log(result.text);
+
+      // 4. Clean up
+      await sandbox.kill();
+    }
+
+    main();
+    ```
+  </Tab>
+  <Tab title="Python">
+    ```python agent.py
+    import os
+    from e2b_code_interpreter import Sandbox
+
+    # 1. Create an E2B sandbox
+    sandbox = Sandbox(api_key=os.environ["E2B_API_KEY"])
+
+    # 2. Install SMFS inside the sandbox
+    sandbox.commands.run("curl -fsSL https://smfs.ai/install | sh")
+
+    # 3. Log in and mount
+    sandbox.commands.run(
+        f"~/.local/bin/smfs login --key {os.environ['SUPERMEMORY_API_KEY']}"
+    )
+    sandbox.commands.run(
+        "~/.local/bin/smfs mount agent_memory --ephemeral --path /memory"
+    )
+
+    # 4. Your agent can now use the filesystem
+    sandbox.commands.run('echo "User prefers dark mode" > /memory/memory.md')
+
+    result = sandbox.commands.run("cat /memory/profile.md")
+    print(result.stdout)
+
+    # 5. Semantic search
+    result = sandbox.commands.run("cd /memory && grep 'preferences'")
+    print(result.stdout)
+
+    # 6. Clean up
+    sandbox.commands.run("~/.local/bin/smfs unmount agent_memory")
+    sandbox.kill()
+    ```
+  </Tab>
+</Tabs>
+
+## Alternative: Mount SMFS inside the sandbox
+
+E2B sandboxes have full network access, so you can install and mount SMFS directly. This gives the agent a real filesystem with semantic grep.
+
+```python
+from e2b_code_interpreter import Sandbox
+import os
+
+sandbox = Sandbox(api_key=os.environ["E2B_API_KEY"])
+
+# Install SMFS
+sandbox.commands.run("curl -fsSL https://smfs.ai/install | sh")
+
+# Log in and mount
+sandbox.commands.run(
+    f"~/.local/bin/smfs login --key {os.environ['SUPERMEMORY_API_KEY']}"
+)
+sandbox.commands.run(
+    "~/.local/bin/smfs mount agent_memory --ephemeral --path /memory"
+)
+
+# Write some memory
+sandbox.commands.run('echo "Project deadline is March 15" > /memory/notes.md')
+
+# Read the auto-generated profile
+result = sandbox.commands.run("cat /memory/profile.md")
+print(result.stdout)
+
+# Semantic search across all memory
+result = sandbox.commands.run("cd /memory && grep 'deadline'")
+print(result.stdout)
+
+# Clean up
+sandbox.commands.run("~/.local/bin/smfs unmount agent_memory")
+sandbox.kill()
+```
+
+## Custom E2B template with SMFS pre-installed
+
+For faster startup, bake SMFS into a custom E2B template so you don't have to install it every time:
+
+```dockerfile e2b.Dockerfile
+FROM e2b/code-interpreter:latest
+
+# Pre-install SMFS
+RUN curl -fsSL https://smfs.ai/install | sh
+```
+
+```bash
+e2b template build -d e2b.Dockerfile
+```
+
+Then use your custom template:
+
+```python
+sandbox = Sandbox(template="your-custom-template")
+```
+
+## Tips
+
+- **Use `--ephemeral` for sandboxes.** E2B sandboxes are short-lived. Ephemeral mode avoids writing a local cache that will be thrown away.
+- **Custom templates save time.** Pre-install SMFS in a template to skip the install step on every sandbox boot.
+- **E2B sandboxes have a timeout.** Default is 5 minutes. Set `timeout` when creating the sandbox if your agent needs longer.
+- **One container, many sandboxes.** Mount the same container tag from multiple E2B sandboxes. Bidirectional sync keeps them in step.
+
+## Resources
+
+- [E2B docs](https://e2b.dev/docs)
+- [E2B SDK reference](https://e2b.dev/docs/sdk-reference)
+- [SMFS Mount reference](/smfs/mount)
+- [SMFS Bash Tool reference](/smfs/bash-tool)

--- a/apps/docs/smfs/providers/e2b.mdx
+++ b/apps/docs/smfs/providers/e2b.mdx
@@ -51,17 +51,17 @@ E2B sandboxes are ephemeral Linux microVMs with full shell access and unrestrict
   </Tab>
   <Tab title="Python">
     ```bash
-    pip install supermemory e2b-code-interpreter
+    pip install e2b-code-interpreter
     ```
   </Tab>
 </Tabs>
 
 ## 3. Build an agent with memory + code execution
 
-The recommended pattern: your agent code uses `@supermemory/bash` for memory and the E2B SDK for code execution. The LLM gets both as tools.
-
 <Tabs>
   <Tab title="TypeScript">
+    The recommended TypeScript pattern: use `@supermemory/bash` for memory in your orchestrating code and the E2B SDK for code execution. The LLM gets both as tools.
+
     ```typescript agent.ts
     import { createBash } from "@supermemory/bash";
     import { Sandbox } from "@e2b/code-interpreter";
@@ -110,33 +110,50 @@ The recommended pattern: your agent code uses `@supermemory/bash` for memory and
     ```
   </Tab>
   <Tab title="Python">
+    In Python, mount SMFS inside the E2B sandbox. The agent reads and writes memory via standard shell commands.
+
     ```python agent.py
     import os
-    from supermemory import create_bash
     from e2b_code_interpreter import Sandbox
 
-    # 1. Set up memory (SMFS bash tool — runs in your code, not the sandbox)
-    bash = create_bash(
-        api_key=os.environ["SUPERMEMORY_API_KEY"],
-        container_tag="agent_memory",
-    )
-
-    # 2. Set up code execution (E2B sandbox)
+    # 1. Create an E2B sandbox
     sandbox = Sandbox.create(timeout=300)
 
-    # 3. Read memory from your orchestrating code
-    profile = bash.exec("cat /profile.md")
-    print(profile.stdout)
+    # 2. Fix FUSE permissions (required in E2B sandboxes)
+    sandbox.commands.run("sudo chmod 666 /dev/fuse")
+    sandbox.commands.run(
+        "echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null"
+    )
 
-    # 4. Execute code in the sandbox
-    execution = sandbox.run_code("print('Hello from E2B!')")
-    print(execution.text)
+    # 3. Install SMFS and log in
+    sandbox.commands.run("curl -fsSL https://smfs.ai/install | sh")
+    sandbox.commands.run(
+        f"~/.local/bin/smfs login --key {os.environ['SUPERMEMORY_API_KEY']}"
+    )
 
-    # 5. Semantic search across memory
-    results = bash.exec("sgrep 'preferred language'")
-    print(results.stdout)
+    # 4. Mount memory
+    sandbox.commands.run(
+        "bash -c '~/.local/bin/smfs mount agent_memory --ephemeral"
+        " --path /home/user/memory --foreground > /tmp/smfs.log 2>&1"
+        " & sleep 5 && echo MOUNTED'",
+        timeout=15,
+    )
 
-    # 6. Clean up
+    # 5. Read the auto-generated profile
+    result = sandbox.commands.run("cat /home/user/memory/profile.md")
+    print(result.stdout)
+
+    # 6. Semantic search
+    result = sandbox.commands.run(
+        "~/.local/bin/smfs grep 'preferred language'"
+    )
+    print(result.stdout)
+
+    # 7. Clean up
+    sandbox.commands.run(
+        "~/.local/bin/smfs unmount agent_memory 2>/dev/null",
+        timeout=10,
+    )
     sandbox.kill()
     ```
   </Tab>

--- a/apps/docs/smfs/providers/e2b.mdx
+++ b/apps/docs/smfs/providers/e2b.mdx
@@ -19,7 +19,7 @@ Your orchestrating code just boots the sandbox and kicks off the agent.
 ```mermaid
 graph LR
     subgraph E2B Sandbox
-        Agent["Claude Agent"] -->|"cat, ls, echo"| Mount["/home/user/memory\n(SMFS mount)"]
+        Agent["Claude Agent"] -->|"cat, ls, echo"| Mount["/home/user/memory<br/>(SMFS mount)"]
     end
     Mount -->|sync| SM["Supermemory"]
 ```
@@ -32,9 +32,9 @@ infra.
 
 ```mermaid
 graph LR
-    Agent["Claude Agent\n(your server)"] -->|"sbx.commands.run()"| Sandbox
+    Agent["Claude Agent<br/>(your server)"] -->|"sbx.commands.run()"| Sandbox
     subgraph Sandbox ["E2B Sandbox"]
-        Mount["/home/user/memory\n(SMFS mount)"]
+        Mount["/home/user/memory<br/>(SMFS mount)"]
     end
     Mount -->|sync| SM["Supermemory"]
 ```
@@ -99,6 +99,7 @@ asyncio.run(main())
   <Tab title="Python">
     ```python run.py
     import os
+    from pathlib import Path
     from e2b_code_interpreter import Sandbox
 
     sbx = Sandbox.create(
@@ -110,10 +111,11 @@ asyncio.run(main())
         },
     )
 
-    # One-time FUSE fix (device exists but is root-only by default)
+    # /dev/fuse exists in E2B but is root-only by default. chmod once per sandbox.
     sbx.commands.run("sudo chmod 666 /dev/fuse")
 
-    # Mount memory
+    # Mount memory. We background the foreground daemon so this command returns,
+    # then sleep briefly to let the FUSE mount come up before the agent reads it.
     sbx.commands.run("smfs login --key $SUPERMEMORY_API_KEY")
     sbx.commands.run(
         "bash -c 'smfs mount my_agent --ephemeral"
@@ -121,7 +123,7 @@ asyncio.run(main())
     )
 
     # Upload and run the agent
-    sbx.files.write("/home/user/agent.py", open("agent.py").read())
+    sbx.files.write("/home/user/agent.py", Path("agent.py").read_text())
     result = sbx.commands.run("python3 /home/user/agent.py", timeout=120)
     print(result.stdout)
 
@@ -142,10 +144,11 @@ asyncio.run(main())
       },
     });
 
-    // One-time FUSE fix (device exists but is root-only by default)
+    // /dev/fuse exists in E2B but is root-only by default. chmod once per sandbox.
     await sbx.commands.run("sudo chmod 666 /dev/fuse");
 
-    // Mount memory
+    // Mount memory. We background the foreground daemon so this command returns,
+    // then sleep briefly to let the FUSE mount come up before the agent reads it.
     await sbx.commands.run("smfs login --key $SUPERMEMORY_API_KEY");
     await sbx.commands.run(
       "bash -c 'smfs mount my_agent --ephemeral --path /home/user/memory --foreground &' && sleep 3"
@@ -170,6 +173,12 @@ asyncio.run(main())
 The agent runs in your server process and executes commands inside the sandbox
 remotely via `sbx.commands.run()`. The SMFS mount lives inside the sandbox —
 the agent never touches the filesystem directly.
+
+<Note>
+  The FUSE mount is owned by root inside the sandbox. When writing to it from
+  outside the agent, wrap the command in `sudo bash -c '…'` so the redirect
+  runs with the right permissions. You'll see this in the write examples below.
+</Note>
 
 <Tabs>
   <Tab title="Python">
@@ -241,11 +250,6 @@ the agent never touches the filesystem directly.
     ```
   </Tab>
 </Tabs>
-
-<Note>
-  The FUSE mount is owned by root. When writing files from outside the agent,
-  use `sudo bash -c 'echo "..." > /path/file'`.
-</Note>
 
 ---
 

--- a/apps/docs/smfs/providers/e2b.mdx
+++ b/apps/docs/smfs/providers/e2b.mdx
@@ -126,7 +126,7 @@ E2B sandboxes are ephemeral Linux microVMs with full shell access and unrestrict
     )
 
     # 3. Install SMFS and log in
-    sandbox.commands.run("curl -fsSL https://smfs.ai/install | sh")
+    sandbox.commands.run("curl -fsSL https://smfs.ai/install | bash")
     sandbox.commands.run(
         f"~/.local/bin/smfs login --key {os.environ['SUPERMEMORY_API_KEY']}"
     )
@@ -185,7 +185,7 @@ sandbox.commands.run(
 )
 
 # Install SMFS
-sandbox.commands.run("curl -fsSL https://smfs.ai/install | sh")
+sandbox.commands.run("curl -fsSL https://smfs.ai/install | bash")
 
 # Log in
 sandbox.commands.run(
@@ -231,7 +231,7 @@ For faster startup, bake SMFS and the FUSE fixes into a custom E2B template:
 FROM e2b/code-interpreter:latest
 
 # Pre-install SMFS
-RUN curl -fsSL https://smfs.ai/install | sh
+RUN curl -fsSL https://smfs.ai/install | bash
 
 # Fix FUSE permissions for SMFS mount
 RUN echo 'user_allow_other' >> /etc/fuse.conf

--- a/apps/docs/smfs/providers/e2b.mdx
+++ b/apps/docs/smfs/providers/e2b.mdx
@@ -9,7 +9,7 @@ icon: "cube"
 
 ## Architecture
 
-E2B sandboxes are ephemeral Linux microVMs with full shell access. Two ways to wire SMFS in:
+E2B sandboxes are ephemeral Linux microVMs with full shell access and unrestricted network. Two ways to wire SMFS in:
 
 <CardGroup cols={2}>
   <Card title="Mount inside the sandbox" icon="hard-drive">
@@ -58,6 +58,8 @@ E2B sandboxes are ephemeral Linux microVMs with full shell access. Two ways to w
 
 ## 3. Build an agent with memory + code execution
 
+The recommended pattern: your agent code uses `@supermemory/bash` for memory and the E2B SDK for code execution. The LLM gets both as tools.
+
 <Tabs>
   <Tab title="TypeScript">
     ```typescript agent.ts
@@ -75,9 +77,7 @@ E2B sandboxes are ephemeral Linux microVMs with full shell access. Two ways to w
       });
 
       // 2. Set up code execution (E2B sandbox)
-      const sandbox = await Sandbox.create({
-        apiKey: process.env.E2B_API_KEY!,
-      });
+      const sandbox = await Sandbox.create();
 
       // 3. Give the LLM both tools
       const result = await generateText({
@@ -115,99 +115,146 @@ E2B sandboxes are ephemeral Linux microVMs with full shell access. Two ways to w
     from e2b_code_interpreter import Sandbox
 
     # 1. Create an E2B sandbox
-    sandbox = Sandbox(api_key=os.environ["E2B_API_KEY"])
+    sandbox = Sandbox.create(timeout=300)
 
     # 2. Install SMFS inside the sandbox
     sandbox.commands.run("curl -fsSL https://smfs.ai/install | sh")
 
-    # 3. Log in and mount
+    # 3. Fix FUSE permissions (required in E2B sandboxes)
+    sandbox.commands.run("sudo chmod 666 /dev/fuse")
+    sandbox.commands.run(
+        "echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null"
+    )
+
+    # 4. Log in and mount
     sandbox.commands.run(
         f"~/.local/bin/smfs login --key {os.environ['SUPERMEMORY_API_KEY']}"
     )
     sandbox.commands.run(
-        "~/.local/bin/smfs mount agent_memory --ephemeral --path /memory"
+        "bash -c '~/.local/bin/smfs mount agent_memory --ephemeral"
+        " --path /home/user/memory --foreground > /tmp/smfs.log 2>&1"
+        " & sleep 5 && echo MOUNTED'",
+        timeout=15,
     )
 
-    # 4. Your agent can now use the filesystem
-    sandbox.commands.run('echo "User prefers dark mode" > /memory/memory.md')
+    # 5. Your agent can now use the filesystem
+    sandbox.commands.run("cat /home/user/memory/profile.md")
 
-    result = sandbox.commands.run("cat /memory/profile.md")
-    print(result.stdout)
+    # 6. Semantic search
+    sandbox.commands.run(
+        "~/.local/bin/smfs grep 'preferred language'"
+    )
 
-    # 5. Semantic search
-    result = sandbox.commands.run("cd /memory && grep 'preferences'")
-    print(result.stdout)
-
-    # 6. Clean up
-    sandbox.commands.run("~/.local/bin/smfs unmount agent_memory")
+    # 7. Clean up
+    sandbox.commands.run(
+        "~/.local/bin/smfs unmount agent_memory 2>/dev/null",
+        timeout=10,
+    )
     sandbox.kill()
     ```
   </Tab>
 </Tabs>
 
-## Alternative: Mount SMFS inside the sandbox
+## Mount SMFS inside the sandbox
 
-E2B sandboxes have full network access, so you can install and mount SMFS directly. This gives the agent a real filesystem with semantic grep.
+E2B sandboxes have full network access and FUSE support, so you can install and mount SMFS directly. Two setup steps are needed first:
+
+<Warning>
+  E2B sandboxes require FUSE permission fixes before mounting. Run these commands once after creating the sandbox:
+
+  ```bash
+  sudo chmod 666 /dev/fuse
+  echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null
+  ```
+</Warning>
 
 ```python
 from e2b_code_interpreter import Sandbox
 import os
 
-sandbox = Sandbox(api_key=os.environ["E2B_API_KEY"])
+sandbox = Sandbox.create(timeout=300)
+
+# One-time FUSE setup
+sandbox.commands.run("sudo chmod 666 /dev/fuse")
+sandbox.commands.run(
+    "echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null"
+)
 
 # Install SMFS
 sandbox.commands.run("curl -fsSL https://smfs.ai/install | sh")
 
-# Log in and mount
+# Log in
 sandbox.commands.run(
     f"~/.local/bin/smfs login --key {os.environ['SUPERMEMORY_API_KEY']}"
 )
+
+# Mount with ephemeral mode (recommended for sandboxes)
+# Run in background since mount is a long-running daemon
 sandbox.commands.run(
-    "~/.local/bin/smfs mount agent_memory --ephemeral --path /memory"
+    "bash -c '~/.local/bin/smfs mount agent_memory --ephemeral"
+    " --path /home/user/memory --foreground > /tmp/smfs.log 2>&1"
+    " & sleep 5 && echo MOUNTED'",
+    timeout=15,
 )
 
-# Write some memory
-sandbox.commands.run('echo "Project deadline is March 15" > /memory/notes.md')
-
 # Read the auto-generated profile
-result = sandbox.commands.run("cat /memory/profile.md")
+result = sandbox.commands.run("cat /home/user/memory/profile.md")
 print(result.stdout)
 
-# Semantic search across all memory
-result = sandbox.commands.run("cd /memory && grep 'deadline'")
+# Semantic grep works inside the mount
+result = sandbox.commands.run("~/.local/bin/smfs grep 'deadlines'")
 print(result.stdout)
 
 # Clean up
-sandbox.commands.run("~/.local/bin/smfs unmount agent_memory")
+sandbox.commands.run("~/.local/bin/smfs unmount agent_memory 2>/dev/null", timeout=10)
 sandbox.kill()
 ```
 
 ## Custom E2B template with SMFS pre-installed
 
-For faster startup, bake SMFS into a custom E2B template so you don't have to install it every time:
+For faster startup, bake SMFS and the FUSE fixes into a custom E2B template:
 
 ```dockerfile e2b.Dockerfile
 FROM e2b/code-interpreter:latest
 
 # Pre-install SMFS
 RUN curl -fsSL https://smfs.ai/install | sh
+
+# Fix FUSE permissions for SMFS mount
+RUN echo 'user_allow_other' >> /etc/fuse.conf
 ```
 
 ```bash
 e2b template build -d e2b.Dockerfile
 ```
 
-Then use your custom template:
+Then use your custom template — no setup needed at runtime:
 
 ```python
-sandbox = Sandbox(template="your-custom-template")
+sandbox = Sandbox.create(template="your-custom-template")
+
+# FUSE device still needs chmod at runtime (device nodes reset on boot)
+sandbox.commands.run("sudo chmod 666 /dev/fuse")
+
+# Mount directly
+sandbox.commands.run(
+    f"~/.local/bin/smfs login --key {os.environ['SUPERMEMORY_API_KEY']}"
+)
+sandbox.commands.run(
+    "bash -c '~/.local/bin/smfs mount agent_memory --ephemeral"
+    " --path /home/user/memory --foreground > /tmp/smfs.log 2>&1"
+    " & sleep 5'",
+    timeout=15,
+)
 ```
 
 ## Tips
 
 - **Use `--ephemeral` for sandboxes.** E2B sandboxes are short-lived. Ephemeral mode avoids writing a local cache that will be thrown away.
+- **Always fix FUSE permissions.** E2B sandboxes need `sudo chmod 666 /dev/fuse` and `user_allow_other` in `/etc/fuse.conf` before mounting.
+- **Mount in background.** The SMFS daemon is long-running. Use `bash -c '... --foreground &'` with a sleep to let it initialize.
 - **Custom templates save time.** Pre-install SMFS in a template to skip the install step on every sandbox boot.
-- **E2B sandboxes have a timeout.** Default is 5 minutes. Set `timeout` when creating the sandbox if your agent needs longer.
+- **E2B sandboxes have a timeout.** Default is 5 minutes. Pass `timeout=300` (or more) when creating the sandbox if your agent needs longer.
 - **One container, many sandboxes.** Mount the same container tag from multiple E2B sandboxes. Bidirectional sync keeps them in step.
 
 ## Resources

--- a/apps/docs/smfs/providers/e2b.mdx
+++ b/apps/docs/smfs/providers/e2b.mdx
@@ -1,108 +1,71 @@
 ---
 title: "E2B"
-sidebarTitle: "E2B"
-description: "Give your E2B sandboxes persistent memory with SMFS."
-icon: "cube"
+description: "Give your AI agent persistent memory inside an E2B sandbox using SMFS"
 ---
 
-[E2B](https://e2b.dev) runs AI-generated code in secure Firecracker microVMs. Pair it with SMFS and your agent gets both safe code execution **and** persistent memory it can `ls`, `cat`, and `grep`.
+Mount a Supermemory container inside an [E2B](https://e2b.dev) sandbox so your
+agent can read and write memory with plain bash commands.
 
-## Architecture
+## How it works
 
-E2B sandboxes are ephemeral Linux microVMs with full shell access and unrestricted network. Two ways to wire SMFS in:
-
-<CardGroup cols={2}>
-  <Card title="Mount inside the sandbox" icon="hard-drive">
-    Install the `smfs` binary inside the sandbox and mount a container. The agent uses standard Unix commands to read and write memory.
-  </Card>
-  <Card title="Bash Tool in your agent code" icon="terminal">
-    Use `@supermemory/bash` in the code that **orchestrates** the sandbox. Memory lives in your agent code; code execution lives in E2B.
-  </Card>
-</CardGroup>
+1. Create an E2B sandbox
+2. Install SMFS and mount a Supermemory container inside it
+3. Run a Claude agent inside the sandbox — it uses `cat`, `ls`, `echo`, etc. on the mount
+4. Everything the agent writes is persisted to Supermemory automatically
 
 ## Prerequisites
 
-- A [Supermemory](https://console.supermemory.ai) account and API key
-- An [E2B](https://e2b.dev) account and API key
-- Node.js 18+ or Python 3.10+
+- A [Supermemory API key](https://supermemory.ai)
+- An [E2B API key](https://e2b.dev)
+- An [Anthropic API key](https://console.anthropic.com)
 
-## 1. Get your API keys
-
-### Supermemory
-
-1. Go to [console.supermemory.ai](https://console.supermemory.ai)
-2. Navigate to **Settings → API Keys**
-3. Create a new key and copy it
-
-### E2B
-
-1. Go to [e2b.dev](https://e2b.dev) and sign up
-2. Open the [Dashboard](https://e2b.dev/dashboard)
-3. Navigate to **API Keys**
-4. Copy your API key
-
-## 2. Install the SDKs
+## Quick start
 
 <Tabs>
   <Tab title="TypeScript">
     ```bash
-    npm install @supermemory/bash @e2b/code-interpreter
+    npm install @anthropic-ai/claude-agent-sdk @e2b/code-interpreter
     ```
-  </Tab>
-  <Tab title="Python">
-    ```bash
-    pip install e2b-code-interpreter
-    ```
-  </Tab>
-</Tabs>
-
-## 3. Build an agent with memory + code execution
-
-<Tabs>
-  <Tab title="TypeScript">
-    The recommended TypeScript pattern: use `@supermemory/bash` for memory in your orchestrating code and the E2B SDK for code execution. The LLM gets both as tools.
 
     ```typescript agent.ts
-    import { createBash } from "@supermemory/bash";
     import { Sandbox } from "@e2b/code-interpreter";
-    import { generateText, tool } from "ai";
-    import { openai } from "@ai-sdk/openai";
-    import { z } from "zod";
+    import { query, ClaudeAgentOptions } from "@anthropic-ai/claude-agent-sdk";
 
     async function main() {
-      // 1. Set up memory (SMFS bash tool)
-      const { bash, toolDescription } = await createBash({
-        apiKey: process.env.SUPERMEMORY_API_KEY!,
-        containerTag: "agent_memory",
-      });
+      // 1. Create an E2B sandbox
+      const sandbox = await Sandbox.create({ timeoutMs: 300_000 });
 
-      // 2. Set up code execution (E2B sandbox)
-      const sandbox = await Sandbox.create();
+      // 2. Fix FUSE permissions (required in E2B)
+      await sandbox.commands.run("sudo chmod 666 /dev/fuse");
+      await sandbox.commands.run(
+        "echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null"
+      );
 
-      // 3. Give the LLM both tools
-      const result = await generateText({
-        model: openai("gpt-4o"),
-        tools: {
-          memory: tool({
-            description: toolDescription,
-            parameters: z.object({ cmd: z.string() }),
-            execute: async ({ cmd }) => bash.exec(cmd),
-          }),
-          execute_code: tool({
-            description: "Run Python code in an isolated sandbox",
-            parameters: z.object({ code: z.string() }),
-            execute: async ({ code }) => {
-              const execution = await sandbox.runCode(code);
-              return execution.text;
-            },
-          }),
+      // 3. Install SMFS, log in, and mount
+      await sandbox.commands.run("curl -fsSL https://smfs.ai/install | bash");
+      await sandbox.commands.run(
+        `~/.local/bin/smfs login --key ${process.env.SUPERMEMORY_API_KEY}`
+      );
+      await sandbox.commands.run(
+        "bash -c '~/.local/bin/smfs mount my_agent --ephemeral --path /home/user/memory --foreground > /tmp/smfs.log 2>&1 & sleep 5'"
+      );
+
+      // 4. Run a Claude agent inside the sandbox with bash access
+      for await (const message of query({
+        prompt: `You have access to a persistent memory filesystem mounted at /home/user/memory.
+    Use bash commands to explore it (ls, cat) and write notes to it (echo "..." > file).
+
+    First, read /home/user/memory/profile.md to learn about the user.
+    Then create /home/user/memory/session_notes.md with a summary of what you found.`,
+        options: {
+          allowedTools: ["Bash", "Read", "Write"],
         },
-        prompt: "Check my memory for the user's preferences, then write a script that uses them.",
-      });
+      })) {
+        if (message.type === "text") console.log(message.text);
+      }
 
-      console.log(result.text);
-
-      // 4. Clean up
+      // 5. Clean up
+      await sandbox.commands.run("~/.local/bin/smfs unmount my_agent 2>/dev/null");
       await sandbox.kill();
     }
 
@@ -110,122 +73,80 @@ E2B sandboxes are ephemeral Linux microVMs with full shell access and unrestrict
     ```
   </Tab>
   <Tab title="Python">
-    In Python, mount SMFS inside the E2B sandbox. The agent reads and writes memory via standard shell commands.
+    ```bash
+    pip install claude-agent-sdk e2b-code-interpreter
+    ```
 
     ```python agent.py
+    import asyncio
     import os
+    from claude_agent_sdk import query, ClaudeAgentOptions
     from e2b_code_interpreter import Sandbox
 
-    # 1. Create an E2B sandbox
-    sandbox = Sandbox.create(timeout=300)
+    async def main():
+        # 1. Create an E2B sandbox
+        sandbox = Sandbox.create(timeout=300)
 
-    # 2. Fix FUSE permissions (required in E2B sandboxes)
-    sandbox.commands.run("sudo chmod 666 /dev/fuse")
-    sandbox.commands.run(
-        "echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null"
-    )
+        # 2. Fix FUSE permissions (required in E2B)
+        sandbox.commands.run("sudo chmod 666 /dev/fuse")
+        sandbox.commands.run(
+            "echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null"
+        )
 
-    # 3. Install SMFS and log in
-    sandbox.commands.run("curl -fsSL https://smfs.ai/install | bash")
-    sandbox.commands.run(
-        f"~/.local/bin/smfs login --key {os.environ['SUPERMEMORY_API_KEY']}"
-    )
+        # 3. Install SMFS, log in, and mount
+        sandbox.commands.run("curl -fsSL https://smfs.ai/install | bash")
+        sandbox.commands.run(
+            f"~/.local/bin/smfs login --key {os.environ['SUPERMEMORY_API_KEY']}"
+        )
+        sandbox.commands.run(
+            "bash -c '~/.local/bin/smfs mount my_agent --ephemeral"
+            " --path /home/user/memory --foreground > /tmp/smfs.log 2>&1"
+            " & sleep 5'",
+            timeout=15,
+        )
 
-    # 4. Mount memory
-    sandbox.commands.run(
-        "bash -c '~/.local/bin/smfs mount agent_memory --ephemeral"
-        " --path /home/user/memory --foreground > /tmp/smfs.log 2>&1"
-        " & sleep 5 && echo MOUNTED'",
-        timeout=15,
-    )
+        # 4. Run a Claude agent inside the sandbox with bash access
+        async for message in query(
+            prompt="""You have access to a persistent memory filesystem mounted at /home/user/memory.
+    Use bash commands to explore it (ls, cat) and write notes to it.
 
-    # 5. Read the auto-generated profile
-    result = sandbox.commands.run("cat /home/user/memory/profile.md")
-    print(result.stdout)
+    First, read /home/user/memory/profile.md to learn about the user.
+    Then create /home/user/memory/session_notes.md with a summary of what you found.""",
+            options=ClaudeAgentOptions(
+                allowed_tools=["Bash", "Read", "Write"],
+            ),
+        ):
+            print(message)
 
-    # 6. Semantic search
-    result = sandbox.commands.run(
-        "~/.local/bin/smfs grep 'preferred language'"
-    )
-    print(result.stdout)
+        # 5. Clean up
+        sandbox.commands.run(
+            "~/.local/bin/smfs unmount my_agent 2>/dev/null", timeout=10
+        )
+        sandbox.kill()
 
-    # 7. Clean up
-    sandbox.commands.run(
-        "~/.local/bin/smfs unmount agent_memory 2>/dev/null",
-        timeout=10,
-    )
-    sandbox.kill()
+    asyncio.run(main())
     ```
   </Tab>
 </Tabs>
 
-## Mount SMFS inside the sandbox
-
-E2B sandboxes have full network access and FUSE support, so you can install and mount SMFS directly. Two setup steps are needed first:
-
 <Warning>
-  E2B sandboxes require FUSE permission fixes before mounting. Run these commands once after creating the sandbox:
+  E2B sandboxes require two FUSE permission fixes before mounting:
+  1. `sudo chmod 666 /dev/fuse` — the device exists but is root-only by default
+  2. `echo 'user_allow_other' | sudo tee -a /etc/fuse.conf` — needed for the `allow_other` mount option
 
-  ```bash
-  sudo chmod 666 /dev/fuse
-  echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null
-  ```
+  Without these, `smfs mount` will fail with a permission error.
 </Warning>
 
-```python
-from e2b_code_interpreter import Sandbox
-import os
-
-sandbox = Sandbox.create(timeout=300)
-
-# One-time FUSE setup
-sandbox.commands.run("sudo chmod 666 /dev/fuse")
-sandbox.commands.run(
-    "echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null"
-)
-
-# Install SMFS
-sandbox.commands.run("curl -fsSL https://smfs.ai/install | bash")
-
-# Log in
-sandbox.commands.run(
-    f"~/.local/bin/smfs login --key {os.environ['SUPERMEMORY_API_KEY']}"
-)
-
-# Mount with ephemeral mode (recommended for sandboxes)
-# Run in background since mount is a long-running daemon
-sandbox.commands.run(
-    "bash -c '~/.local/bin/smfs mount agent_memory --ephemeral"
-    " --path /home/user/memory --foreground > /tmp/smfs.log 2>&1"
-    " & sleep 5 && echo MOUNTED'",
-    timeout=15,
-)
-
-# Read the auto-generated profile
-result = sandbox.commands.run("cat /home/user/memory/profile.md")
-print(result.stdout)
-
-# Write to memory (use sudo — FUSE mount is owned by root)
-sandbox.commands.run(
-    "sudo bash -c 'echo \"User prefers Python\" > /home/user/memory/notes.md'"
-)
-
-# Semantic grep works inside the mount
-result = sandbox.commands.run("~/.local/bin/smfs grep 'deadlines'")
-print(result.stdout)
-
-# Clean up
-sandbox.commands.run("~/.local/bin/smfs unmount agent_memory 2>/dev/null", timeout=10)
-sandbox.kill()
-```
-
 <Note>
-  The FUSE mount is owned by root. Writing files requires `sudo` (e.g., `sudo bash -c 'echo "..." > /path/file'`). Reads work without sudo.
+  The FUSE mount is owned by root. Writing files requires `sudo`
+  (e.g., `sudo bash -c 'echo "..." > /path/file'`). Reads work without sudo.
+  The Claude agent handles this automatically when using the Bash tool.
 </Note>
 
-## Custom E2B template with SMFS pre-installed
+## Custom E2B template
 
-For faster startup, bake SMFS and the FUSE fixes into a custom E2B template:
+For production, bake SMFS into a custom E2B template so every sandbox starts
+with it pre-installed:
 
 ```dockerfile e2b.Dockerfile
 FROM e2b/code-interpreter:latest
@@ -233,7 +154,8 @@ FROM e2b/code-interpreter:latest
 # Pre-install SMFS
 RUN curl -fsSL https://smfs.ai/install | bash
 
-# Fix FUSE permissions for SMFS mount
+# Fix FUSE permissions
+RUN chmod 666 /dev/fuse
 RUN echo 'user_allow_other' >> /etc/fuse.conf
 ```
 
@@ -241,38 +163,12 @@ RUN echo 'user_allow_other' >> /etc/fuse.conf
 e2b template build -d e2b.Dockerfile
 ```
 
-Then use your custom template — no setup needed at runtime:
-
-```python
-sandbox = Sandbox.create(template="your-custom-template")
-
-# FUSE device still needs chmod at runtime (device nodes reset on boot)
-sandbox.commands.run("sudo chmod 666 /dev/fuse")
-
-# Mount directly
-sandbox.commands.run(
-    f"~/.local/bin/smfs login --key {os.environ['SUPERMEMORY_API_KEY']}"
-)
-sandbox.commands.run(
-    "bash -c '~/.local/bin/smfs mount agent_memory --ephemeral"
-    " --path /home/user/memory --foreground > /tmp/smfs.log 2>&1"
-    " & sleep 5'",
-    timeout=15,
-)
-```
+Then your agent code only needs to log in and mount — no install step.
 
 ## Tips
 
-- **Use `--ephemeral` for sandboxes.** E2B sandboxes are short-lived. Ephemeral mode avoids writing a local cache that will be thrown away.
-- **Always fix FUSE permissions.** E2B sandboxes need `sudo chmod 666 /dev/fuse` and `user_allow_other` in `/etc/fuse.conf` before mounting.
-- **Mount in background.** The SMFS daemon is long-running. Use `bash -c '... --foreground &'` with a sleep to let it initialize.
-- **Custom templates save time.** Pre-install SMFS in a template to skip the install step on every sandbox boot.
-- **E2B sandboxes have a timeout.** Default is 5 minutes. Pass `timeout=300` (or more) when creating the sandbox if your agent needs longer.
-- **One container, many sandboxes.** Mount the same container tag from multiple E2B sandboxes. Bidirectional sync keeps them in step.
-
-## Resources
-
-- [E2B docs](https://e2b.dev/docs)
-- [E2B SDK reference](https://e2b.dev/docs/sdk-reference)
-- [SMFS Mount reference](/smfs/mount)
-- [SMFS Bash Tool reference](/smfs/bash-tool)
+- Use `--ephemeral` when mounting inside sandboxes — it keeps the cache in memory
+  only, but writes still push to Supermemory
+- Use `smfs grep 'query'` for semantic search across all files in the container
+- The agent can write structured data (JSON, markdown) to the mount and it
+  persists across sandbox sessions via Supermemory

--- a/apps/docs/smfs/providers/e2b.mdx
+++ b/apps/docs/smfs/providers/e2b.mdx
@@ -4,14 +4,29 @@ description: "Give your AI agent persistent memory inside an E2B sandbox using S
 ---
 
 Mount a Supermemory container inside an [E2B](https://e2b.dev) sandbox so your
-agent can read and write memory with plain bash commands.
+agent can read and write memory using standard filesystem commands.
 
 ## How it works
 
-1. Create an E2B sandbox
-2. Install SMFS and mount a Supermemory container inside it
-3. Install the Claude Agent SDK inside the sandbox and run the agent there
-4. The agent uses `cat`, `ls`, `echo`, etc. on the mount — everything persists to Supermemory
+```
+┌─────────────────────────────────────────┐
+│  E2B Sandbox                            │
+│                                         │
+│  ┌──────────┐    ┌───────────────────┐  │
+│  │  Claude   │───▶│  /home/user/memory │  │
+│  │  Agent    │    │  (SMFS mount)     │  │
+│  └──────────┘    └────────┬──────────┘  │
+│                           │              │
+└───────────────────────────┼──────────────┘
+                            │
+                    ┌───────▼───────┐
+                    │  Supermemory  │
+                    └───────────────┘
+```
+
+The agent runs inside the sandbox. SMFS mounts a Supermemory container as a
+regular directory. The agent uses `cat`, `ls`, `echo` — standard bash. Writes
+sync to Supermemory automatically.
 
 ## Prerequisites
 
@@ -19,186 +34,130 @@ agent can read and write memory with plain bash commands.
 - An [E2B API key](https://e2b.dev)
 - An [Anthropic API key](https://console.anthropic.com)
 
-## Quick start
+## 1. Create a custom template
 
-<Tabs>
-  <Tab title="TypeScript">
-    ```bash
-    npm install @e2b/code-interpreter
-    ```
-
-    ```typescript agent.ts
-    import { Sandbox } from "@e2b/code-interpreter";
-
-    async function main() {
-      const sandbox = await Sandbox.create({ timeoutMs: 300_000 });
-
-      // Fix FUSE permissions (required in E2B)
-      await sandbox.commands.run("sudo chmod 666 /dev/fuse");
-      await sandbox.commands.run(
-        "echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null"
-      );
-
-      // Install SMFS, log in, and mount
-      await sandbox.commands.run(
-        "curl -fsSL https://smfs.ai/install | bash",
-        { timeoutMs: 60_000 }
-      );
-      await sandbox.commands.run(
-        `~/.local/bin/smfs login --key ${process.env.SUPERMEMORY_API_KEY}`
-      );
-      await sandbox.commands.run(
-        "bash -c '~/.local/bin/smfs mount my_agent --ephemeral --path /home/user/memory --foreground > /tmp/smfs.log 2>&1 & sleep 5'"
-      );
-
-      // Install Claude Agent SDK inside the sandbox
-      await sandbox.commands.run(
-        "pip install claude-agent-sdk",
-        { timeoutMs: 60_000 }
-      );
-
-      // Write the agent script into the sandbox
-      await sandbox.files.write("/home/user/agent.py", `
-import asyncio
-from claude_agent_sdk import query, ClaudeAgentOptions
-
-async def main():
-    async for message in query(
-        prompt="""You have a persistent memory filesystem at /home/user/memory.
-Use bash to explore it (ls, cat) and write notes (echo "..." > file).
-
-Read /home/user/memory/profile.md to learn about the user.
-Then create /home/user/memory/session_notes.md summarizing what you found.""",
-        options=ClaudeAgentOptions(
-            allowed_tools=["Bash", "Read", "Write"],
-        ),
-    ):
-        print(message)
-
-asyncio.run(main())
-`);
-
-      // Run the agent inside the sandbox
-      const result = await sandbox.commands.run(
-        `ANTHROPIC_API_KEY=${process.env.ANTHROPIC_API_KEY} python3 /home/user/agent.py`,
-        { timeoutMs: 120_000 }
-      );
-      console.log(result.stdout);
-
-      await sandbox.kill();
-    }
-
-    main();
-    ```
-  </Tab>
-  <Tab title="Python">
-    ```bash
-    pip install e2b-code-interpreter
-    ```
-
-    ```python agent.py
-    import os
-    from e2b_code_interpreter import Sandbox
-
-    sandbox = Sandbox.create(timeout=300)
-
-    # Fix FUSE permissions (required in E2B)
-    sandbox.commands.run("sudo chmod 666 /dev/fuse")
-    sandbox.commands.run(
-        "echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null"
-    )
-
-    # Install SMFS, log in, and mount
-    sandbox.commands.run(
-        "curl -fsSL https://smfs.ai/install | bash",
-        timeout=60,
-    )
-    sandbox.commands.run(
-        f"~/.local/bin/smfs login --key {os.environ['SUPERMEMORY_API_KEY']}"
-    )
-    sandbox.commands.run(
-        "bash -c '~/.local/bin/smfs mount my_agent --ephemeral"
-        " --path /home/user/memory --foreground > /tmp/smfs.log 2>&1"
-        " & sleep 5'",
-        timeout=15,
-    )
-
-    # Install Claude Agent SDK inside the sandbox
-    sandbox.commands.run("pip install claude-agent-sdk", timeout=60)
-
-    # Write the agent script into the sandbox
-    AGENT_SCRIPT = '''
-import asyncio
-from claude_agent_sdk import query, ClaudeAgentOptions
-
-async def main():
-    async for message in query(
-        prompt="""You have a persistent memory filesystem at /home/user/memory.
-Use bash to explore it (ls, cat) and write notes (echo "..." > file).
-
-Read /home/user/memory/profile.md to learn about the user.
-Then create /home/user/memory/session_notes.md summarizing what you found.""",
-        options=ClaudeAgentOptions(
-            allowed_tools=["Bash", "Read", "Write"],
-        ),
-    ):
-        print(message)
-
-asyncio.run(main())
-'''
-    sandbox.files.write("/home/user/run_agent.py", AGENT_SCRIPT)
-
-    # Run the agent inside the sandbox
-    result = sandbox.commands.run(
-        f"ANTHROPIC_API_KEY={os.environ['ANTHROPIC_API_KEY']}"
-        " python3 /home/user/run_agent.py",
-        timeout=120,
-    )
-    print(result.stdout)
-
-    sandbox.kill()
-    ```
-  </Tab>
-</Tabs>
-
-<Warning>
-  E2B sandboxes require two FUSE permission fixes before mounting:
-  1. `sudo chmod 666 /dev/fuse` — the device exists but is root-only by default
-  2. `echo 'user_allow_other' | sudo tee -a /etc/fuse.conf` — needed for the `allow_other` mount option
-
-  Without these, `smfs mount` will fail with a permission error.
-</Warning>
-
-<Note>
-  The FUSE mount is owned by root. Writing files requires `sudo`
-  (e.g., `sudo bash -c 'echo "..." > /path/file'`). Reads work without sudo.
-  The Claude agent handles this automatically when using the Bash tool.
-</Note>
-
-## Custom E2B template
-
-For production, bake SMFS into a custom E2B template so every sandbox starts
-with it pre-installed:
+Bake SMFS and the Claude Agent SDK into a template so sandboxes start ready:
 
 ```dockerfile e2b.Dockerfile
 FROM e2b/code-interpreter:latest
 
-RUN curl -fsSL https://smfs.ai/install | bash
-RUN pip install claude-agent-sdk
-RUN chmod 666 /dev/fuse
+RUN apt-get update && apt-get install -y fuse3 && rm -rf /var/lib/apt/lists/*
 RUN echo 'user_allow_other' >> /etc/fuse.conf
+RUN curl -fsSL https://smfs.ai/install | bash -s -- 0.0.1-rc2
+ENV PATH="/root/.local/bin:$PATH"
+RUN pip install claude-agent-sdk
 ```
 
 ```bash
 e2b template build -d e2b.Dockerfile
 ```
 
-Then your orchestrating code only needs to log in, mount, and run the agent.
+## 2. Write your agent
+
+This is the code that runs inside the sandbox. It's just normal Python —
+nothing sandbox-specific:
+
+```python agent.py
+import asyncio
+from claude_agent_sdk import query, ClaudeAgentOptions
+
+MEMORY = "/home/user/memory"
+
+async def main():
+    async for message in query(
+        prompt=f"You have a persistent memory filesystem at {MEMORY}. "
+               "Read profile.md to learn about the user, then create "
+               "session_notes.md summarizing what you found.",
+        options=ClaudeAgentOptions(
+            allowed_tools=["Bash", "Read", "Write"],
+            cwd=MEMORY,
+        ),
+    ):
+        print(message)
+
+asyncio.run(main())
+```
+
+## 3. Run it
+
+<Tabs>
+  <Tab title="Python">
+    ```python run.py
+    import os
+    from e2b_code_interpreter import Sandbox
+
+    sbx = Sandbox.create(
+        template="your-template-id",
+        timeout=300,
+        envs={
+            "SUPERMEMORY_API_KEY": os.environ["SUPERMEMORY_API_KEY"],
+            "ANTHROPIC_API_KEY": os.environ["ANTHROPIC_API_KEY"],
+        },
+    )
+
+    # One-time FUSE fix (device exists but is root-only by default)
+    sbx.commands.run("sudo chmod 666 /dev/fuse")
+
+    # Mount memory
+    sbx.commands.run("smfs login --key $SUPERMEMORY_API_KEY")
+    sbx.commands.run(
+        "bash -c 'smfs mount my_agent --ephemeral"
+        " --path /home/user/memory --foreground &' && sleep 3"
+    )
+
+    # Run the agent
+    result = sbx.commands.run("python3 agent.py", timeout=120)
+    print(result.stdout)
+
+    sbx.kill()
+    ```
+  </Tab>
+  <Tab title="TypeScript">
+    ```typescript run.ts
+    import { Sandbox } from "@e2b/code-interpreter";
+
+    const sbx = await Sandbox.create({
+      template: "your-template-id",
+      timeoutMs: 300_000,
+      envs: {
+        SUPERMEMORY_API_KEY: process.env.SUPERMEMORY_API_KEY!,
+        ANTHROPIC_API_KEY: process.env.ANTHROPIC_API_KEY!,
+      },
+    });
+
+    // One-time FUSE fix (device exists but is root-only by default)
+    await sbx.commands.run("sudo chmod 666 /dev/fuse");
+
+    // Mount memory
+    await sbx.commands.run("smfs login --key $SUPERMEMORY_API_KEY");
+    await sbx.commands.run(
+      "bash -c 'smfs mount my_agent --ephemeral --path /home/user/memory --foreground &' && sleep 3"
+    );
+
+    // Run the agent
+    const result = await sbx.commands.run("python3 agent.py", {
+      timeoutMs: 120_000,
+    });
+    console.log(result.stdout);
+
+    await sbx.kill();
+    ```
+  </Tab>
+</Tabs>
+
+<Note>
+  The FUSE mount is owned by root. The Claude agent handles this automatically
+  with the Bash tool (it uses `sudo` when needed). If you're writing files
+  manually, use `sudo bash -c 'echo "..." > /path/file'`.
+</Note>
 
 ## Tips
 
-- Use `--ephemeral` when mounting inside sandboxes — keeps the cache in memory
-  only, but writes still push to Supermemory
+- Use `--ephemeral` for sandbox mounts — keeps the cache in memory only, but
+  writes still push to Supermemory
 - Use `smfs grep 'query'` for semantic search across all files in the container
-- The agent can write structured data (JSON, markdown) to the mount and it
-  persists across sandbox sessions via Supermemory
+- Without a custom template, add the install steps to your run script:
+  ```python
+  sbx.commands.run("curl -fsSL https://smfs.ai/install | bash -s -- 0.0.1-rc2", timeout=60)
+  sbx.commands.run("pip install claude-agent-sdk", timeout=60)
+  ```

--- a/apps/docs/smfs/providers/e2b.mdx
+++ b/apps/docs/smfs/providers/e2b.mdx
@@ -10,8 +10,8 @@ agent can read and write memory with plain bash commands.
 
 1. Create an E2B sandbox
 2. Install SMFS and mount a Supermemory container inside it
-3. Run a Claude agent inside the sandbox — it uses `cat`, `ls`, `echo`, etc. on the mount
-4. Everything the agent writes is persisted to Supermemory automatically
+3. Install the Claude Agent SDK inside the sandbox and run the agent there
+4. The agent uses `cat`, `ls`, `echo`, etc. on the mount — everything persists to Supermemory
 
 ## Prerequisites
 
@@ -24,25 +24,26 @@ agent can read and write memory with plain bash commands.
 <Tabs>
   <Tab title="TypeScript">
     ```bash
-    npm install @anthropic-ai/claude-agent-sdk @e2b/code-interpreter
+    npm install @e2b/code-interpreter
     ```
 
     ```typescript agent.ts
     import { Sandbox } from "@e2b/code-interpreter";
-    import { query, ClaudeAgentOptions } from "@anthropic-ai/claude-agent-sdk";
 
     async function main() {
-      // 1. Create an E2B sandbox
       const sandbox = await Sandbox.create({ timeoutMs: 300_000 });
 
-      // 2. Fix FUSE permissions (required in E2B)
+      // Fix FUSE permissions (required in E2B)
       await sandbox.commands.run("sudo chmod 666 /dev/fuse");
       await sandbox.commands.run(
         "echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null"
       );
 
-      // 3. Install SMFS, log in, and mount
-      await sandbox.commands.run("curl -fsSL https://smfs.ai/install | bash");
+      // Install SMFS, log in, and mount
+      await sandbox.commands.run(
+        "curl -fsSL https://smfs.ai/install | bash",
+        { timeoutMs: 60_000 }
+      );
       await sandbox.commands.run(
         `~/.local/bin/smfs login --key ${process.env.SUPERMEMORY_API_KEY}`
       );
@@ -50,22 +51,40 @@ agent can read and write memory with plain bash commands.
         "bash -c '~/.local/bin/smfs mount my_agent --ephemeral --path /home/user/memory --foreground > /tmp/smfs.log 2>&1 & sleep 5'"
       );
 
-      // 4. Run a Claude agent inside the sandbox with bash access
-      for await (const message of query({
-        prompt: `You have access to a persistent memory filesystem mounted at /home/user/memory.
-    Use bash commands to explore it (ls, cat) and write notes to it (echo "..." > file).
+      // Install Claude Agent SDK inside the sandbox
+      await sandbox.commands.run(
+        "pip install claude-agent-sdk",
+        { timeoutMs: 60_000 }
+      );
 
-    First, read /home/user/memory/profile.md to learn about the user.
-    Then create /home/user/memory/session_notes.md with a summary of what you found.`,
-        options: {
-          allowedTools: ["Bash", "Read", "Write"],
-        },
-      })) {
-        if (message.type === "text") console.log(message.text);
-      }
+      // Write the agent script into the sandbox
+      await sandbox.files.write("/home/user/agent.py", `
+import asyncio
+from claude_agent_sdk import query, ClaudeAgentOptions
 
-      // 5. Clean up
-      await sandbox.commands.run("~/.local/bin/smfs unmount my_agent 2>/dev/null");
+async def main():
+    async for message in query(
+        prompt="""You have a persistent memory filesystem at /home/user/memory.
+Use bash to explore it (ls, cat) and write notes (echo "..." > file).
+
+Read /home/user/memory/profile.md to learn about the user.
+Then create /home/user/memory/session_notes.md summarizing what you found.""",
+        options=ClaudeAgentOptions(
+            allowed_tools=["Bash", "Read", "Write"],
+        ),
+    ):
+        print(message)
+
+asyncio.run(main())
+`);
+
+      // Run the agent inside the sandbox
+      const result = await sandbox.commands.run(
+        `ANTHROPIC_API_KEY=${process.env.ANTHROPIC_API_KEY} python3 /home/user/agent.py`,
+        { timeoutMs: 120_000 }
+      );
+      console.log(result.stdout);
+
       await sandbox.kill();
     }
 
@@ -74,57 +93,70 @@ agent can read and write memory with plain bash commands.
   </Tab>
   <Tab title="Python">
     ```bash
-    pip install claude-agent-sdk e2b-code-interpreter
+    pip install e2b-code-interpreter
     ```
 
     ```python agent.py
-    import asyncio
     import os
-    from claude_agent_sdk import query, ClaudeAgentOptions
     from e2b_code_interpreter import Sandbox
 
-    async def main():
-        # 1. Create an E2B sandbox
-        sandbox = Sandbox.create(timeout=300)
+    sandbox = Sandbox.create(timeout=300)
 
-        # 2. Fix FUSE permissions (required in E2B)
-        sandbox.commands.run("sudo chmod 666 /dev/fuse")
-        sandbox.commands.run(
-            "echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null"
-        )
+    # Fix FUSE permissions (required in E2B)
+    sandbox.commands.run("sudo chmod 666 /dev/fuse")
+    sandbox.commands.run(
+        "echo 'user_allow_other' | sudo tee -a /etc/fuse.conf > /dev/null"
+    )
 
-        # 3. Install SMFS, log in, and mount
-        sandbox.commands.run("curl -fsSL https://smfs.ai/install | bash")
-        sandbox.commands.run(
-            f"~/.local/bin/smfs login --key {os.environ['SUPERMEMORY_API_KEY']}"
-        )
-        sandbox.commands.run(
-            "bash -c '~/.local/bin/smfs mount my_agent --ephemeral"
-            " --path /home/user/memory --foreground > /tmp/smfs.log 2>&1"
-            " & sleep 5'",
-            timeout=15,
-        )
+    # Install SMFS, log in, and mount
+    sandbox.commands.run(
+        "curl -fsSL https://smfs.ai/install | bash",
+        timeout=60,
+    )
+    sandbox.commands.run(
+        f"~/.local/bin/smfs login --key {os.environ['SUPERMEMORY_API_KEY']}"
+    )
+    sandbox.commands.run(
+        "bash -c '~/.local/bin/smfs mount my_agent --ephemeral"
+        " --path /home/user/memory --foreground > /tmp/smfs.log 2>&1"
+        " & sleep 5'",
+        timeout=15,
+    )
 
-        # 4. Run a Claude agent inside the sandbox with bash access
-        async for message in query(
-            prompt="""You have access to a persistent memory filesystem mounted at /home/user/memory.
-    Use bash commands to explore it (ls, cat) and write notes to it.
+    # Install Claude Agent SDK inside the sandbox
+    sandbox.commands.run("pip install claude-agent-sdk", timeout=60)
 
-    First, read /home/user/memory/profile.md to learn about the user.
-    Then create /home/user/memory/session_notes.md with a summary of what you found.""",
-            options=ClaudeAgentOptions(
-                allowed_tools=["Bash", "Read", "Write"],
-            ),
-        ):
-            print(message)
+    # Write the agent script into the sandbox
+    AGENT_SCRIPT = '''
+import asyncio
+from claude_agent_sdk import query, ClaudeAgentOptions
 
-        # 5. Clean up
-        sandbox.commands.run(
-            "~/.local/bin/smfs unmount my_agent 2>/dev/null", timeout=10
-        )
-        sandbox.kill()
+async def main():
+    async for message in query(
+        prompt="""You have a persistent memory filesystem at /home/user/memory.
+Use bash to explore it (ls, cat) and write notes (echo "..." > file).
 
-    asyncio.run(main())
+Read /home/user/memory/profile.md to learn about the user.
+Then create /home/user/memory/session_notes.md summarizing what you found.""",
+        options=ClaudeAgentOptions(
+            allowed_tools=["Bash", "Read", "Write"],
+        ),
+    ):
+        print(message)
+
+asyncio.run(main())
+'''
+    sandbox.files.write("/home/user/run_agent.py", AGENT_SCRIPT)
+
+    # Run the agent inside the sandbox
+    result = sandbox.commands.run(
+        f"ANTHROPIC_API_KEY={os.environ['ANTHROPIC_API_KEY']}"
+        " python3 /home/user/run_agent.py",
+        timeout=120,
+    )
+    print(result.stdout)
+
+    sandbox.kill()
     ```
   </Tab>
 </Tabs>
@@ -151,10 +183,8 @@ with it pre-installed:
 ```dockerfile e2b.Dockerfile
 FROM e2b/code-interpreter:latest
 
-# Pre-install SMFS
 RUN curl -fsSL https://smfs.ai/install | bash
-
-# Fix FUSE permissions
+RUN pip install claude-agent-sdk
 RUN chmod 666 /dev/fuse
 RUN echo 'user_allow_other' >> /etc/fuse.conf
 ```
@@ -163,11 +193,11 @@ RUN echo 'user_allow_other' >> /etc/fuse.conf
 e2b template build -d e2b.Dockerfile
 ```
 
-Then your agent code only needs to log in and mount — no install step.
+Then your orchestrating code only needs to log in, mount, and run the agent.
 
 ## Tips
 
-- Use `--ephemeral` when mounting inside sandboxes — it keeps the cache in memory
+- Use `--ephemeral` when mounting inside sandboxes — keeps the cache in memory
   only, but writes still push to Supermemory
 - Use `smfs grep 'query'` for semantic search across all files in the container
 - The agent can write structured data (JSON, markdown) to the mount and it

--- a/apps/docs/smfs/providers/vercel.mdx
+++ b/apps/docs/smfs/providers/vercel.mdx
@@ -3,14 +3,14 @@ title: "Vercel AI SDK"
 description: "Give your AI agent persistent memory using SMFS with the Vercel AI SDK"
 ---
 
-Mount a Supermemory container on your server and give your Vercel AI SDK agent
-access to it through a bash tool.
+Mount a Supermemory container on your server and let a Claude agent access it
+through the built-in bash tool.
 
 ## How it works
 
 1. Install SMFS on your server and mount a Supermemory container
-2. Define a bash tool that runs commands against the mount
-3. The Vercel AI SDK agent uses the tool to read/write memory with standard commands
+2. Run a Claude agent with bash tool access — it reads/writes the mount using standard commands
+3. Everything the agent writes persists to Supermemory automatically
 
 <Note>
   The Vercel AI SDK runs in your server process (not in a sandbox). SMFS mounts
@@ -20,99 +20,71 @@ access to it through a bash tool.
 ## Prerequisites
 
 - A [Supermemory API key](https://supermemory.ai)
-- An [OpenAI](https://platform.openai.com) or [Anthropic](https://console.anthropic.com) API key
+- An [Anthropic API key](https://console.anthropic.com)
 - SMFS installed on your server: `curl -fsSL https://smfs.ai/install | bash`
 
 ## Quick start
 
+First, mount SMFS on your server:
+
 ```bash
-npm install ai @ai-sdk/anthropic zod
+smfs login --key $SUPERMEMORY_API_KEY
+smfs mount my_agent --path ./memory
+```
+
+Then run the agent:
+
+```bash
+pip install claude-agent-sdk
+```
+
+```python agent.py
+import asyncio
+from claude_agent_sdk import query, ClaudeAgentOptions
+
+async def main():
+    async for message in query(
+        prompt="""You have a persistent memory filesystem at ./memory.
+Use bash to explore it (ls, cat) and write notes (echo "..." > file).
+
+Read ./memory/profile.md to learn about the user.
+Then create ./memory/session_notes.md summarizing what you found.""",
+        options=ClaudeAgentOptions(
+            allowed_tools=["Bash", "Read", "Write"],
+            cwd="./memory",
+        ),
+    ):
+        print(message)
+
+asyncio.run(main())
+```
+
+Or with TypeScript:
+
+```bash
+npm install @anthropic-ai/claude-agent-sdk
 ```
 
 ```typescript agent.ts
-import { generateText, tool } from "ai";
-import { anthropic } from "@ai-sdk/anthropic";
-import { z } from "zod";
-import { execSync } from "child_process";
-
-// Mount SMFS before starting the server:
-//   smfs login --key $SUPERMEMORY_API_KEY
-//   smfs mount my_agent --path ./memory
-
-const MEMORY_PATH = "./memory";
+import { query } from "@anthropic-ai/claude-agent-sdk";
 
 async function main() {
-  const result = await generateText({
-    model: anthropic("claude-sonnet-4-20250514"),
-    tools: {
-      bash: tool({
-        description:
-          "Run a bash command. The persistent memory filesystem is at " +
-          MEMORY_PATH,
-        parameters: z.object({ command: z.string() }),
-        execute: async ({ command }) => {
-          try {
-            return execSync(command, {
-              cwd: MEMORY_PATH,
-              encoding: "utf-8",
-              timeout: 10_000,
-            });
-          } catch (e: any) {
-            return e.stderr || e.message;
-          }
-        },
-      }),
+  for await (const message of query({
+    prompt: `You have a persistent memory filesystem at ./memory.
+Use bash to explore it (ls, cat) and write notes (echo "..." > file).
+
+Read ./memory/profile.md to learn about the user.
+Then create ./memory/session_notes.md summarizing what you found.`,
+    options: {
+      allowedTools: ["Bash", "Read", "Write"],
+      cwd: "./memory",
     },
-    maxSteps: 10,
-    prompt: `You have access to a persistent memory filesystem at ${MEMORY_PATH}.
-Use the bash tool to explore it (ls, cat) and write notes (echo "..." > file).
-
-Read profile.md to learn about the user, then create session_notes.md with a summary.`,
-  });
-
-  console.log(result.text);
+  })) {
+    if (message.type === "text") console.log(message.text);
+  }
 }
 
 main();
-```
-
-## Streaming
-
-```typescript
-import { streamText, tool } from "ai";
-import { anthropic } from "@ai-sdk/anthropic";
-import { z } from "zod";
-import { execSync } from "child_process";
-
-const MEMORY_PATH = "./memory";
-
-const result = streamText({
-  model: anthropic("claude-sonnet-4-20250514"),
-  tools: {
-    bash: tool({
-      description:
-        "Run a bash command against the memory filesystem at " + MEMORY_PATH,
-      parameters: z.object({ command: z.string() }),
-      execute: async ({ command }) => {
-        try {
-          return execSync(command, {
-            cwd: MEMORY_PATH,
-            encoding: "utf-8",
-            timeout: 10_000,
-          });
-        } catch (e: any) {
-          return e.stderr || e.message;
-        }
-      },
-    }),
-  },
-  maxSteps: 10,
-  prompt: "Read my memory and summarize what you know about me.",
-});
-
-for await (const chunk of result.textStream) {
-  process.stdout.write(chunk);
-}
 ```
 
 ## Tips

--- a/apps/docs/smfs/providers/vercel.mdx
+++ b/apps/docs/smfs/providers/vercel.mdx
@@ -1,0 +1,168 @@
+---
+title: "Vercel AI SDK"
+sidebarTitle: "Vercel AI SDK"
+description: "Add persistent memory to agents built with the Vercel AI SDK."
+icon: "triangle"
+---
+
+The [Vercel AI SDK](https://sdk.vercel.ai) is the most popular framework for building AI agents in TypeScript. SMFS plugs in as a tool — give your agent a `bash` tool backed by `@supermemory/bash` and it can `ls`, `cat`, `grep`, and write to a Supermemory container without any filesystem to manage.
+
+## Architecture
+
+The Vercel AI SDK uses a tool-calling pattern: you define tools, the model decides when to call them. `@supermemory/bash` fits this perfectly — it's a single tool that exposes a virtual filesystem backed by Supermemory.
+
+```
+User → AI SDK → LLM → calls bash tool → @supermemory/bash → Supermemory API
+```
+
+No sandbox needed. The bash tool runs in your server process and handles all the memory operations.
+
+## Prerequisites
+
+- A [Supermemory](https://console.supermemory.ai) account and API key
+- Node.js 18+
+- An LLM provider (OpenAI, Anthropic, Google, etc.)
+
+## 1. Install
+
+```bash
+npm install @supermemory/bash ai @ai-sdk/openai zod
+```
+
+## 2. Create an agent with memory
+
+```typescript agent.ts
+import { createBash } from "@supermemory/bash";
+import { generateText, tool } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { z } from "zod";
+
+async function main() {
+  // Set up the SMFS bash tool
+  const { bash, toolDescription } = await createBash({
+    apiKey: process.env.SUPERMEMORY_API_KEY!,
+    containerTag: "user_42",
+  });
+
+  const result = await generateText({
+    model: openai("gpt-4o"),
+    tools: {
+      bash: tool({
+        description: toolDescription,
+        parameters: z.object({ cmd: z.string() }),
+        execute: async ({ cmd }) => bash.exec(cmd),
+      }),
+    },
+    maxSteps: 10,
+    system: `You have access to a persistent memory filesystem via the bash tool.
+Use it to remember things about the user across conversations.
+Start by reading /profile.md to see what you already know.`,
+    prompt: "What do you remember about me?",
+  });
+
+  console.log(result.text);
+}
+
+main();
+```
+
+That's it. The model will call `bash({ cmd: "cat /profile.md" })` to read the user's profile, `bash({ cmd: "ls /" })` to browse memory, and `bash({ cmd: "grep 'preferences'" })` to search semantically.
+
+## 3. Multi-step agent with memory
+
+A more complete example with conversation history and memory persistence:
+
+```typescript chat.ts
+import { createBash } from "@supermemory/bash";
+import { generateText, tool, CoreMessage } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { z } from "zod";
+
+// Create one bash instance per user (reuse across requests)
+const userBashInstances = new Map();
+
+async function getBash(userId: string) {
+  if (!userBashInstances.has(userId)) {
+    const instance = await createBash({
+      apiKey: process.env.SUPERMEMORY_API_KEY!,
+      containerTag: `user_${userId}`,
+    });
+    userBashInstances.set(userId, instance);
+  }
+  return userBashInstances.get(userId);
+}
+
+export async function chat(userId: string, messages: CoreMessage[]) {
+  const { bash, toolDescription } = await getBash(userId);
+
+  return generateText({
+    model: openai("gpt-4o"),
+    tools: {
+      bash: tool({
+        description: toolDescription,
+        parameters: z.object({ cmd: z.string() }),
+        execute: async ({ cmd }) => bash.exec(cmd),
+      }),
+    },
+    maxSteps: 10,
+    system: `You are a helpful assistant with persistent memory.
+
+Use the bash tool to:
+- Read /profile.md at the start of each conversation for context
+- Save important facts to /memory.md
+- Search with grep when looking for specific information
+- Organize notes in subdirectories as needed`,
+    messages,
+  });
+}
+```
+
+## With Vercel AI SDK Streams
+
+For streaming responses in a Next.js app:
+
+```typescript app/api/chat/route.ts
+import { createBash } from "@supermemory/bash";
+import { streamText, tool } from "ai";
+import { openai } from "@ai-sdk/openai";
+import { z } from "zod";
+
+export async function POST(req: Request) {
+  const { messages, userId } = await req.json();
+
+  const { bash, toolDescription } = await createBash({
+    apiKey: process.env.SUPERMEMORY_API_KEY!,
+    containerTag: `user_${userId}`,
+  });
+
+  const result = streamText({
+    model: openai("gpt-4o"),
+    tools: {
+      bash: tool({
+        description: toolDescription,
+        parameters: z.object({ cmd: z.string() }),
+        execute: async ({ cmd }) => bash.exec(cmd),
+      }),
+    },
+    maxSteps: 10,
+    system: "You have persistent memory via the bash tool. Read /profile.md for context.",
+    messages,
+  });
+
+  return result.toDataStreamResponse();
+}
+```
+
+## Tips
+
+- **One `createBash` per user.** Use the user's ID as the container tag. Each user gets their own isolated memory.
+- **Read `profile.md` first.** Tell the model to `cat /profile.md` at the start of each conversation. It's a live digest of everything in the container.
+- **`sgrep` for semantic search.** Inside the bash tool, `sgrep "query"` searches by meaning, not just text. Regular `grep` does literal matching.
+- **Cache the bash instance.** `createBash` warms the path index on startup. Reuse the instance across requests for the same user.
+- **Works with any LLM provider.** Swap `openai("gpt-4o")` for `anthropic("claude-sonnet-4-20250514")`, `google("gemini-2.0-flash")`, or any AI SDK-compatible provider.
+
+## Resources
+
+- [Vercel AI SDK docs](https://sdk.vercel.ai/docs)
+- [SMFS Bash Tool reference](/smfs/bash-tool)
+- [Supermemory quickstart](/quickstart)

--- a/apps/docs/smfs/providers/vercel.mdx
+++ b/apps/docs/smfs/providers/vercel.mdx
@@ -3,48 +3,59 @@ title: "Vercel AI SDK"
 description: "Give your AI agent persistent memory using SMFS with the Vercel AI SDK"
 ---
 
-Mount a Supermemory container on your server and let a Claude agent read and
-write memory using standard filesystem commands.
+This guide is about the [Vercel AI SDK](https://ai-sdk.dev) — the TypeScript
+agent framework — not Vercel hosting. The choice of pattern depends on where
+your code actually runs:
+
+- **Self-hosted Node** (your own VM, ECS, Fly.io, Railway, a Vercel Sandbox,
+  etc.): you can mount SMFS as a real filesystem on the server.
+- **Vercel Functions / serverless / edge**: there's no long-lived process to
+  hold a FUSE mount, so use the [Bash Tool](/smfs/bash-tool)
+  (`@supermemory/bash`) instead. The container becomes the filesystem; no mount
+  needed.
 
 ## How it works
 
-There are two ways to wire SMFS into a Vercel-based agent — pick the one that
-fits your architecture.
-
-### Claude Agent SDK (agent has full filesystem access)
+### Self-hosted Node (real mount)
 
 The agent runs as a separate process with direct access to the SMFS mount.
-Best when you want the agent to have full bash, read, and write capabilities.
+Best when you want full bash, read, and write capabilities and your server is
+long-lived.
 
 ```mermaid
 graph LR
     subgraph Your Server
-        Agent["Claude Agent"] -->|"cat, ls, echo"| Mount["./memory\n(SMFS mount)"]
+        Agent["Claude Agent"] -->|"cat, ls, echo"| Mount["./memory<br/>(SMFS mount)"]
     end
     Mount -->|sync| SM["Supermemory"]
 ```
 
-### Vercel AI SDK (agent uses a tool)
+### Vercel Functions / serverless (Bash Tool)
 
-The agent runs inside `generateText` and accesses memory through a bash tool
-you define. Best when you're building an API route and want to keep everything
-in one TypeScript process.
+The agent runs inside `generateText` and accesses memory through `@supermemory/bash`,
+which proxies bash commands to your Supermemory container over HTTP. No mount,
+no FUSE, no long-lived process required.
 
 ```mermaid
 graph LR
-    subgraph Your Server
-        AI["generateText()"] -->|"bash tool"| Mount["./memory\n(SMFS mount)"]
+    subgraph Vercel Function
+        AI["generateText()"] -->|"bash tool"| Bash["@supermemory/bash"]
     end
-    Mount -->|sync| SM["Supermemory"]
+    Bash -->|HTTPS| SM["Supermemory"]
 ```
 
 ## Prerequisites
 
 - A [Supermemory API key](https://supermemory.ai)
 - An [Anthropic API key](https://console.anthropic.com)
-- SMFS installed: `curl -fsSL https://smfs.ai/install | bash`
+- For Pattern A only: SMFS installed on your server (`curl -fsSL https://smfs.ai/install | bash`)
 
-## Mount memory
+---
+
+## Pattern A: Claude Agent SDK on self-hosted Node
+
+Use this when the Vercel AI SDK is just the orchestrator and your real workload
+is a Claude agent running on a long-lived server you control.
 
 Start the mount once when your server boots — not per-request:
 
@@ -53,12 +64,14 @@ smfs login --key $SUPERMEMORY_API_KEY
 smfs mount my_agent --path ./memory
 ```
 
----
-
-## Pattern A: Claude Agent SDK
+<Note>
+  This won't work on Vercel Functions or any serverless runtime: there's no
+  process between requests to hold the mount, and FUSE isn't available. For
+  those targets, jump to Pattern B.
+</Note>
 
 Write a standalone agent script. Nothing server-specific — just Python that
-reads and writes files.
+reads and writes files:
 
 ```python agent.py
 import asyncio
@@ -87,39 +100,37 @@ python3 agent.py
 
 ---
 
-## Pattern B: Vercel AI SDK
+## Pattern B: Vercel AI SDK + Bash Tool (serverless-friendly)
 
-Expose the memory filesystem as a bash tool inside an API route. The agent
-calls the tool to run commands against the mount.
+`@supermemory/bash` exposes your Supermemory container as a single agent tool
+— `run_bash(command)` — without mounting anything. It runs anywhere TypeScript
+runs, including Vercel Functions, edge runtimes, and Lambda.
+
+```bash
+npm install @supermemory/bash ai @ai-sdk/anthropic zod
+```
 
 ```typescript api/agent.ts
 import { generateText, tool } from "ai";
 import { anthropic } from "@ai-sdk/anthropic";
+import { createBash } from "@supermemory/bash";
 import { z } from "zod";
-import { execSync } from "child_process";
-
-const MEMORY = "./memory";
 
 export async function POST(req: Request) {
   const { prompt } = await req.json();
 
+  const { bash, toolDescription } = await createBash({
+    apiKey: process.env.SUPERMEMORY_API_KEY!,
+    containerTag: "my_agent",
+  });
+
   const result = await generateText({
-    model: anthropic("claude-sonnet-4-20250514"),
+    model: anthropic("claude-sonnet-4-5"),
     tools: {
       bash: tool({
-        description: `Run a bash command. Memory filesystem is at ${MEMORY}.`,
-        parameters: z.object({ command: z.string() }),
-        execute: async ({ command }) => {
-          try {
-            return execSync(command, {
-              cwd: MEMORY,
-              encoding: "utf-8",
-              timeout: 10_000,
-            });
-          } catch (e: any) {
-            return e.stderr || e.message;
-          }
-        },
+        description: toolDescription,
+        inputSchema: z.object({ cmd: z.string() }),
+        execute: async ({ cmd }) => bash.exec(cmd),
       }),
     },
     maxSteps: 10,
@@ -130,10 +141,29 @@ export async function POST(req: Request) {
 }
 ```
 
+A few things worth calling out:
+
+- **`maxSteps: 10`** lets the agent chain multiple bash calls per request
+  (read `profile.md`, then `cat` a few notes, then write a summary). Bump it
+  if your agent needs deeper chains; lower it to cap cost per request.
+- **`toolDescription`** is a pre-written description of the available bash
+  surface (semantic `sgrep`, `cat`, `ls`, redirects, etc.). Hand it straight
+  to the model — don't roll your own.
+- **No timeout/abort plumbing.** `bash.exec` already runs against the
+  container over HTTPS, so it returns when the command returns. No event-loop
+  blocking and no FUSE.
+
+See the [Bash Tool reference](/smfs/bash-tool) for the full command surface,
+memory path configuration, and other framework integrations.
+
 ---
 
 ## Tips
 
-- Mount SMFS once when your server starts, not per-request
-- Use `smfs grep 'query'` for semantic search across all files
-- Use `--ephemeral` if you don't need a local cache on the server
+- **Pattern A**: mount SMFS once when your server starts, not per-request.
+  Use `--ephemeral` if you don't need a local cache on the server.
+- **Pattern B**: configure memory paths once at startup with
+  `configureMemoryPaths(["/notes/", "/journal.md"])` to control which files
+  get distilled into Supermemory memories.
+- Both: use `smfs grep 'query'` (Pattern A) or `sgrep 'query'` inside the
+  bash tool (Pattern B) for semantic search across all files.

--- a/apps/docs/smfs/providers/vercel.mdx
+++ b/apps/docs/smfs/providers/vercel.mdx
@@ -1,63 +1,73 @@
 ---
 title: "Vercel AI SDK"
-sidebarTitle: "Vercel AI SDK"
-description: "Add persistent memory to agents built with the Vercel AI SDK."
-icon: "triangle"
+description: "Give your AI agent persistent memory using SMFS with the Vercel AI SDK"
 ---
 
-The [Vercel AI SDK](https://sdk.vercel.ai) is the most popular framework for building AI agents in TypeScript. SMFS plugs in as a tool — give your agent a `bash` tool backed by `@supermemory/bash` and it can `ls`, `cat`, `grep`, and write to a Supermemory container without any filesystem to manage.
+Mount a Supermemory container on your server and give your Vercel AI SDK agent
+access to it through a bash tool.
 
-## Architecture
+## How it works
 
-The Vercel AI SDK uses a tool-calling pattern: you define tools, the model decides when to call them. `@supermemory/bash` fits this perfectly — it's a single tool that exposes a virtual filesystem backed by Supermemory.
+1. Install SMFS on your server and mount a Supermemory container
+2. Define a bash tool that runs commands against the mount
+3. The Vercel AI SDK agent uses the tool to read/write memory with standard commands
 
-```
-User → AI SDK → LLM → calls bash tool → @supermemory/bash → Supermemory API
-```
-
-No sandbox needed. The bash tool runs in your server process and handles all the memory operations.
+<Note>
+  The Vercel AI SDK runs in your server process (not in a sandbox). SMFS mounts
+  directly on the host where your server runs.
+</Note>
 
 ## Prerequisites
 
-- A [Supermemory](https://console.supermemory.ai) account and API key
-- Node.js 18+
-- An LLM provider (OpenAI, Anthropic, Google, etc.)
+- A [Supermemory API key](https://supermemory.ai)
+- An [OpenAI](https://platform.openai.com) or [Anthropic](https://console.anthropic.com) API key
+- SMFS installed on your server: `curl -fsSL https://smfs.ai/install | bash`
 
-## 1. Install
+## Quick start
 
 ```bash
-npm install @supermemory/bash ai @ai-sdk/openai zod
+npm install ai @ai-sdk/anthropic zod
 ```
 
-## 2. Create an agent with memory
-
 ```typescript agent.ts
-import { createBash } from "@supermemory/bash";
 import { generateText, tool } from "ai";
-import { openai } from "@ai-sdk/openai";
+import { anthropic } from "@ai-sdk/anthropic";
 import { z } from "zod";
+import { execSync } from "child_process";
+
+// Mount SMFS before starting the server:
+//   smfs login --key $SUPERMEMORY_API_KEY
+//   smfs mount my_agent --path ./memory
+
+const MEMORY_PATH = "./memory";
 
 async function main() {
-  // Set up the SMFS bash tool
-  const { bash, toolDescription } = await createBash({
-    apiKey: process.env.SUPERMEMORY_API_KEY!,
-    containerTag: "user_42",
-  });
-
   const result = await generateText({
-    model: openai("gpt-4o"),
+    model: anthropic("claude-sonnet-4-20250514"),
     tools: {
       bash: tool({
-        description: toolDescription,
-        parameters: z.object({ cmd: z.string() }),
-        execute: async ({ cmd }) => bash.exec(cmd),
+        description:
+          "Run a bash command. The persistent memory filesystem is at " +
+          MEMORY_PATH,
+        parameters: z.object({ command: z.string() }),
+        execute: async ({ command }) => {
+          try {
+            return execSync(command, {
+              cwd: MEMORY_PATH,
+              encoding: "utf-8",
+              timeout: 10_000,
+            });
+          } catch (e: any) {
+            return e.stderr || e.message;
+          }
+        },
       }),
     },
     maxSteps: 10,
-    system: `You have access to a persistent memory filesystem via the bash tool.
-Use it to remember things about the user across conversations.
-Start by reading /profile.md to see what you already know.`,
-    prompt: "What do you remember about me?",
+    prompt: `You have access to a persistent memory filesystem at ${MEMORY_PATH}.
+Use the bash tool to explore it (ls, cat) and write notes (echo "..." > file).
+
+Read profile.md to learn about the user, then create session_notes.md with a summary.`,
   });
 
   console.log(result.text);
@@ -66,103 +76,47 @@ Start by reading /profile.md to see what you already know.`,
 main();
 ```
 
-That's it. The model will call `bash({ cmd: "cat /profile.md" })` to read the user's profile, `bash({ cmd: "ls /" })` to browse memory, and `bash({ cmd: "grep 'preferences'" })` to search semantically.
+## Streaming
 
-## 3. Multi-step agent with memory
-
-A more complete example with conversation history and memory persistence:
-
-```typescript chat.ts
-import { createBash } from "@supermemory/bash";
-import { generateText, tool, CoreMessage } from "ai";
-import { openai } from "@ai-sdk/openai";
-import { z } from "zod";
-
-// Create one bash instance per user (reuse across requests)
-const userBashInstances = new Map();
-
-async function getBash(userId: string) {
-  if (!userBashInstances.has(userId)) {
-    const instance = await createBash({
-      apiKey: process.env.SUPERMEMORY_API_KEY!,
-      containerTag: `user_${userId}`,
-    });
-    userBashInstances.set(userId, instance);
-  }
-  return userBashInstances.get(userId);
-}
-
-export async function chat(userId: string, messages: CoreMessage[]) {
-  const { bash, toolDescription } = await getBash(userId);
-
-  return generateText({
-    model: openai("gpt-4o"),
-    tools: {
-      bash: tool({
-        description: toolDescription,
-        parameters: z.object({ cmd: z.string() }),
-        execute: async ({ cmd }) => bash.exec(cmd),
-      }),
-    },
-    maxSteps: 10,
-    system: `You are a helpful assistant with persistent memory.
-
-Use the bash tool to:
-- Read /profile.md at the start of each conversation for context
-- Save important facts to /memory.md
-- Search with grep when looking for specific information
-- Organize notes in subdirectories as needed`,
-    messages,
-  });
-}
-```
-
-## With Vercel AI SDK Streams
-
-For streaming responses in a Next.js app:
-
-```typescript app/api/chat/route.ts
-import { createBash } from "@supermemory/bash";
+```typescript
 import { streamText, tool } from "ai";
-import { openai } from "@ai-sdk/openai";
+import { anthropic } from "@ai-sdk/anthropic";
 import { z } from "zod";
+import { execSync } from "child_process";
 
-export async function POST(req: Request) {
-  const { messages, userId } = await req.json();
+const MEMORY_PATH = "./memory";
 
-  const { bash, toolDescription } = await createBash({
-    apiKey: process.env.SUPERMEMORY_API_KEY!,
-    containerTag: `user_${userId}`,
-  });
+const result = streamText({
+  model: anthropic("claude-sonnet-4-20250514"),
+  tools: {
+    bash: tool({
+      description:
+        "Run a bash command against the memory filesystem at " + MEMORY_PATH,
+      parameters: z.object({ command: z.string() }),
+      execute: async ({ command }) => {
+        try {
+          return execSync(command, {
+            cwd: MEMORY_PATH,
+            encoding: "utf-8",
+            timeout: 10_000,
+          });
+        } catch (e: any) {
+          return e.stderr || e.message;
+        }
+      },
+    }),
+  },
+  maxSteps: 10,
+  prompt: "Read my memory and summarize what you know about me.",
+});
 
-  const result = streamText({
-    model: openai("gpt-4o"),
-    tools: {
-      bash: tool({
-        description: toolDescription,
-        parameters: z.object({ cmd: z.string() }),
-        execute: async ({ cmd }) => bash.exec(cmd),
-      }),
-    },
-    maxSteps: 10,
-    system: "You have persistent memory via the bash tool. Read /profile.md for context.",
-    messages,
-  });
-
-  return result.toDataStreamResponse();
+for await (const chunk of result.textStream) {
+  process.stdout.write(chunk);
 }
 ```
 
 ## Tips
 
-- **One `createBash` per user.** Use the user's ID as the container tag. Each user gets their own isolated memory.
-- **Read `profile.md` first.** Tell the model to `cat /profile.md` at the start of each conversation. It's a live digest of everything in the container.
-- **`sgrep` for semantic search.** Inside the bash tool, `sgrep "query"` searches by meaning, not just text. Regular `grep` does literal matching.
-- **Cache the bash instance.** `createBash` warms the path index on startup. Reuse the instance across requests for the same user.
-- **Works with any LLM provider.** Swap `openai("gpt-4o")` for `anthropic("claude-sonnet-4-20250514")`, `google("gemini-2.0-flash")`, or any AI SDK-compatible provider.
-
-## Resources
-
-- [Vercel AI SDK docs](https://sdk.vercel.ai/docs)
-- [SMFS Bash Tool reference](/smfs/bash-tool)
-- [Supermemory quickstart](/quickstart)
+- Mount SMFS once when your server starts, not per-request
+- Use `smfs grep 'query'` for semantic search across all files in the container
+- Use `--ephemeral` if you don't need a local cache on the server

--- a/apps/docs/smfs/providers/vercel.mdx
+++ b/apps/docs/smfs/providers/vercel.mdx
@@ -8,24 +8,35 @@ write memory using standard filesystem commands.
 
 ## How it works
 
-```
-┌──────────────────────────────────────┐
-│  Your Server                         │
-│                                      │
-│  ┌──────────┐    ┌────────────────┐  │
-│  │  Claude   │───▶│  ./memory      │  │
-│  │  Agent    │    │  (SMFS mount)  │  │
-│  └──────────┘    └───────┬────────┘  │
-│                          │           │
-└──────────────────────────┼───────────┘
-                           │
-                   ┌───────▼───────┐
-                   │  Supermemory  │
-                   └───────────────┘
+There are two ways to wire SMFS into a Vercel-based agent — pick the one that
+fits your architecture.
+
+### Claude Agent SDK (agent has full filesystem access)
+
+The agent runs as a separate process with direct access to the SMFS mount.
+Best when you want the agent to have full bash, read, and write capabilities.
+
+```mermaid
+graph LR
+    subgraph Your Server
+        Agent["Claude Agent"] -->|"cat, ls, echo"| Mount["./memory\n(SMFS mount)"]
+    end
+    Mount -->|sync| SM["Supermemory"]
 ```
 
-SMFS mounts directly on the host. No sandbox needed — the agent runs in your
-server process and accesses memory through the filesystem.
+### Vercel AI SDK (agent uses a tool)
+
+The agent runs inside `generateText` and accesses memory through a bash tool
+you define. Best when you're building an API route and want to keep everything
+in one TypeScript process.
+
+```mermaid
+graph LR
+    subgraph Your Server
+        AI["generateText()"] -->|"bash tool"| Mount["./memory\n(SMFS mount)"]
+    end
+    Mount -->|sync| SM["Supermemory"]
+```
 
 ## Prerequisites
 
@@ -33,27 +44,36 @@ server process and accesses memory through the filesystem.
 - An [Anthropic API key](https://console.anthropic.com)
 - SMFS installed: `curl -fsSL https://smfs.ai/install | bash`
 
-## 1. Mount memory
+## Mount memory
+
+Start the mount once when your server boots — not per-request:
 
 ```bash
 smfs login --key $SUPERMEMORY_API_KEY
 smfs mount my_agent --path ./memory
 ```
 
-## 2. Write your agent
+---
+
+## Pattern A: Claude Agent SDK
+
+Write a standalone agent script. Nothing server-specific — just Python that
+reads and writes files.
 
 ```python agent.py
 import asyncio
 from claude_agent_sdk import query, ClaudeAgentOptions
 
+MEMORY = "./memory"
+
 async def main():
     async for message in query(
-        prompt="You have a persistent memory filesystem at ./memory. "
+        prompt=f"You have a persistent memory filesystem at {MEMORY}. "
                "Read profile.md to learn about the user, then create "
                "session_notes.md summarizing what you found.",
         options=ClaudeAgentOptions(
             allowed_tools=["Bash", "Read", "Write"],
-            cwd="./memory",
+            cwd=MEMORY,
         ),
     ):
         print(message)
@@ -65,13 +85,12 @@ asyncio.run(main())
 python3 agent.py
 ```
 
-That's it. The agent reads and writes files in `./memory` using standard bash
-commands. Everything syncs to Supermemory automatically.
+---
 
-## Using with the Vercel AI SDK
+## Pattern B: Vercel AI SDK
 
-If you're building an API route with the Vercel AI SDK, expose the memory
-filesystem as a tool:
+Expose the memory filesystem as a bash tool inside an API route. The agent
+calls the tool to run commands against the mount.
 
 ```typescript api/agent.ts
 import { generateText, tool } from "ai";
@@ -79,7 +98,6 @@ import { anthropic } from "@ai-sdk/anthropic";
 import { z } from "zod";
 import { execSync } from "child_process";
 
-// SMFS is mounted at ./memory (started when the server boots)
 const MEMORY = "./memory";
 
 export async function POST(req: Request) {
@@ -93,7 +111,11 @@ export async function POST(req: Request) {
         parameters: z.object({ command: z.string() }),
         execute: async ({ command }) => {
           try {
-            return execSync(command, { cwd: MEMORY, encoding: "utf-8", timeout: 10_000 });
+            return execSync(command, {
+              cwd: MEMORY,
+              encoding: "utf-8",
+              timeout: 10_000,
+            });
           } catch (e: any) {
             return e.stderr || e.message;
           }
@@ -107,6 +129,8 @@ export async function POST(req: Request) {
   return Response.json({ text: result.text });
 }
 ```
+
+---
 
 ## Tips
 

--- a/apps/docs/smfs/providers/vercel.mdx
+++ b/apps/docs/smfs/providers/vercel.mdx
@@ -3,40 +3,44 @@ title: "Vercel AI SDK"
 description: "Give your AI agent persistent memory using SMFS with the Vercel AI SDK"
 ---
 
-Mount a Supermemory container on your server and let a Claude agent access it
-through the built-in bash tool.
+Mount a Supermemory container on your server and let a Claude agent read and
+write memory using standard filesystem commands.
 
 ## How it works
 
-1. Install SMFS on your server and mount a Supermemory container
-2. Run a Claude agent with bash tool access — it reads/writes the mount using standard commands
-3. Everything the agent writes persists to Supermemory automatically
+```
+┌──────────────────────────────────────┐
+│  Your Server                         │
+│                                      │
+│  ┌──────────┐    ┌────────────────┐  │
+│  │  Claude   │───▶│  ./memory      │  │
+│  │  Agent    │    │  (SMFS mount)  │  │
+│  └──────────┘    └───────┬────────┘  │
+│                          │           │
+└──────────────────────────┼───────────┘
+                           │
+                   ┌───────▼───────┐
+                   │  Supermemory  │
+                   └───────────────┘
+```
 
-<Note>
-  The Vercel AI SDK runs in your server process (not in a sandbox). SMFS mounts
-  directly on the host where your server runs.
-</Note>
+SMFS mounts directly on the host. No sandbox needed — the agent runs in your
+server process and accesses memory through the filesystem.
 
 ## Prerequisites
 
 - A [Supermemory API key](https://supermemory.ai)
 - An [Anthropic API key](https://console.anthropic.com)
-- SMFS installed on your server: `curl -fsSL https://smfs.ai/install | bash`
+- SMFS installed: `curl -fsSL https://smfs.ai/install | bash`
 
-## Quick start
-
-First, mount SMFS on your server:
+## 1. Mount memory
 
 ```bash
 smfs login --key $SUPERMEMORY_API_KEY
 smfs mount my_agent --path ./memory
 ```
 
-Then run the agent:
-
-```bash
-pip install claude-agent-sdk
-```
+## 2. Write your agent
 
 ```python agent.py
 import asyncio
@@ -44,11 +48,9 @@ from claude_agent_sdk import query, ClaudeAgentOptions
 
 async def main():
     async for message in query(
-        prompt="""You have a persistent memory filesystem at ./memory.
-Use bash to explore it (ls, cat) and write notes (echo "..." > file).
-
-Read ./memory/profile.md to learn about the user.
-Then create ./memory/session_notes.md summarizing what you found.""",
+        prompt="You have a persistent memory filesystem at ./memory. "
+               "Read profile.md to learn about the user, then create "
+               "session_notes.md summarizing what you found.",
         options=ClaudeAgentOptions(
             allowed_tools=["Bash", "Read", "Write"],
             cwd="./memory",
@@ -59,36 +61,55 @@ Then create ./memory/session_notes.md summarizing what you found.""",
 asyncio.run(main())
 ```
 
-Or with TypeScript:
-
 ```bash
-npm install @anthropic-ai/claude-agent-sdk
+python3 agent.py
 ```
 
-```typescript agent.ts
-import { query } from "@anthropic-ai/claude-agent-sdk";
+That's it. The agent reads and writes files in `./memory` using standard bash
+commands. Everything syncs to Supermemory automatically.
 
-async function main() {
-  for await (const message of query({
-    prompt: `You have a persistent memory filesystem at ./memory.
-Use bash to explore it (ls, cat) and write notes (echo "..." > file).
+## Using with the Vercel AI SDK
 
-Read ./memory/profile.md to learn about the user.
-Then create ./memory/session_notes.md summarizing what you found.`,
-    options: {
-      allowedTools: ["Bash", "Read", "Write"],
-      cwd: "./memory",
+If you're building an API route with the Vercel AI SDK, expose the memory
+filesystem as a tool:
+
+```typescript api/agent.ts
+import { generateText, tool } from "ai";
+import { anthropic } from "@ai-sdk/anthropic";
+import { z } from "zod";
+import { execSync } from "child_process";
+
+// SMFS is mounted at ./memory (started when the server boots)
+const MEMORY = "./memory";
+
+export async function POST(req: Request) {
+  const { prompt } = await req.json();
+
+  const result = await generateText({
+    model: anthropic("claude-sonnet-4-20250514"),
+    tools: {
+      bash: tool({
+        description: `Run a bash command. Memory filesystem is at ${MEMORY}.`,
+        parameters: z.object({ command: z.string() }),
+        execute: async ({ command }) => {
+          try {
+            return execSync(command, { cwd: MEMORY, encoding: "utf-8", timeout: 10_000 });
+          } catch (e: any) {
+            return e.stderr || e.message;
+          }
+        },
+      }),
     },
-  })) {
-    if (message.type === "text") console.log(message.text);
-  }
-}
+    maxSteps: 10,
+    prompt,
+  });
 
-main();
+  return Response.json({ text: result.text });
+}
 ```
 
 ## Tips
 
 - Mount SMFS once when your server starts, not per-request
-- Use `smfs grep 'query'` for semantic search across all files in the container
+- Use `smfs grep 'query'` for semantic search across all files
 - Use `--ephemeral` if you don't need a local cache on the server


### PR DESCRIPTION
## SMFS Documentation

Comprehensive SMFS documentation covering provider guides, Python bash tool, and example apps.

### 1. Provider Guides (Mermaid + Both Patterns)

Each provider guide documents **two patterns**:
1. **Agent inside the sandbox** — agent code runs inside the sandbox with direct filesystem access to the SMFS mount
2. **Agent outside the sandbox** — agent runs in your server/Worker and executes commands inside the sandbox remotely

| Provider | Status | Notes |
|----------|--------|-------|
| **E2B** | Working | Full end-to-end verified |
| **Vercel AI SDK** | Working | Pattern A for self-hosted Node, Pattern B uses `@supermemory/bash` for serverless |
| **Cloudflare** | Docker verified | Correct Containers API (`Container` class, `getContainer`, `wrangler.jsonc`) |
| **Daytona** | Blocked | `api.supermemory.ai` unreachable from datacenter IPs — documented with Warning |

Key changes:
- **Mermaid diagrams** replace ASCII art (broken rendering in Mintlify)
- **Two patterns per provider** (agent inside + agent outside sandbox)
- **Cloudflare Containers API corrected** — proper `Container` class, Durable Object bindings, `envVars` for secrets
- **Vercel page scoped correctly** — Pattern A for self-hosted, Pattern B for serverless
- **Security warning** on Cloudflare Pattern B's `/exec` endpoint

### 2. Python Bash Tool Documentation

New page `smfs/bash-tool-python.mdx` documenting the `supermemory-bash` Python package:
- Install via `pip install supermemory-bash` / `uv add supermemory-bash`
- Quickstart with `create_bash(api_key=..., container_tag=...)`
- Agent loop examples for Anthropic SDK and OpenAI SDK
- Memory configuration (`configure_memory_paths`, `profile.md`)
- Full configuration reference table
- Known limitations

### 3. Examples Page

Updated page `smfs/examples.mdx` linking to the [`supermemoryai/examples`](https://github.com/supermemoryai/examples) repo with three web-based demo apps:
- **Research Assistant** — Next.js + `@supermemory/bash` + Vercel AI SDK (upload docs, chat with AI)
- **Knowledge Base** — FastAPI + `supermemory-bash` + vanilla HTML/JS (notes + AI chat)
- **Code Sandbox** — Next.js + E2B SDK + SMFS mount (code editor + AI assistant)

See [supermemoryai/examples#1](https://github.com/supermemoryai/examples/pull/1) for the full example apps.

### Files changed

- `apps/docs/smfs/providers/e2b.mdx` (rewritten)
- `apps/docs/smfs/providers/daytona.mdx` (rewritten)
- `apps/docs/smfs/providers/vercel.mdx` (rewritten)
- `apps/docs/smfs/providers/cloudflare.mdx` (rewritten)
- `apps/docs/smfs/bash-tool-python.mdx` (new)
- `apps/docs/smfs/examples.mdx` (new, updated for web-based apps)
- `apps/docs/docs.json` (modified — nav entries)
- `apps/docs/smfs/overview.mdx` (modified — cards for bash tool + examples)
- `apps/docs/smfs/install.mdx` (modified — `| bash` instead of `| sh`)

### Known issues

- `smfs.ai/install` requires explicit version (`bash -s -- 0.0.1-rc2`) — all GitHub releases are pre-releases
- Install script needs `bash` not `sh` (uses `[[ ]]` syntax)
- E2B: FUSE device needs `sudo chmod 666 /dev/fuse` at runtime; mount files owned by root
- Daytona: `api.supermemory.ai` blocked from datacenter IPs
- Docker: install path is `~/.local/bin/` which needs `ENV PATH="/root/.local/bin:$PATH"`
- `supermemory-bash` Python package not yet published to PyPI (on `python-sdk` branch of `supermemoryai/smfs`)

## Testing

This is a documentation-only change (MDX files). Testing consisted of:

1. **Live provider testing** (done in earlier session iterations):
   - E2B: full end-to-end sandbox creation, SMFS mount, file I/O, Claude agent execution
   - Daytona: confirmed network block, documented with Warning
   - Vercel/local: SMFS mount, file I/O, Claude Agent SDK agent execution
   - Cloudflare: Docker build verified with SMFS + Claude SDK

2. **Review cycle**: simplify + review subagents identified issues across all files. A build subagent addressed all high/medium priority items. Key fixes: Mermaid `\n` to `<br/>`, Cloudflare Containers API correction, Vercel serverless scoping, Daytona file upload bug, security warning on exec endpoint, top-level `await` fix in Python quickstart, `shellQuote` helper in TS example.

3. **Manual verification**: confirmed Mermaid syntax matches existing patterns in the repo (`search/overview.mdx`, `connectors/overview.mdx`), `@supermemory/bash` API matches `bash-tool.mdx` reference, Python SDK API verified against `supermemoryai/smfs` source.