### PR TITLE
Fix missing blue gradient (Nova tint) on mobile and adjust position

### DIFF
--- a/apps/web/app/(app)/page.tsx
+++ b/apps/web/app/(app)/page.tsx
@@ -78,7 +78,7 @@ const GRADIENT_TOP_WIDTH_MAX = 1440
 function gradientTopPositionForWidth(width: number) {
 	const minW = 320
 	const pctWide = 15
-	const pctNarrow = 70
+	const pctNarrow = 55
 	const w = Math.min(GRADIENT_TOP_WIDTH_MAX, Math.max(minW, width))
 	const t = (w - minW) / (GRADIENT_TOP_WIDTH_MAX - minW)
 	const eased = t * t
@@ -516,9 +516,8 @@ export default function NewPage() {
 
 	const isChatView = viewMode === "chat"
 	const isGraphMode = viewMode === "graph" && !isMobile
-	const isMemoriesDesktop = viewMode === "list" && !isMobile
-	const isHomeDesktop = viewMode === "dashboard" && !isMobile
-	const showNovaBackdrop = isGraphMode || isMemoriesDesktop || isHomeDesktop
+	const showNovaBackdrop =
+		viewMode === "graph" || viewMode === "list" || viewMode === "dashboard"
 	const isDashboardShell =
 		viewMode === "dashboard" || (viewMode === "graph" && isMobile)
 


### PR DESCRIPTION
The blue gradient background (Nova tint) was hidden on mobile devices because `showNovaBackdrop` required `!isMobile`. This made the app appear as plain black on phones.

### Changes

- **Show gradient on mobile:** `showNovaBackdrop` now includes all view modes (`graph`, `list`, `dashboard`) regardless of screen size
- **Move gradient higher:** Adjusted `pctNarrow` from `70%` to `55%` so the blue tint appears in the middle-upper area on mobile instead of near the bottom
- **Cleanup:** Removed unused `isMemoriesDesktop` and `isHomeDesktop` variables

## Before
<img width="426" height="871" alt="Screenshot 2026-05-08 at 9 40 25 PM" src="https://github.com/user-attachments/assets/6e15cf30-f127-46a6-ab2b-1891c1cd0c7f" />


## After
<img width="499" height="893" alt="Screenshot 2026-05-08 at 9 39 08 PM" src="https://github.com/user-attachments/assets/22258f2f-29db-4932-8f4f-23cbb5c33987" />

