### PR TITLE
Fix chat auto-scroll during streaming responses

### DIFF
--- a/apps/web/components/chat/index.tsx
+++ b/apps/web/components/chat/index.tsx
@@ -553,6 +553,45 @@ export function ChatSidebar({
 		checkIfScrolledToBottom()
 	}, [messages, checkIfScrolledToBottom])
 
+	useEffect(() => {
+		const isStreaming = status === "streaming"
+		const lastMessage = messages[messages.length - 1]
+		const isLastMessageFromAssistant = lastMessage?.role === "assistant"
+
+		if (isStreaming && isLastMessageFromAssistant && isScrolledToBottom) {
+			scrollToBottom()
+		}
+	}, [status, messages, isScrolledToBottom, scrollToBottom])
+
+	useEffect(() => {
+		const container = messagesContainerRef.current
+		if (!container) return
+
+		const isStreaming = status === "streaming"
+		if (!isStreaming) return
+
+		const mutationObserver = new MutationObserver(() => {
+			if (isScrolledToBottom) {
+				requestAnimationFrame(() => {
+					scrollToBottom()
+				})
+			}
+		})
+
+		const messagesWrapper = container.firstElementChild
+		if (messagesWrapper) {
+			mutationObserver.observe(messagesWrapper, {
+				childList: true,
+				subtree: true,
+				characterData: true,
+			})
+		}
+
+		return () => {
+			mutationObserver.disconnect()
+		}
+	}, [status, isScrolledToBottom, scrollToBottom])
+
 	// Add scroll event listener to track scroll position
 	useEffect(() => {
 		const container = messagesContainerRef.current

--- a/apps/web/components/chat/index.tsx
+++ b/apps/web/components/chat/index.tsx
@@ -561,7 +561,11 @@ export function ChatSidebar({
 		const lastMessage = messages[messages.length - 1]
 		const isLastMessageFromAssistant = lastMessage?.role === "assistant"
 
-		if (isStreaming && isLastMessageFromAssistant && isScrolledToBottomRef.current) {
+		if (
+			isStreaming &&
+			isLastMessageFromAssistant &&
+			isScrolledToBottomRef.current
+		) {
 			scrollToBottom()
 		}
 	}, [status, messages, scrollToBottom])

--- a/apps/web/components/chat/index.tsx
+++ b/apps/web/components/chat/index.tsx
@@ -561,10 +561,10 @@ export function ChatSidebar({
 		const lastMessage = messages[messages.length - 1]
 		const isLastMessageFromAssistant = lastMessage?.role === "assistant"
 
-		if (isStreaming && isLastMessageFromAssistant && isScrolledToBottom) {
+		if (isStreaming && isLastMessageFromAssistant && isScrolledToBottomRef.current) {
 			scrollToBottom()
 		}
-	}, [status, messages, isScrolledToBottom, scrollToBottom])
+	}, [status, messages, scrollToBottom])
 
 	useEffect(() => {
 		const container = messagesContainerRef.current

--- a/apps/web/components/chat/index.tsx
+++ b/apps/web/components/chat/index.tsx
@@ -187,6 +187,7 @@ export function ChatSidebar({
 		null,
 	)
 	const messagesContainerRef = useRef<HTMLDivElement>(null)
+	const isScrolledToBottomRef = useRef(true)
 	const sentQueuedMessageRef = useRef<string | null>(null)
 	const { selectedProject } = useProject()
 	const { allProjects } = useContainerTags()
@@ -296,6 +297,7 @@ export function ChatSidebar({
 		const { scrollTop, scrollHeight, clientHeight } = container
 		const distanceFromBottom = scrollHeight - scrollTop - clientHeight
 		const isAtBottom = distanceFromBottom <= 20
+		isScrolledToBottomRef.current = isAtBottom
 		setIsScrolledToBottom(isAtBottom)
 	}, [])
 
@@ -303,6 +305,7 @@ export function ChatSidebar({
 		if (messagesContainerRef.current) {
 			messagesContainerRef.current.scrollTop =
 				messagesContainerRef.current.scrollHeight
+			isScrolledToBottomRef.current = true
 			setIsScrolledToBottom(true)
 		}
 	}, [])
@@ -571,26 +574,23 @@ export function ChatSidebar({
 		if (!isStreaming) return
 
 		const mutationObserver = new MutationObserver(() => {
-			if (isScrolledToBottom) {
+			if (isScrolledToBottomRef.current) {
 				requestAnimationFrame(() => {
 					scrollToBottom()
 				})
 			}
 		})
 
-		const messagesWrapper = container.firstElementChild
-		if (messagesWrapper) {
-			mutationObserver.observe(messagesWrapper, {
-				childList: true,
-				subtree: true,
-				characterData: true,
-			})
-		}
+		mutationObserver.observe(container, {
+			childList: true,
+			subtree: true,
+			characterData: true,
+		})
 
 		return () => {
 			mutationObserver.disconnect()
 		}
-	}, [status, isScrolledToBottom, scrollToBottom])
+	}, [status, scrollToBottom])
 
 	// Add scroll event listener to track scroll position
 	useEffect(() => {


### PR DESCRIPTION
## Summary
Fixed the chat interface to automatically scroll down as the AI model streams its response. Previously, the chat only scrolled when the user sent a message, but not when the assistant's response was being generated.

## Changes Made
- Added a `useEffect` hook to detect when streaming status changes and scroll to bottom
- Added a `MutationObserver` to detect DOM content changes during streaming and auto-scroll in real-time
- auto-scrolling only happens when isScrolledToBottom is true so if user is up and reading his previous message he doesnt go all the way down

Checked on local 

https://github.com/user-attachments/assets/c1b5dea9-d6f1-4f99-881a-23df34707829

