### PR TITLE
Model selection bug in ChatService

### DIFF
--- a/apps/web/components/chat/index.tsx
+++ b/apps/web/components/chat/index.tsx
@@ -164,8 +164,9 @@ export function ChatSidebar({
 	const isMobile = useIsMobile()
 	const isPageDesktop = layout === "page" && !isMobile
 	const [input, setInput] = useState("")
-	const [selectedModel, setSelectedModel] =
-		useState<ModelId>(initialSelectedModel ?? "claude-sonnet-4.6")
+	const [selectedModel, setSelectedModel] = useState<ModelId>(
+		initialSelectedModel ?? "claude-sonnet-4.6",
+	)
 	const selectedModelRef = useRef(selectedModel)
 	selectedModelRef.current = selectedModel
 	const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null)

--- a/apps/web/components/chat/index.tsx
+++ b/apps/web/components/chat/index.tsx
@@ -165,7 +165,9 @@ export function ChatSidebar({
 	const isPageDesktop = layout === "page" && !isMobile
 	const [input, setInput] = useState("")
 	const [selectedModel, setSelectedModel] =
-		useState<ModelId>("claude-sonnet-4.6")
+		useState<ModelId>(initialSelectedModel ?? "claude-sonnet-4.6")
+	const selectedModelRef = useRef(selectedModel)
+	selectedModelRef.current = selectedModel
 	const [copiedMessageId, setCopiedMessageId] = useState<string | null>(null)
 	const [hoveredMessageId, setHoveredMessageId] = useState<string | null>(null)
 	const [messageFeedback, setMessageFeedback] = useState<
@@ -187,6 +189,8 @@ export function ChatSidebar({
 	const sentQueuedMessageRef = useRef<string | null>(null)
 	const { selectedProject } = useProject()
 	const { allProjects } = useContainerTags()
+	const selectedProjectRef = useRef(selectedProject)
+	selectedProjectRef.current = selectedProject
 	const chatSpaceLabel = useMemo(
 		() =>
 			getChatSpaceDisplayLabel({
@@ -206,23 +210,26 @@ export function ChatSidebar({
 		(id: string) => setThreadId(id),
 		[setThreadId],
 	)
+	const chatApiBase =
+		process.env.NEXT_PUBLIC_BACKEND_URL ?? "https://api.supermemory.ai"
+
 	const chatTransport = useMemo(
 		() =>
 			new DefaultChatTransport({
-				api: `${process.env.NEXT_PUBLIC_BACKEND_URL ?? "https://api.supermemory.ai"}/chat`,
+				api: `${chatApiBase}/chat`,
 				credentials: "include",
 				prepareSendMessagesRequest: ({ messages }) => ({
 					body: {
 						messages,
 						metadata: {
 							chatId: chatIdRef.current,
-							projectId: selectedProject,
-							model: selectedModel,
+							projectId: selectedProjectRef.current,
+							model: selectedModelRef.current,
 						},
 					},
 				}),
 			}),
-		[selectedProject, selectedModel],
+		[chatApiBase],
 	)
 	const [pendingThreadLoad, setPendingThreadLoad] = useState<{
 		id: string
@@ -502,6 +509,10 @@ export function ChatSidebar({
 			status !== "streaming" &&
 			sentQueuedMessageRef.current !== queuedMessage
 		) {
+			if (initialSelectedModel && selectedModel !== initialSelectedModel) {
+				setSelectedModel(initialSelectedModel)
+				return
+			}
 			sentQueuedMessageRef.current = queuedMessage
 			if (!threadId) setThreadId(fallbackChatId)
 			analytics.chatMessageSent({ source: queuedMessageSource })
@@ -512,6 +523,8 @@ export function ChatSidebar({
 		isChatOpen,
 		queuedMessage,
 		queuedMessageSource,
+		initialSelectedModel,
+		selectedModel,
 		status,
 		sendMessage,
 		onConsumeQueuedMessage,


### PR DESCRIPTION
## Fix chat model metadata (home composer + transport)

`ChatSidebar` always initialized the chat model to Claude and ignored `initialSelectedModel` from the home. The UI showed your pick, but the request still used Claude because of wrong default + stale “remembered” model. The chat transport also kept a stale closure around `selectedModel` / `selectedProject`, so `useChat` could keep sending the first model in `metadata` even after the user changed it.

### Summary of changes

- **State initialization:** `selectedModel` now initializes from `initialSelectedModel` (falls back to `claude-sonnet-4.6` when not provided).
- **Stale closure fix:** `selectedModelRef` and `selectedProjectRef` so `DefaultChatTransport.prepareSendMessagesRequest` always reads the latest model and project.
- **Queued message handling:** Guard in the `useEffect` that auto-sends queued messages so we sync `selectedModel` to `initialSelectedModel` before `sendMessage`, avoiding the wrong model on the first send.

