### PR TITLE
fix: fetch chat history when opening recent conversations sheet

### DIFF
--- a/apps/web/components/chat/index.tsx
+++ b/apps/web/components/chat/index.tsx
@@ -399,6 +399,12 @@ export function ChatSidebar({
 		}
 	}, [selectedProject])
 
+	useEffect(() => {
+		if (!isHistoryOpen) return
+		fetchThreads()
+		analytics.chatHistoryViewed?.()
+	}, [isHistoryOpen, fetchThreads])
+
 	const loadThread = useCallback(
 		async (id: string) => {
 			try {
@@ -441,12 +447,14 @@ export function ChatSidebar({
 
 	// Auto-restore thread from URL on mount (e.g. reload or direct link)
 	const didAutoLoadRef = useRef(false)
+	const initialThreadIdRef = useRef(threadId)
 	useEffect(() => {
 		if (didAutoLoadRef.current) return
-		if (!threadId) return
+		const initialThreadId = initialThreadIdRef.current
+		if (!initialThreadId) return
 		didAutoLoadRef.current = true
-		loadThread(threadId)
-	}, [threadId, loadThread])
+		loadThread(initialThreadId)
+	}, [loadThread])
 
 	const deleteThread = useCallback(
 		async (threadId: string) => {
@@ -596,10 +604,7 @@ export function ChatSidebar({
 			open={isHistoryOpen}
 			onOpenChange={(open) => {
 				setIsHistoryOpen(open)
-				if (open) {
-					fetchThreads()
-					analytics.chatHistoryViewed?.()
-				} else {
+				if (!open) {
 					setConfirmingDeleteId(null)
 				}
 			}}


### PR DESCRIPTION
## Problem
Clicking "Recent Conversations" showed empty list because:
1. `fetchThreads()` was only called in Sheet's `onOpenChange`, which doesn't trigger when opened via toolbar button
2. Auto-restore effect tried to load threads from URL even for newly created chats (causing 404s)

## Solution
- Add `useEffect` that triggers `fetchThreads()` whenever `isHistoryOpen` becomes true
- Fix auto-restore to only load threads that existed in URL on initial mount

<img width="1113" height="965" alt="Screenshot 2026-05-10 at 12 17 15 PM" src="https://github.com/user-attachments/assets/1be377d4-0086-4602-bc98-84bfb0d9d13c" />
