### PR TITLE
fix: remove excessive bottom padding below input bar on mobile dashboard

### DIFF
--- a/apps/web/app/(app)/page.tsx
+++ b/apps/web/app/(app)/page.tsx
@@ -698,12 +698,7 @@ export default function NewPage() {
 				</AnimatePresence>
 
 				{isDashboardShell && (
-					<div
-						className={cn(
-							"pointer-events-none fixed inset-x-0 z-30 bg-gradient-to-t from-black via-black/40 to-transparent pt-12",
-							isMobile ? "bottom-[4.5rem]" : "bottom-0",
-						)}
-					>
+					<div className="pointer-events-none fixed inset-x-0 bottom-0 z-30 bg-gradient-to-t from-black via-black/40 to-transparent pt-12">
 						<div className="pointer-events-auto">
 							<HomeChatComposer onStartChat={handleHomeChatStart} />
 						</div>

--- a/apps/web/components/dashboard-view.tsx
+++ b/apps/web/components/dashboard-view.tsx
@@ -697,7 +697,7 @@ export function DashboardView({
 	return (
 		<div
 			className={cn(
-				"min-h-0 flex-1 overflow-y-auto p-4 pt-2! pb-32 md:p-6 md:pb-36 md:pr-0",
+				"min-h-0 flex-1 overflow-y-auto p-4 pt-2! pb-20 md:p-6 md:pb-36 md:pr-0",
 				dmSansClassName(),
 			)}
 		>


### PR DESCRIPTION
## Summary

Fixes excessive bottom padding below the input bar on the mobile dashboard view.

The fixed input bar wrapper had `bottom-[4.5rem]` on mobile, creating a 72px dead gap below it — originally intended for a mobile bottom nav bar that no longer exists. This change removes that offset and adjusts the scroll container padding accordingly.

### Changes

- **`apps/web/app/(app)/page.tsx`** — Removed conditional `bottom-[4.5rem]` mobile offset on the fixed input bar wrapper; now uses `bottom-0` unconditionally
- **`apps/web/components/dashboard-view.tsx`** — Reduced mobile scroll content bottom padding from `pb-32` (128px) to `pb-20` (80px) to match the new input bar position

## Testing

### Static Analysis
- TypeScript type-check: **Pass** (all errors pre-existing in unrelated packages)
- Biome lint on changed files: **Pass** (3 pre-existing warnings, none introduced)

### Visual Layout (Playwright headless, 5 viewports)

Measured DOM metrics for the `HomeChatComposer` overlay wrapper:

| Viewport | Gap below overlay | Result |
|---|---|---|
| Mobile 390x844 (iPhone 14) — initial | 0 px | Pass |
| Mobile 390x844 — scrolled to bottom | 0 px | Pass |
| Mobile 375x667 (iPhone SE) | 0 px | Pass |
| Desktop 1280x800 | 0 px | Pass |
| Breakpoint 767px / 768px boundary | 0 px | Pass |

Input bar is flush at the viewport bottom on all viewports. Desktop behavior unchanged.
