### PR TITLE
feat: improve Add Memory modal — smart note tab, simplified link tab, close confirmation

### DIFF
--- a/apps/web/app/(app)/page.tsx
+++ b/apps/web/app/(app)/page.tsx
@@ -24,6 +24,7 @@ import { RaycastDetail } from "@/components/integrations/raycast-detail"
 import { PluginsDetail } from "@/components/integrations/plugins-detail"
 import { AnimatedGradientBackground } from "@/components/animated-gradient-background"
 import { AddDocumentModal } from "@/components/add-document"
+import { isAcceptedFile } from "@/components/add-document/file"
 import { DocumentModal } from "@/components/document-modal"
 import { DocumentsCommandPalette } from "@/components/documents-command-palette"
 import { FullscreenNoteModal } from "@/components/fullscreen-note-modal"
@@ -49,6 +50,7 @@ import type { z } from "zod"
 import { useViewMode } from "@/lib/view-mode-context"
 import type { MemoryOfDay } from "@/components/dashboard-view"
 import { ErrorBoundary } from "@/components/error-boundary"
+import { FileTextIcon } from "lucide-react"
 import { cn } from "@lib/utils"
 import {
 	addDocumentParam,
@@ -381,6 +383,64 @@ export default function NewPage() {
 		enabled: !!user,
 	})
 
+	// Global file drag-and-drop: dropping files anywhere on the page opens the Add Memory modal
+	const [globalDroppedFiles, setGlobalDroppedFiles] = useState<File[]>([])
+	const [isGlobalDragging, setIsGlobalDragging] = useState(false)
+	const globalDragCounter = useRef(0)
+
+	const handleGlobalDragEnter = useCallback((e: React.DragEvent) => {
+		e.preventDefault()
+		globalDragCounter.current++
+		if (e.dataTransfer.types.includes("Files")) {
+			setIsGlobalDragging(true)
+		}
+	}, [])
+
+	const handleGlobalDragLeave = useCallback((e: React.DragEvent) => {
+		e.preventDefault()
+		globalDragCounter.current--
+		if (globalDragCounter.current === 0) {
+			setIsGlobalDragging(false)
+		}
+	}, [])
+
+	const handleGlobalDragOver = useCallback((e: React.DragEvent) => {
+		e.preventDefault()
+	}, [])
+
+	const handleGlobalDrop = useCallback(
+		(e: React.DragEvent) => {
+			e.preventDefault()
+			globalDragCounter.current = 0
+			setIsGlobalDragging(false)
+			if (addDoc !== null) return // Modal already open, let it handle its own drops
+			const files = Array.from(e.dataTransfer.files)
+			const accepted = files.filter(isAcceptedFile)
+			if (accepted.length === 0) {
+				if (files.length > 0) {
+					toast.error(
+						files.length === 1
+							? "This file type is not supported"
+							: `${files.length} files are not supported`,
+					)
+				}
+				return
+			}
+			const rejected = files.length - accepted.length
+			if (rejected > 0) {
+				toast.error(
+					rejected === 1
+						? "One file type is not supported"
+						: `${rejected} files are not supported`,
+				)
+			}
+			setGlobalDroppedFiles(accepted)
+			analytics.addDocumentModalOpened()
+			setAddDoc("file")
+		},
+		[addDoc, setAddDoc],
+	)
+
 	useHotkeys("c", () => {
 		analytics.addDocumentModalOpened()
 		setAddDoc("note")
@@ -540,7 +600,24 @@ export default function NewPage() {
 					"relative flex min-h-dvh flex-col bg-[#05080D]",
 					isGraphMode && "h-dvh overflow-hidden",
 				)}
+				onDragEnter={handleGlobalDragEnter}
+				onDragLeave={handleGlobalDragLeave}
+				onDragOver={handleGlobalDragOver}
+				onDrop={handleGlobalDrop}
 			>
+				{isGlobalDragging && addDoc === null && (
+					<div className="pointer-events-none fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+						<div className="flex flex-col items-center gap-3 rounded-2xl border-2 border-dashed border-[#4BA0FA] bg-[#4BA0FA]/10 px-12 py-10">
+							<FileTextIcon className="size-10 text-[#4BA0FA]" />
+							<p className="text-lg font-medium text-white">
+								Drop files to add as memories
+							</p>
+							<p className="text-sm text-[#737373]">
+								PDFs, images, documents, and more
+							</p>
+						</div>
+					</div>
+				)}
 				{showNovaBackdrop && (
 					<>
 						<AnimatedGradientBackground
@@ -719,7 +796,11 @@ export default function NewPage() {
 
 				<AddDocumentModal
 					isOpen={addDoc !== null}
-					onClose={() => setAddDoc(null)}
+					onClose={() => {
+						setAddDoc(null)
+						setGlobalDroppedFiles([])
+					}}
+					initialFiles={globalDroppedFiles}
 				/>
 				<DocumentsCommandPalette
 					open={isSearchOpen}

--- a/apps/web/app/(app)/page.tsx
+++ b/apps/web/app/(app)/page.tsx
@@ -390,14 +390,14 @@ export default function NewPage() {
 
 	const handleGlobalDragEnter = useCallback((e: React.DragEvent) => {
 		e.preventDefault()
+		if (!e.dataTransfer.types.includes("Files")) return
 		globalDragCounter.current++
-		if (e.dataTransfer.types.includes("Files")) {
-			setIsGlobalDragging(true)
-		}
+		setIsGlobalDragging(true)
 	}, [])
 
 	const handleGlobalDragLeave = useCallback((e: React.DragEvent) => {
 		e.preventDefault()
+		if (!e.dataTransfer.types.includes("Files")) return
 		globalDragCounter.current--
 		if (globalDragCounter.current === 0) {
 			setIsGlobalDragging(false)
@@ -405,11 +405,13 @@ export default function NewPage() {
 	}, [])
 
 	const handleGlobalDragOver = useCallback((e: React.DragEvent) => {
+		if (!e.dataTransfer.types.includes("Files")) return
 		e.preventDefault()
 	}, [])
 
 	const handleGlobalDrop = useCallback(
 		(e: React.DragEvent) => {
+			if (!e.dataTransfer.types.includes("Files")) return
 			e.preventDefault()
 			globalDragCounter.current = 0
 			setIsGlobalDragging(false)
@@ -421,7 +423,7 @@ export default function NewPage() {
 					toast.error(
 						files.length === 1
 							? "This file type is not supported"
-							: `${files.length} files are not supported`,
+							: `None of the ${files.length} files are supported`,
 					)
 				}
 				return
@@ -595,6 +597,7 @@ export default function NewPage() {
 
 	return (
 		<HotkeysProvider>
+			{/* biome-ignore lint/a11y/noStaticElementInteractions: global file drag-and-drop zone requires event handlers on a div */}
 			<div
 				className={cn(
 					"relative flex min-h-dvh flex-col bg-[#05080D]",

--- a/apps/web/components/add-document/file.tsx
+++ b/apps/web/components/add-document/file.tsx
@@ -33,7 +33,7 @@ interface FileContentProps {
 	isOpen?: boolean
 }
 
-function isAcceptedFile(file: File): boolean {
+export function isAcceptedFile(file: File): boolean {
 	const name = file.name.toLowerCase()
 	const ext = name.includes(".") ? name.slice(name.lastIndexOf(".")) : ""
 	const allowedExt = new Set([
@@ -53,7 +53,7 @@ function isAcceptedFile(file: File): boolean {
 	return false
 }
 
-function fileQueueKey(file: File): string {
+export function fileQueueKey(file: File): string {
 	return `${file.name}:${file.size}:${file.lastModified}`
 }
 

--- a/apps/web/components/add-document/index.tsx
+++ b/apps/web/components/add-document/index.tsx
@@ -190,7 +190,11 @@ export function AddDocument({
 		}
 	}, [isOpen])
 
-	// Seed file queue from global drag-and-drop (only once per modal open)
+	// Seed file queue from global drag-and-drop (only once per modal open).
+	// We construct FileQueueItem objects directly instead of going through
+	// FileContent's addFiles (which does duplicate detection via fileQueueKey)
+	// because this only runs once on a freshly cleared queue, so duplicates
+	// are impossible.
 	const initialFilesConsumed = useRef(false)
 	useEffect(() => {
 		if (!isOpen) {

--- a/apps/web/components/add-document/index.tsx
+++ b/apps/web/components/add-document/index.tsx
@@ -105,6 +105,9 @@ export function AddDocument({
 
 	// Form data state for button click handling
 	const [noteContent, setNoteContent] = useState("")
+	const [noteContentType, setNoteContentType] = useState<"note" | "link">(
+		"note",
+	)
 	const [linkData, setLinkData] = useState<LinkData>({
 		url: "",
 		title: "",
@@ -129,19 +132,28 @@ export function AddDocument({
 	useEffect(() => {
 		if (!isOpen) {
 			setFileData({ items: [], title: "", description: "" })
+			setNoteContentType("note")
 		}
 	}, [isOpen])
 
 	// Submit handlers
 	const handleNoteSubmit = useCallback(
-		(content: string) => {
+		(content: string, contentType: "note" | "link") => {
 			if (!content.trim()) {
 				toast.error("Please enter some content")
 				return
 			}
-			noteMutation.mutate({ content, project: localSelectedProject })
+			if (contentType === "link") {
+				const normalizedUrl = normalizeUrl(content.trim())
+				linkMutation.mutate({
+					url: normalizedUrl,
+					project: localSelectedProject,
+				})
+			} else {
+				noteMutation.mutate({ content, project: localSelectedProject })
+			}
 		},
-		[noteMutation, localSelectedProject],
+		[noteMutation, linkMutation, localSelectedProject],
 	)
 
 	const handleLinkSubmit = useCallback(
@@ -215,6 +227,12 @@ export function AddDocument({
 		setNoteContent(content)
 	}, [])
 
+	const handleNoteRequestSubmit = useCallback(() => {
+		// This will be called by Cmd+Enter from the editor
+		// For now it just does the note submit; Task 3 will expand this for files
+		handleNoteSubmit(noteContent, noteContentType)
+	}, [handleNoteSubmit, noteContent, noteContentType])
+
 	const handleLinkDataChange = useCallback((data: LinkData) => {
 		setLinkData(data)
 	}, [])
@@ -226,7 +244,7 @@ export function AddDocument({
 	const handleButtonClick = () => {
 		switch (activeTab) {
 			case "note":
-				handleNoteSubmit(noteContent)
+				handleNoteSubmit(noteContent, noteContentType)
 				break
 			case "link":
 				handleLinkSubmit(linkData)
@@ -311,6 +329,8 @@ export function AddDocument({
 						<NoteContent
 							onSubmit={handleNoteSubmit}
 							onContentChange={handleNoteContentChange}
+							onContentTypeChange={setNoteContentType}
+							onRequestSubmit={handleNoteRequestSubmit}
 							isSubmitting={noteMutation.isPending}
 							isOpen={isOpen}
 						/>
@@ -389,7 +409,13 @@ export function AddDocument({
 									</>
 								) : (
 									<>
-										+ Add {activeTab}{" "}
+										{activeTab === "note"
+											? noteContentType === "link"
+												? "Save link"
+												: "Save note"
+											: activeTab === "link"
+												? "Save link"
+												: `+ Add ${activeTab}`}{" "}
 										{!isMobile && (
 											<span
 												className={cn(

--- a/apps/web/components/add-document/index.tsx
+++ b/apps/web/components/add-document/index.tsx
@@ -14,9 +14,7 @@ import { FileContent, type FileData } from "./file"
 import { useProject } from "@/stores"
 import { toast } from "sonner"
 import { useDocumentMutations } from "../../hooks/use-document-mutations"
-import { useCustomer } from "autumn-js/react"
-import { useTokenUsage } from "@/hooks/use-token-usage"
-import { formatUsageNumber } from "@/lib/billing-utils"
+import { normalizeUrl } from "@/lib/url-helpers"
 import { SpaceSelector } from "../space-selector"
 import { useIsMobile } from "@hooks/use-mobile"
 import { addDocumentParam } from "@/lib/search-params"
@@ -124,16 +122,6 @@ export function AddDocument({
 		onClose,
 	})
 
-	const autumn = useCustomer()
-	const {
-		tokensUsed,
-		searchesUsed,
-		planUsagePct,
-		hasPaidPlan,
-		isLoading: isLoadingUsage,
-	} = useTokenUsage(autumn)
-	const [isUpgrading, setIsUpgrading] = useState(false)
-
 	useEffect(() => {
 		setLocalSelectedProject(globalSelectedProject)
 	}, [globalSelectedProject])
@@ -158,11 +146,12 @@ export function AddDocument({
 
 	const handleLinkSubmit = useCallback(
 		(data: LinkData) => {
-			if (!data.url.trim()) {
+			const normalizedUrl = normalizeUrl(data.url.trim())
+			if (!normalizedUrl || normalizedUrl === "https://") {
 				toast.error("Please enter a URL")
 				return
 			}
-			linkMutation.mutate({ url: data.url, project: localSelectedProject })
+			linkMutation.mutate({ url: normalizedUrl, project: localSelectedProject })
 		},
 		[linkMutation, localSelectedProject],
 	)
@@ -309,161 +298,6 @@ export function AddDocument({
 						/>
 					))}
 				</div>
-
-				{isMobile && (
-					<div className="mt-3 flex flex-col gap-2">
-						<div className="flex justify-between items-center">
-							<span
-								className={cn(
-									"text-[#FAFAFA] text-sm font-medium",
-									dmSansClassName(),
-								)}
-							>
-								Plan usage
-							</span>
-							<span
-								className={cn(
-									"text-sm font-medium tabular-nums",
-									hasPaidPlan ? "text-[#4BA0FA]" : "text-[#737373]",
-									dmSansClassName(),
-								)}
-							>
-								{isLoadingUsage
-									? "…"
-									: `${planUsagePct < 1 && planUsagePct > 0 ? "< 1" : Math.round(planUsagePct)}% used`}
-							</span>
-						</div>
-						<div className="h-2 w-full rounded-[40px] bg-[#2E353D] p-px overflow-hidden">
-							<div
-								className="h-full rounded-[40px]"
-								style={{
-									width: `${planUsagePct}%`,
-									background:
-										planUsagePct > 80
-											? "#ef4444"
-											: hasPaidPlan
-												? "linear-gradient(to right, #4BA0FA 80%, #002757 100%)"
-												: "#0054AD",
-								}}
-								title={`${formatUsageNumber(tokensUsed)} tokens · ${formatUsageNumber(searchesUsed)} queries`}
-							/>
-						</div>
-						{!isLoadingUsage && (
-							<p
-								className={cn(
-									"text-xs text-[#737373] tabular-nums",
-									dmSansClassName(),
-								)}
-							>
-								{formatUsageNumber(tokensUsed)} tokens ·{" "}
-								{formatUsageNumber(searchesUsed)} queries
-							</p>
-						)}
-					</div>
-				)}
-
-				{!isMobile && (
-					<div data-testid="usage-counter" className="flex flex-col gap-3 mr-4">
-						<div className="flex flex-col gap-2">
-							<div className="flex justify-between items-center">
-								<span
-									className={cn(
-										"text-[#FAFAFA] text-sm font-medium",
-										dmSansClassName(),
-									)}
-								>
-									Plan usage
-								</span>
-								<span
-									className={cn(
-										"text-sm font-medium tabular-nums",
-										hasPaidPlan ? "text-[#4BA0FA]" : "text-[#737373]",
-										dmSansClassName(),
-									)}
-								>
-									{isLoadingUsage
-										? "…"
-										: `${planUsagePct < 1 && planUsagePct > 0 ? "< 1" : Math.round(planUsagePct)}% used`}
-								</span>
-							</div>
-							<div className="h-2 w-full rounded-[40px] bg-[#2E353D] p-px overflow-hidden">
-								<div
-									className="h-full rounded-[40px]"
-									style={{
-										width: `${planUsagePct}%`,
-										background:
-											planUsagePct > 80
-												? "#ef4444"
-												: hasPaidPlan
-													? "linear-gradient(to right, #4BA0FA 80%, #002757 100%)"
-													: "#0054AD",
-									}}
-									title={`${formatUsageNumber(tokensUsed)} tokens · ${formatUsageNumber(searchesUsed)} queries`}
-								/>
-							</div>
-							{!isLoadingUsage && (
-								<p
-									className={cn(
-										"text-xs text-[#737373] tabular-nums",
-										dmSansClassName(),
-									)}
-								>
-									{formatUsageNumber(tokensUsed)} tokens ·{" "}
-									{formatUsageNumber(searchesUsed)} queries
-								</p>
-							)}
-						</div>
-
-						{!hasPaidPlan && (
-							<button
-								type="button"
-								onClick={async () => {
-									setIsUpgrading(true)
-									try {
-										const result = await autumn.attach({
-											planId: "api_pro",
-											successUrl: `${window.location.origin}/settings#account`,
-										})
-										if (result?.paymentUrl) {
-											window.open(result.paymentUrl, "_self")
-											return
-										}
-										autumn.refetch?.()
-									} catch (error) {
-										console.error(error)
-										toast.error("Failed to start checkout. Please try again.")
-									} finally {
-										setIsUpgrading(false)
-									}
-								}}
-								disabled={isUpgrading}
-								className={cn(
-									"relative w-full h-9 rounded-[10px] flex items-center justify-center",
-									"text-[#FAFAFA] font-medium text-[13px]",
-									"disabled:opacity-60 disabled:cursor-not-allowed",
-									"cursor-pointer transition-opacity hover:opacity-90",
-									dmSansClassName(),
-								)}
-								style={{
-									background:
-										"linear-gradient(182.37deg, #0ff0d2 -91.53%, #5bd3fb -67.8%, #1e0ff0 95.17%)",
-									boxShadow:
-										"1px 1px 2px 0px #1A88FF inset, 0 2px 10px 0 rgba(5, 1, 0, 0.20)",
-								}}
-							>
-								{isUpgrading ? (
-									<>
-										<Loader2 className="size-3 animate-spin mr-1.5" />
-										Upgrading…
-									</>
-								) : (
-									"Upgrade to Pro"
-								)}
-								<div className="absolute inset-0 pointer-events-none rounded-[inherit] shadow-[inset_1px_1px_2px_1px_#1A88FF]" />
-							</button>
-						)}
-					</div>
-				)}
 			</div>
 
 			<div

--- a/apps/web/components/add-document/index.tsx
+++ b/apps/web/components/add-document/index.tsx
@@ -29,9 +29,14 @@ type TabType = "note" | "link" | "file" | "connect"
 interface AddDocumentModalProps {
 	isOpen: boolean
 	onClose: () => void
+	initialFiles?: File[]
 }
 
-export function AddDocumentModal({ isOpen, onClose }: AddDocumentModalProps) {
+export function AddDocumentModal({
+	isOpen,
+	onClose,
+	initialFiles,
+}: AddDocumentModalProps) {
 	const isMobile = useIsMobile()
 	const hasUnsavedContentRef = useRef<() => boolean>(() => false)
 	const isSubmittingRef = useRef(false)
@@ -74,6 +79,7 @@ export function AddDocumentModal({ isOpen, onClose }: AddDocumentModalProps) {
 						isOpen={isOpen}
 						hasUnsavedContentRef={hasUnsavedContentRef}
 						isSubmittingRef={isSubmittingRef}
+						initialFiles={initialFiles}
 					/>
 				</div>
 			</DialogContent>
@@ -115,12 +121,14 @@ export function AddDocument({
 	isOpen,
 	hasUnsavedContentRef,
 	isSubmittingRef,
+	initialFiles,
 }: {
 	onClose: () => void
 	onRequestClose?: () => void
 	isOpen?: boolean
 	hasUnsavedContentRef?: React.MutableRefObject<() => boolean>
 	isSubmittingRef?: React.MutableRefObject<boolean>
+	initialFiles?: File[]
 }) {
 	const isMobile = useIsMobile()
 	const [addParam, setAddParam] = useQueryState("add", addDocumentParam)
@@ -181,6 +189,27 @@ export function AddDocument({
 			setNoteDroppedFiles([])
 		}
 	}, [isOpen])
+
+	// Seed file queue from global drag-and-drop (only once per modal open)
+	const initialFilesConsumed = useRef(false)
+	useEffect(() => {
+		if (!isOpen) {
+			initialFilesConsumed.current = false
+			return
+		}
+		if (initialFilesConsumed.current) return
+		if (!initialFiles || initialFiles.length === 0) return
+		initialFilesConsumed.current = true
+		const items: FileQueueItem[] = initialFiles.map((file) => ({
+			id: crypto.randomUUID(),
+			file,
+			status: "pending" as const,
+		}))
+		setFileData((prev) => ({
+			...prev,
+			items: [...prev.items, ...items],
+		}))
+	}, [isOpen, initialFiles])
 
 	// Submit handlers
 	const handleNoteSubmit = useCallback(

--- a/apps/web/components/add-document/index.tsx
+++ b/apps/web/components/add-document/index.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useCallback, useRef } from "react"
+import { useState, useEffect, useCallback, useRef, useMemo } from "react"
 import { useQueryState } from "nuqs"
 import { Dialog, DialogContent, DialogTitle } from "@repo/ui/components/dialog"
 import { cn } from "@lib/utils"
@@ -10,7 +10,12 @@ import { Button } from "@ui/components/button"
 import { ConnectContent } from "./connections"
 import { NoteContent } from "./note"
 import { LinkContent, type LinkData } from "./link"
-import { FileContent, type FileData, type FileQueueItem, fileQueueKey } from "./file"
+import {
+	FileContent,
+	type FileData,
+	type FileQueueItem,
+	fileQueueKey,
+} from "./file"
 import { useProject } from "@/stores"
 import { toast } from "sonner"
 import { useDocumentMutations } from "../../hooks/use-document-mutations"
@@ -31,17 +36,22 @@ export function AddDocumentModal({ isOpen, onClose }: AddDocumentModalProps) {
 	const hasUnsavedContentRef = useRef<() => boolean>(() => false)
 	const isSubmittingRef = useRef(false)
 
-	const handleCloseRequest = useCallback(() => {
+	const confirmThenClose = useCallback(() => {
 		if (isSubmittingRef.current) return // Block close during submission
 		if (hasUnsavedContentRef.current()) {
-			const confirmed = window.confirm("You have unsaved content. Are you sure you want to close?")
+			const confirmed = window.confirm(
+				"You have unsaved content. Are you sure you want to close?",
+			)
 			if (!confirmed) return
 		}
 		onClose()
 	}, [onClose])
 
 	return (
-		<Dialog open={isOpen} onOpenChange={(open: boolean) => !open && handleCloseRequest()}>
+		<Dialog
+			open={isOpen}
+			onOpenChange={(open: boolean) => !open && confirmThenClose()}
+		>
 			<DialogContent
 				className={cn(
 					"border-none bg-[#1B1F24] flex flex-col",
@@ -60,6 +70,7 @@ export function AddDocumentModal({ isOpen, onClose }: AddDocumentModalProps) {
 				<div className="min-h-0 flex-1 overflow-hidden">
 					<AddDocument
 						onClose={onClose}
+						onRequestClose={confirmThenClose}
 						isOpen={isOpen}
 						hasUnsavedContentRef={hasUnsavedContentRef}
 						isSubmittingRef={isSubmittingRef}
@@ -100,11 +111,13 @@ const tabs = [
 
 export function AddDocument({
 	onClose,
+	onRequestClose,
 	isOpen,
 	hasUnsavedContentRef,
 	isSubmittingRef,
 }: {
 	onClose: () => void
+	onRequestClose?: () => void
 	isOpen?: boolean
 	hasUnsavedContentRef?: React.MutableRefObject<() => boolean>
 	isSubmittingRef?: React.MutableRefObject<boolean>
@@ -125,13 +138,12 @@ export function AddDocument({
 
 	// Form data state for button click handling
 	const [noteContent, setNoteContent] = useState("")
+	const [notePlainText, setNotePlainText] = useState("")
 	const [noteContentType, setNoteContentType] = useState<"note" | "link">(
 		"note",
 	)
 	const [linkData, setLinkData] = useState<LinkData>({
 		url: "",
-		title: "",
-		description: "",
 	})
 	const [fileData, setFileData] = useState<FileData>({
 		items: [],
@@ -143,6 +155,10 @@ export function AddDocument({
 
 	const [noteDroppedFiles, setNoteDroppedFiles] = useState<FileQueueItem[]>([])
 
+	// When submitting both text and files simultaneously, the first mutation to
+	// complete would trigger onClose and dismiss the modal before the second
+	// finishes. This ref gates the onClose callback so the combined submission
+	// in handleButtonClick can await both promises and close the modal itself.
 	const skipMutationCloseRef = useRef(false)
 
 	const { noteMutation, linkMutation, fileMutation } = useDocumentMutations({
@@ -160,6 +176,7 @@ export function AddDocument({
 	useEffect(() => {
 		if (!isOpen) {
 			setFileData({ items: [], title: "", description: "" })
+			setNotePlainText("")
 			setNoteContentType("note")
 			setNoteDroppedFiles([])
 		}
@@ -173,7 +190,9 @@ export function AddDocument({
 				return
 			}
 			if (contentType === "link") {
-				const normalizedUrl = normalizeUrl(content.trim())
+				// Use plain text for URL — markdown serialization may wrap URLs
+				// in link syntax like [url](url) which would corrupt the value.
+				const normalizedUrl = normalizeUrl(notePlainText.trim())
 				linkMutation.mutate({
 					url: normalizedUrl,
 					project: localSelectedProject,
@@ -182,7 +201,7 @@ export function AddDocument({
 				noteMutation.mutate({ content, project: localSelectedProject })
 			}
 		},
-		[noteMutation, linkMutation, localSelectedProject],
+		[noteMutation, linkMutation, localSelectedProject, notePlainText],
 	)
 
 	const handleLinkSubmit = useCallback(
@@ -281,15 +300,23 @@ export function AddDocument({
 		setNoteDroppedFiles((prev) => prev.filter((f) => f.id !== id))
 	}, [])
 
+	const handleRetryNoteFile = useCallback((id: string) => {
+		setNoteDroppedFiles((prev) =>
+			prev.map((f) =>
+				f.id === id
+					? { ...f, status: "pending" as const, errorMessage: undefined }
+					: f,
+			),
+		)
+	}, [])
+
 	const handleNoteFileSubmit = useCallback(async () => {
 		const pending = noteDroppedFiles.filter((i) => i.status === "pending")
 		if (pending.length === 0) return
 
 		setNoteDroppedFiles((prev) =>
 			prev.map((i) =>
-				i.status === "pending"
-					? { ...i, status: "uploading" as const }
-					: i,
+				i.status === "pending" ? { ...i, status: "uploading" as const } : i,
 			),
 		)
 
@@ -334,6 +361,10 @@ export function AddDocument({
 		setNoteContent(content)
 	}, [])
 
+	const handleNotePlainTextChange = useCallback((text: string) => {
+		setNotePlainText(text)
+	}, [])
+
 	const handleLinkDataChange = useCallback((data: LinkData) => {
 		setLinkData(data)
 	}, [])
@@ -354,10 +385,12 @@ export function AddDocument({
 					// Save all: text + files
 					skipMutationCloseRef.current = true
 					try {
+						// Use plain text for link URLs — markdown may wrap them in
+						// link syntax like [url](url) which would corrupt the value.
 						const textPromise =
 							noteContentType === "link"
 								? linkMutation.mutateAsync({
-										url: normalizeUrl(noteContent.trim()),
+										url: normalizeUrl(notePlainText.trim()),
 										project: localSelectedProject,
 									})
 								: noteMutation.mutateAsync({
@@ -365,8 +398,13 @@ export function AddDocument({
 										project: localSelectedProject,
 									})
 						const filePromise = handleNoteFileSubmit()
-						await Promise.all([textPromise, filePromise])
-						onClose()
+						const [, fileResult] = await Promise.all([textPromise, filePromise])
+						// Only close if all file uploads succeeded; partial failures
+						// should keep the modal open so users can retry or remove items.
+						const hasFileFailures = fileResult && fileResult.failures.length > 0
+						if (!hasFileFailures) {
+							onClose()
+						}
 					} catch {
 						// At least one failed — modal stays open
 					} finally {
@@ -390,7 +428,23 @@ export function AddDocument({
 				void handleFileSubmit(fileData)
 				break
 		}
-	}, [activeTab, noteDroppedFiles, noteContent, noteContentType, linkMutation, noteMutation, localSelectedProject, handleNoteFileSubmit, onClose, handleNoteSubmit, handleLinkSubmit, linkData, handleFileSubmit, fileData])
+	}, [
+		activeTab,
+		noteDroppedFiles,
+		noteContent,
+		notePlainText,
+		noteContentType,
+		linkMutation,
+		noteMutation,
+		localSelectedProject,
+		handleNoteFileSubmit,
+		onClose,
+		handleNoteSubmit,
+		handleLinkSubmit,
+		linkData,
+		handleFileSubmit,
+		fileData,
+	])
 
 	const handleNoteRequestSubmit = useCallback(() => {
 		// Called by Cmd+Enter from the editor — uses same logic as CTA button
@@ -420,14 +474,30 @@ export function AddDocument({
 		}
 	}, [isSubmitting, isSubmittingRef])
 
-	const handleClose = useCallback(() => {
-		if (isSubmitting) return
-		if (hasUnsavedContent()) {
-			const confirmed = window.confirm("You have unsaved content. Are you sure you want to close?")
-			if (!confirmed) return
+	// Delegate to the parent's confirmation-aware close when available (modal
+	// context), otherwise fall back to closing directly (standalone usage).
+	const handleClose = onRequestClose ?? onClose
+
+	const ctaLabel = useMemo(() => {
+		if (activeTab === "note") {
+			const noteHasPendingFiles = noteDroppedFiles.some(
+				(i) => i.status === "pending",
+			)
+			const noteHasText = noteContent.trim().length > 0
+			if (noteHasText && noteHasPendingFiles) {
+				return "Save all"
+			}
+			if (noteHasPendingFiles) {
+				const pendingCount = noteDroppedFiles.filter(
+					(i) => i.status === "pending",
+				).length
+				return pendingCount === 1 ? "Save file" : `Save ${pendingCount} files`
+			}
+			return noteContentType === "link" ? "Save link" : "Save note"
 		}
-		onClose()
-	}, [isSubmitting, hasUnsavedContent, onClose])
+		if (activeTab === "link") return "Save link"
+		return `+ Add ${activeTab}`
+	}, [activeTab, noteDroppedFiles, noteContent, noteContentType])
 
 	const fileTabHasPending = fileData.items.some((i) => i.status === "pending")
 	const fileTabSubmitDisabled =
@@ -500,12 +570,18 @@ export function AddDocument({
 						<NoteContent
 							onSubmit={handleNoteSubmit}
 							onContentChange={handleNoteContentChange}
+							onPlainTextChange={handleNotePlainTextChange}
 							onContentTypeChange={setNoteContentType}
 							onRequestSubmit={handleNoteRequestSubmit}
-							isSubmitting={noteMutation.isPending || linkMutation.isPending || fileMutation.isPending}
+							isSubmitting={
+								noteMutation.isPending ||
+								linkMutation.isPending ||
+								fileMutation.isPending
+							}
 							isOpen={isOpen}
 							onFilesDropped={handleNoteFilesDropped}
 							onRemoveFile={handleRemoveNoteFile}
+							onRetryFile={handleRetryNoteFile}
 							droppedFiles={noteDroppedFiles.map((f) => ({
 								id: f.id,
 								name: f.file.name,
@@ -589,30 +665,7 @@ export function AddDocument({
 									</>
 								) : (
 									<>
-										{(() => {
-											if (activeTab === "note") {
-												const noteHasPendingFiles = noteDroppedFiles.some(
-													(i) => i.status === "pending",
-												)
-												const noteHasText = noteContent.trim().length > 0
-												if (noteHasText && noteHasPendingFiles) {
-													return "Save all"
-												}
-												if (noteHasPendingFiles) {
-													const pendingCount = noteDroppedFiles.filter(
-														(i) => i.status === "pending",
-													).length
-													return pendingCount === 1
-														? "Save file"
-														: `Save ${pendingCount} files`
-												}
-												return noteContentType === "link"
-													? "Save link"
-													: "Save note"
-											}
-											if (activeTab === "link") return "Save link"
-											return `+ Add ${activeTab}`
-										})()}{" "}
+										{ctaLabel}{" "}
 										{!isMobile && (
 											<span
 												className={cn(

--- a/apps/web/components/add-document/index.tsx
+++ b/apps/web/components/add-document/index.tsx
@@ -28,9 +28,20 @@ interface AddDocumentModalProps {
 
 export function AddDocumentModal({ isOpen, onClose }: AddDocumentModalProps) {
 	const isMobile = useIsMobile()
+	const hasUnsavedContentRef = useRef<() => boolean>(() => false)
+	const isSubmittingRef = useRef(false)
+
+	const handleCloseRequest = useCallback(() => {
+		if (isSubmittingRef.current) return // Block close during submission
+		if (hasUnsavedContentRef.current()) {
+			const confirmed = window.confirm("You have unsaved content. Are you sure you want to close?")
+			if (!confirmed) return
+		}
+		onClose()
+	}, [onClose])
 
 	return (
-		<Dialog open={isOpen} onOpenChange={(open: boolean) => !open && onClose()}>
+		<Dialog open={isOpen} onOpenChange={(open: boolean) => !open && handleCloseRequest()}>
 			<DialogContent
 				className={cn(
 					"border-none bg-[#1B1F24] flex flex-col",
@@ -47,7 +58,12 @@ export function AddDocumentModal({ isOpen, onClose }: AddDocumentModalProps) {
 			>
 				<DialogTitle className="sr-only">Add Document</DialogTitle>
 				<div className="min-h-0 flex-1 overflow-hidden">
-					<AddDocument onClose={onClose} isOpen={isOpen} />
+					<AddDocument
+						onClose={onClose}
+						isOpen={isOpen}
+						hasUnsavedContentRef={hasUnsavedContentRef}
+						isSubmittingRef={isSubmittingRef}
+					/>
 				</div>
 			</DialogContent>
 		</Dialog>
@@ -85,9 +101,13 @@ const tabs = [
 export function AddDocument({
 	onClose,
 	isOpen,
+	hasUnsavedContentRef,
+	isSubmittingRef,
 }: {
 	onClose: () => void
 	isOpen?: boolean
+	hasUnsavedContentRef?: React.MutableRefObject<() => boolean>
+	isSubmittingRef?: React.MutableRefObject<boolean>
 }) {
 	const isMobile = useIsMobile()
 	const [addParam, setAddParam] = useQueryState("add", addDocumentParam)
@@ -380,6 +400,35 @@ export function AddDocument({
 	const isSubmitting =
 		noteMutation.isPending || linkMutation.isPending || fileMutation.isPending
 
+	const hasUnsavedContent = useCallback((): boolean => {
+		if (noteContent.trim().length > 0) return true
+		if (noteDroppedFiles.length > 0) return true
+		if (linkData.url.trim().length > 0) return true
+		if (fileData.items.length > 0) return true
+		return false
+	}, [noteContent, noteDroppedFiles, linkData, fileData])
+
+	useEffect(() => {
+		if (hasUnsavedContentRef) {
+			hasUnsavedContentRef.current = hasUnsavedContent
+		}
+	}, [hasUnsavedContent, hasUnsavedContentRef])
+
+	useEffect(() => {
+		if (isSubmittingRef) {
+			isSubmittingRef.current = isSubmitting
+		}
+	}, [isSubmitting, isSubmittingRef])
+
+	const handleClose = useCallback(() => {
+		if (isSubmitting) return
+		if (hasUnsavedContent()) {
+			const confirmed = window.confirm("You have unsaved content. Are you sure you want to close?")
+			if (!confirmed) return
+		}
+		onClose()
+	}, [isSubmitting, hasUnsavedContent, onClose])
+
 	const fileTabHasPending = fileData.items.some((i) => i.status === "pending")
 	const fileTabSubmitDisabled =
 		activeTab === "file" && (!fileTabHasPending || isSubmitting)
@@ -411,7 +460,7 @@ export function AddDocument({
 						</div>
 						<button
 							type="button"
-							onClick={onClose}
+							onClick={handleClose}
 							disabled={isSubmitting}
 							className="flex size-9 items-center justify-center rounded-full border border-[#1F2937] bg-[#0D121A] text-[#8B8B8B] transition-colors hover:text-white disabled:opacity-50"
 							aria-label="Close add memory"
@@ -515,7 +564,7 @@ export function AddDocument({
 					>
 						<Button
 							variant="ghost"
-							onClick={onClose}
+							onClick={handleClose}
 							disabled={isSubmitting}
 							className={cn(
 								"cursor-pointer rounded-full text-[#737373]",

--- a/apps/web/components/add-document/index.tsx
+++ b/apps/web/components/add-document/index.tsx
@@ -10,7 +10,7 @@ import { Button } from "@ui/components/button"
 import { ConnectContent } from "./connections"
 import { NoteContent } from "./note"
 import { LinkContent, type LinkData } from "./link"
-import { FileContent, type FileData } from "./file"
+import { FileContent, type FileData, type FileQueueItem, fileQueueKey } from "./file"
 import { useProject } from "@/stores"
 import { toast } from "sonner"
 import { useDocumentMutations } from "../../hooks/use-document-mutations"
@@ -121,8 +121,16 @@ export function AddDocument({
 	const fileDataRef = useRef(fileData)
 	fileDataRef.current = fileData
 
+	const [noteDroppedFiles, setNoteDroppedFiles] = useState<FileQueueItem[]>([])
+
+	const skipMutationCloseRef = useRef(false)
+
 	const { noteMutation, linkMutation, fileMutation } = useDocumentMutations({
-		onClose,
+		onClose: () => {
+			if (!skipMutationCloseRef.current) {
+				onClose()
+			}
+		},
 	})
 
 	useEffect(() => {
@@ -133,6 +141,7 @@ export function AddDocument({
 		if (!isOpen) {
 			setFileData({ items: [], title: "", description: "" })
 			setNoteContentType("note")
+			setNoteDroppedFiles([])
 		}
 	}, [isOpen])
 
@@ -222,16 +231,88 @@ export function AddDocument({
 		[fileMutation, localSelectedProject],
 	)
 
+	const handleNoteFilesDropped = useCallback((files: File[]) => {
+		setNoteDroppedFiles((prev) => {
+			const existingKeys = new Set(prev.map((i) => fileQueueKey(i.file)))
+			let duplicateCount = 0
+			const toAdd: FileQueueItem[] = []
+			for (const file of files) {
+				const key = fileQueueKey(file)
+				if (existingKeys.has(key)) {
+					duplicateCount++
+					continue
+				}
+				existingKeys.add(key)
+				toAdd.push({ id: crypto.randomUUID(), file, status: "pending" })
+			}
+			if (duplicateCount > 0) {
+				toast.message(
+					duplicateCount === 1
+						? "Skipped duplicate file"
+						: `Skipped ${duplicateCount} duplicate files`,
+				)
+			}
+			if (toAdd.length === 0) return prev
+			return [...prev, ...toAdd]
+		})
+	}, [])
+
+	const handleRemoveNoteFile = useCallback((id: string) => {
+		setNoteDroppedFiles((prev) => prev.filter((f) => f.id !== id))
+	}, [])
+
+	const handleNoteFileSubmit = useCallback(async () => {
+		const pending = noteDroppedFiles.filter((i) => i.status === "pending")
+		if (pending.length === 0) return
+
+		setNoteDroppedFiles((prev) =>
+			prev.map((i) =>
+				i.status === "pending"
+					? { ...i, status: "uploading" as const }
+					: i,
+			),
+		)
+
+		try {
+			const result = await fileMutation.mutateAsync({
+				fileEntries: pending.map((i) => ({ id: i.id, file: i.file })),
+				project: localSelectedProject,
+			})
+			setNoteDroppedFiles((prev) =>
+				prev.map((i) => {
+					if (i.status !== "uploading") return i
+					const fail = result.failures.find((f) => f.id === i.id)
+					if (fail) {
+						return {
+							...i,
+							status: "error" as const,
+							errorMessage: fail.message,
+						}
+					}
+					return { ...i, status: "success" as const }
+				}),
+			)
+			return result
+		} catch {
+			setNoteDroppedFiles((prev) =>
+				prev.map((i) =>
+					i.status === "uploading"
+						? {
+								...i,
+								status: "error" as const,
+								errorMessage: "Upload failed",
+							}
+						: i,
+				),
+			)
+			throw new Error("File upload failed")
+		}
+	}, [noteDroppedFiles, fileMutation, localSelectedProject])
+
 	// Data change handlers
 	const handleNoteContentChange = useCallback((content: string) => {
 		setNoteContent(content)
 	}, [])
-
-	const handleNoteRequestSubmit = useCallback(() => {
-		// This will be called by Cmd+Enter from the editor
-		// For now it just does the note submit; Task 3 will expand this for files
-		handleNoteSubmit(noteContent, noteContentType)
-	}, [handleNoteSubmit, noteContent, noteContentType])
 
 	const handleLinkDataChange = useCallback((data: LinkData) => {
 		setLinkData(data)
@@ -241,11 +322,47 @@ export function AddDocument({
 		setFileData(data)
 	}, [])
 
-	const handleButtonClick = () => {
+	const handleButtonClick = useCallback(async () => {
 		switch (activeTab) {
-			case "note":
-				handleNoteSubmit(noteContent, noteContentType)
+			case "note": {
+				const hasPendingFiles = noteDroppedFiles.some(
+					(i) => i.status === "pending",
+				)
+				const hasText = noteContent.trim().length > 0
+
+				if (hasText && hasPendingFiles) {
+					// Save all: text + files
+					skipMutationCloseRef.current = true
+					try {
+						const textPromise =
+							noteContentType === "link"
+								? linkMutation.mutateAsync({
+										url: normalizeUrl(noteContent.trim()),
+										project: localSelectedProject,
+									})
+								: noteMutation.mutateAsync({
+										content: noteContent,
+										project: localSelectedProject,
+									})
+						const filePromise = handleNoteFileSubmit()
+						await Promise.all([textPromise, filePromise])
+						onClose()
+					} catch {
+						// At least one failed — modal stays open
+					} finally {
+						skipMutationCloseRef.current = false
+					}
+				} else if (hasPendingFiles) {
+					void handleNoteFileSubmit().catch(() => {
+						/* errors handled in handleNoteFileSubmit */
+					})
+				} else if (hasText) {
+					handleNoteSubmit(noteContent, noteContentType)
+				} else {
+					toast.error("Please enter some content or drop a file")
+				}
 				break
+			}
 			case "link":
 				handleLinkSubmit(linkData)
 				break
@@ -253,7 +370,12 @@ export function AddDocument({
 				void handleFileSubmit(fileData)
 				break
 		}
-	}
+	}, [activeTab, noteDroppedFiles, noteContent, noteContentType, linkMutation, noteMutation, localSelectedProject, handleNoteFileSubmit, onClose, handleNoteSubmit, handleLinkSubmit, linkData, handleFileSubmit, fileData])
+
+	const handleNoteRequestSubmit = useCallback(() => {
+		// Called by Cmd+Enter from the editor — uses same logic as CTA button
+		void handleButtonClick()
+	}, [handleButtonClick])
 
 	const isSubmitting =
 		noteMutation.isPending || linkMutation.isPending || fileMutation.isPending
@@ -331,8 +453,17 @@ export function AddDocument({
 							onContentChange={handleNoteContentChange}
 							onContentTypeChange={setNoteContentType}
 							onRequestSubmit={handleNoteRequestSubmit}
-							isSubmitting={noteMutation.isPending}
+							isSubmitting={noteMutation.isPending || linkMutation.isPending || fileMutation.isPending}
 							isOpen={isOpen}
+							onFilesDropped={handleNoteFilesDropped}
+							onRemoveFile={handleRemoveNoteFile}
+							droppedFiles={noteDroppedFiles.map((f) => ({
+								id: f.id,
+								name: f.file.name,
+								size: f.file.size,
+								status: f.status,
+								errorMessage: f.errorMessage,
+							}))}
 						/>
 					)}
 					{activeTab === "link" && (
@@ -396,7 +527,7 @@ export function AddDocument({
 						{activeTab !== "connect" && (
 							<Button
 								variant="insideOut"
-								onClick={handleButtonClick}
+								onClick={() => void handleButtonClick()}
 								disabled={
 									activeTab === "file" ? fileTabSubmitDisabled : isSubmitting
 								}
@@ -409,13 +540,30 @@ export function AddDocument({
 									</>
 								) : (
 									<>
-										{activeTab === "note"
-											? noteContentType === "link"
-												? "Save link"
-												: "Save note"
-											: activeTab === "link"
-												? "Save link"
-												: `+ Add ${activeTab}`}{" "}
+										{(() => {
+											if (activeTab === "note") {
+												const noteHasPendingFiles = noteDroppedFiles.some(
+													(i) => i.status === "pending",
+												)
+												const noteHasText = noteContent.trim().length > 0
+												if (noteHasText && noteHasPendingFiles) {
+													return "Save all"
+												}
+												if (noteHasPendingFiles) {
+													const pendingCount = noteDroppedFiles.filter(
+														(i) => i.status === "pending",
+													).length
+													return pendingCount === 1
+														? "Save file"
+														: `Save ${pendingCount} files`
+												}
+												return noteContentType === "link"
+													? "Save link"
+													: "Save note"
+											}
+											if (activeTab === "link") return "Save link"
+											return `+ Add ${activeTab}`
+										})()}{" "}
 										{!isMobile && (
 											<span
 												className={cn(

--- a/apps/web/components/add-document/link.tsx
+++ b/apps/web/components/add-document/link.tsx
@@ -4,12 +4,10 @@ import { useState, useEffect } from "react"
 import { cn } from "@lib/utils"
 import { dmSansClassName } from "@/lib/fonts"
 import { useHotkeys } from "react-hotkeys-hook"
+import { normalizeUrl } from "@/lib/url-helpers"
 
 export interface LinkData {
 	url: string
-	title: string
-	description: string
-	image?: string
 }
 
 interface LinkContentProps {
@@ -31,20 +29,13 @@ export function LinkContent({
 
 	const handleSubmit = () => {
 		if (canSubmit && onSubmit) {
-			let normalizedUrl = url.trim()
-			if (
-				!normalizedUrl.startsWith("http://") &&
-				!normalizedUrl.startsWith("https://")
-			) {
-				normalizedUrl = `https://${normalizedUrl}`
-			}
-			onSubmit({ url: normalizedUrl, title: "", description: "" })
+			onSubmit({ url: normalizeUrl(url.trim()) })
 		}
 	}
 
 	const handleUrlChange = (newUrl: string) => {
 		setUrl(newUrl)
-		onDataChange?.({ url: newUrl, title: "", description: "" })
+		onDataChange?.({ url: newUrl })
 	}
 
 	useHotkeys("mod+enter", handleSubmit, {
@@ -56,7 +47,7 @@ export function LinkContent({
 	useEffect(() => {
 		if (!isOpen) {
 			setUrl("")
-			onDataChange?.({ url: "", title: "", description: "" })
+			onDataChange?.({ url: "" })
 		}
 	}, [isOpen, onDataChange])
 

--- a/apps/web/components/add-document/link.tsx
+++ b/apps/web/components/add-document/link.tsx
@@ -2,11 +2,8 @@
 
 import { useState, useEffect } from "react"
 import { cn } from "@lib/utils"
-import { Button } from "@ui/components/button"
 import { dmSansClassName } from "@/lib/fonts"
 import { useHotkeys } from "react-hotkeys-hook"
-import { Image as ImageIcon, Loader2 } from "lucide-react"
-import { toast } from "sonner"
 
 export interface LinkData {
 	url: string
@@ -29,10 +26,6 @@ export function LinkContent({
 	isOpen,
 }: LinkContentProps) {
 	const [url, setUrl] = useState("")
-	const [title, setTitle] = useState("")
-	const [description, setDescription] = useState("")
-	const [image, setImage] = useState<string | undefined>(undefined)
-	const [isPreviewLoading, setIsPreviewLoading] = useState(false)
 
 	const canSubmit = url.trim().length > 0 && !isSubmitting
 
@@ -45,90 +38,13 @@ export function LinkContent({
 			) {
 				normalizedUrl = `https://${normalizedUrl}`
 			}
-			onSubmit({ url: normalizedUrl, title, description })
+			onSubmit({ url: normalizedUrl, title: "", description: "" })
 		}
-	}
-
-	const updateData = (
-		newUrl: string,
-		newTitle: string,
-		newDescription: string,
-		newImage?: string,
-	) => {
-		onDataChange?.({
-			url: newUrl,
-			title: newTitle,
-			description: newDescription,
-			...(newImage && { image: newImage }),
-		})
 	}
 
 	const handleUrlChange = (newUrl: string) => {
 		setUrl(newUrl)
-		updateData(newUrl, title, description, image)
-	}
-
-	const handleTitleChange = (newTitle: string) => {
-		setTitle(newTitle)
-		updateData(url, newTitle, description)
-	}
-
-	const handleDescriptionChange = (newDescription: string) => {
-		setDescription(newDescription)
-		updateData(url, title, newDescription, image)
-	}
-
-	const handlePreviewLink = async () => {
-		if (!url.trim()) {
-			toast.error("Please enter a URL first")
-			return
-		}
-
-		let normalizedUrl = url.trim()
-		if (
-			!normalizedUrl.startsWith("http://") &&
-			!normalizedUrl.startsWith("https://")
-		) {
-			normalizedUrl = `https://${normalizedUrl}`
-			setUrl(normalizedUrl)
-			updateData(normalizedUrl, title, description, image)
-		}
-
-		setIsPreviewLoading(true)
-		try {
-			const response = await fetch(
-				`/api/og?url=${encodeURIComponent(normalizedUrl)}`,
-			)
-
-			if (!response.ok) {
-				const errorData = await response.json().catch(() => ({}))
-				throw new Error(errorData.error || "Failed to fetch preview")
-			}
-
-			const data = await response.json()
-
-			const newTitle = data.title || ""
-			const newDescription = data.description || ""
-			const newImage = data.image || undefined
-
-			setTitle(newTitle)
-			setDescription(newDescription)
-			setImage(newImage)
-			updateData(url, newTitle, newDescription, newImage)
-
-			if (!newTitle && !newDescription && !newImage) {
-				toast.info("No Open Graph data found for this URL")
-			} else {
-				toast.success("Preview loaded successfully")
-			}
-		} catch (error) {
-			console.error("Preview error:", error)
-			toast.error(
-				error instanceof Error ? error.message : "Failed to load preview",
-			)
-		} finally {
-			setIsPreviewLoading(false)
-		}
+		onDataChange?.({ url: newUrl, title: "", description: "" })
 	}
 
 	useHotkeys("mod+enter", handleSubmit, {
@@ -140,9 +56,6 @@ export function LinkContent({
 	useEffect(() => {
 		if (!isOpen) {
 			setUrl("")
-			setTitle("")
-			setDescription("")
-			setImage(undefined)
 			onDataChange?.({ url: "", title: "", description: "" })
 		}
 	}, [isOpen, onDataChange])
@@ -155,83 +68,14 @@ export function LinkContent({
 				>
 					Paste a link to turn it into a memory
 				</p>
-				<div className="flex relative">
-					<input
-						type="text"
-						value={url}
-						onChange={(e) => handleUrlChange(e.target.value)}
-						placeholder="https://example.com"
-						disabled={isSubmitting}
-						className="w-full p-4 rounded-xl bg-[#14161A] shadow-inside-out disabled:opacity-50 outline-1 outline-transparent focus:outline-[#525D6EB2]"
-					/>
-					<Button
-						variant="linkPreview"
-						className="absolute right-2 top-2"
-						disabled={isSubmitting || isPreviewLoading || !url.trim()}
-						onClick={handlePreviewLink}
-					>
-						{isPreviewLoading ? (
-							<>
-								<Loader2 className="size-4 animate-spin mr-2" />
-								Loading…
-							</>
-						) : (
-							"Preview Link"
-						)}
-					</Button>
-				</div>
-			</div>
-			<div className="bg-[#14161A] rounded-[14px] py-6 px-4 space-y-4 shadow-inside-out">
-				<div>
-					<p className="pl-2 pb-2 font-semibold text-[16px] text-[#737373]">
-						Link title
-					</p>
-					<input
-						type="text"
-						value={title}
-						onChange={(e) => handleTitleChange(e.target.value)}
-						placeholder="Mahesh Sanikommu - Portfolio"
-						disabled
-						className="w-full px-4 py-3 bg-[#0F1217] rounded-xl disabled:opacity-50 outline-1 outline-transparent focus:outline-[#525D6EB2]"
-					/>
-				</div>
-				<div>
-					<p className="pl-2 pb-2 font-semibold text-[16px] text-[#737373]">
-						Link description
-					</p>
-					<textarea
-						value={description}
-						onChange={(e) => handleDescriptionChange(e.target.value)}
-						placeholder="Portfolio website of Mahesh Sanikommu"
-						disabled
-						className="w-full px-4 py-3 bg-[#0F1217] rounded-xl resize-none disabled:opacity-50 outline-1 outline-transparent focus:outline-[#525D6EB2]"
-					/>
-				</div>
-				<div>
-					<p className="pl-2 pb-2 font-semibold text-[16px] text-[#737373]">
-						Link Preview Image
-					</p>
-					{image ? (
-						<div className="w-full max-w-md aspect-4/2 bg-[#0F1217] rounded-xl overflow-hidden">
-							<img
-								src={image}
-								alt={title || "Link preview"}
-								className="size-full object-cover"
-								onError={(e) => {
-									e.currentTarget.style.display = "none"
-									e.currentTarget.parentElement?.classList.add("opacity-50")
-									e.currentTarget.parentElement?.classList.add("flex")
-									e.currentTarget.parentElement?.classList.add("items-center")
-									e.currentTarget.parentElement?.classList.add("justify-center")
-								}}
-							/>
-						</div>
-					) : (
-						<div className="w-full max-w-md aspect-4/2 bg-[#0F1217] opacity-50 rounded-xl flex items-center justify-center">
-							<ImageIcon className="size-8 text-[#737373]" />
-						</div>
-					)}
-				</div>
+				<input
+					type="text"
+					value={url}
+					onChange={(e) => handleUrlChange(e.target.value)}
+					placeholder="https://example.com/article"
+					disabled={isSubmitting}
+					className="w-full p-4 rounded-xl bg-[#14161A] shadow-inside-out disabled:opacity-50 outline-1 outline-transparent focus:outline-[#525D6EB2]"
+				/>
 			</div>
 		</div>
 	)

--- a/apps/web/components/add-document/note.tsx
+++ b/apps/web/components/add-document/note.tsx
@@ -2,10 +2,35 @@
 
 import { useState, useEffect } from "react"
 import { TextEditor } from "../text-editor"
+import { isValidUrl } from "@/lib/url-helpers"
+
+function detectContentType(plainText: string): "note" | "link" {
+	const trimmed = plainText.trim()
+	if (!trimmed) return "note"
+	// Must be a single token (no whitespace)
+	if (/\s/.test(trimmed)) return "note"
+	// Try as-is first (has protocol)
+	if (
+		trimmed.startsWith("http://") ||
+		trimmed.startsWith("https://") ||
+		trimmed.startsWith("HTTP://") ||
+		trimmed.startsWith("HTTPS://")
+	) {
+		if (isValidUrl(trimmed)) return "link"
+		return "note"
+	}
+	// Protocol-less: require a dot to avoid classifying single words as links
+	if (!trimmed.includes(".")) return "note"
+	const withProtocol = `https://${trimmed}`
+	if (isValidUrl(withProtocol)) return "link"
+	return "note"
+}
 
 interface NoteContentProps {
-	onSubmit?: (content: string) => void
+	onSubmit?: (content: string, contentType: "note" | "link") => void
 	onContentChange?: (content: string) => void
+	onContentTypeChange?: (type: "note" | "link") => void
+	onRequestSubmit?: () => void
 	isSubmitting?: boolean
 	isOpen?: boolean
 }
@@ -13,16 +38,24 @@ interface NoteContentProps {
 export function NoteContent({
 	onSubmit,
 	onContentChange,
+	onContentTypeChange,
+	onRequestSubmit,
 	isSubmitting,
 	isOpen,
 }: NoteContentProps) {
 	const [content, setContent] = useState("")
+	const [plainText, setPlainText] = useState("")
 
 	const canSubmit = content.trim().length > 0 && !isSubmitting
 
 	const handleSubmit = () => {
 		if (canSubmit && onSubmit) {
-			onSubmit(content)
+			const type = detectContentType(plainText)
+			if (type === "link") {
+				onSubmit(plainText.trim(), "link")
+			} else {
+				onSubmit(content, "note")
+			}
 		}
 	}
 
@@ -35,6 +68,7 @@ export function NoteContent({
 	useEffect(() => {
 		if (!isOpen) {
 			setContent("")
+			setPlainText("")
 			onContentChange?.("")
 		}
 	}, [isOpen, onContentChange])
@@ -44,7 +78,12 @@ export function NoteContent({
 			<TextEditor
 				content={undefined}
 				onContentChange={handleContentChange}
-				onSubmit={handleSubmit}
+				onPlainTextChange={(text) => {
+					setPlainText(text)
+					const type = detectContentType(text)
+					onContentTypeChange?.(type)
+				}}
+				onSubmit={onRequestSubmit ?? handleSubmit}
 				debounceMs={0}
 			/>
 		</div>

--- a/apps/web/components/add-document/note.tsx
+++ b/apps/web/components/add-document/note.tsx
@@ -1,8 +1,17 @@
 "use client"
 
-import { useState, useEffect } from "react"
+import { useState, useEffect, useRef } from "react"
 import { TextEditor } from "../text-editor"
 import { isValidUrl } from "@/lib/url-helpers"
+import { isAcceptedFile } from "./file"
+import { toast } from "sonner"
+import {
+	FileIcon,
+	XIcon,
+	Loader2,
+	CheckIcon,
+	AlertCircleIcon,
+} from "lucide-react"
 
 function detectContentType(plainText: string): "note" | "link" {
 	const trimmed = plainText.trim()
@@ -33,6 +42,15 @@ interface NoteContentProps {
 	onRequestSubmit?: () => void
 	isSubmitting?: boolean
 	isOpen?: boolean
+	onFilesDropped?: (files: File[]) => void
+	onRemoveFile?: (id: string) => void
+	droppedFiles?: {
+		id: string
+		name: string
+		size: number
+		status: "pending" | "uploading" | "success" | "error"
+		errorMessage?: string
+	}[]
 }
 
 export function NoteContent({
@@ -42,9 +60,14 @@ export function NoteContent({
 	onRequestSubmit,
 	isSubmitting,
 	isOpen,
+	onFilesDropped,
+	onRemoveFile,
+	droppedFiles,
 }: NoteContentProps) {
 	const [content, setContent] = useState("")
 	const [plainText, setPlainText] = useState("")
+	const [isDragging, setIsDragging] = useState(false)
+	const dragCounter = useRef(0)
 
 	const canSubmit = content.trim().length > 0 && !isSubmitting
 
@@ -64,6 +87,45 @@ export function NoteContent({
 		onContentChange?.(newContent)
 	}
 
+	const handleDragEnter = (e: React.DragEvent) => {
+		e.preventDefault()
+		dragCounter.current++
+		setIsDragging(true)
+	}
+
+	const handleDragLeave = (e: React.DragEvent) => {
+		e.preventDefault()
+		dragCounter.current--
+		if (dragCounter.current === 0) setIsDragging(false)
+	}
+
+	const handleDragOver = (e: React.DragEvent) => {
+		e.preventDefault()
+	}
+
+	const handleDrop = (e: React.DragEvent) => {
+		e.preventDefault()
+		e.stopPropagation()
+		dragCounter.current = 0
+		setIsDragging(false)
+
+		if (e.dataTransfer.files?.length) {
+			const incoming = Array.from(e.dataTransfer.files)
+			const accepted = incoming.filter(isAcceptedFile)
+			const rejected = incoming.length - accepted.length
+			if (rejected > 0) {
+				toast.error(
+					rejected === 1
+						? "One file type is not supported"
+						: `${rejected} files are not supported`,
+				)
+			}
+			if (accepted.length > 0) {
+				onFilesDropped?.(accepted)
+			}
+		}
+	}
+
 	// Reset content when modal closes
 	useEffect(() => {
 		if (!isOpen) {
@@ -74,18 +136,70 @@ export function NoteContent({
 	}, [isOpen, onContentChange])
 
 	return (
-		<div className="flex h-full min-h-[45dvh] w-full flex-1 overflow-y-auto rounded-[14px] bg-[#10151C] p-3 shadow-inside-out ring-1 ring-[#202A36] md:mb-4! md:bg-[#14161A] md:p-4 md:ring-0">
-			<TextEditor
-				content={undefined}
-				onContentChange={handleContentChange}
-				onPlainTextChange={(text) => {
-					setPlainText(text)
-					const type = detectContentType(text)
-					onContentTypeChange?.(type)
-				}}
-				onSubmit={onRequestSubmit ?? handleSubmit}
-				debounceMs={0}
-			/>
+		<div className="flex h-full flex-col">
+			<div
+				className="relative flex min-h-[45dvh] w-full flex-1 overflow-y-auto rounded-[14px] bg-[#10151C] p-3 shadow-inside-out ring-1 ring-[#202A36] md:mb-4! md:bg-[#14161A] md:p-4 md:ring-0"
+				onDragEnter={handleDragEnter}
+				onDragLeave={handleDragLeave}
+				onDragOver={handleDragOver}
+				onDrop={handleDrop}
+			>
+				<TextEditor
+					content={undefined}
+					onContentChange={handleContentChange}
+					onPlainTextChange={(text) => {
+						setPlainText(text)
+						const type = detectContentType(text)
+						onContentTypeChange?.(type)
+					}}
+					onSubmit={onRequestSubmit ?? handleSubmit}
+					debounceMs={0}
+				/>
+				{isDragging && (
+					<div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center rounded-[14px] border-2 border-dashed border-[#4BA0FA] bg-[#4BA0FA]/10">
+						<div className="flex items-center gap-2 text-sm text-[#4BA0FA]">
+							<FileIcon className="size-4" />
+							Drop files here
+						</div>
+					</div>
+				)}
+			</div>
+			{droppedFiles && droppedFiles.length > 0 && (
+				<div className="flex flex-wrap gap-2 px-1 pt-2">
+					{droppedFiles.map((file) => (
+						<div
+							key={file.id}
+							className="flex items-center gap-1.5 rounded-lg bg-[#14161A] px-2.5 py-1.5 text-xs text-[#D7DEE8]"
+						>
+							<FileIcon className="size-3 text-[#737373]" />
+							<span className="max-w-[150px] truncate">{file.name}</span>
+							<span className="text-[#737373]">
+								{(file.size / 1024 / 1024).toFixed(1)}MB
+							</span>
+							{file.status === "pending" && onRemoveFile && (
+								<button
+									type="button"
+									onClick={() => onRemoveFile(file.id)}
+									className="ml-0.5 text-[#737373] hover:text-white"
+								>
+									<XIcon className="size-3" />
+								</button>
+							)}
+							{file.status === "uploading" && (
+								<Loader2 className="size-3 animate-spin text-[#4BA0FA]" />
+							)}
+							{file.status === "success" && (
+								<CheckIcon className="size-3 text-green-500" />
+							)}
+							{file.status === "error" && (
+								<span className="text-red-400" title={file.errorMessage}>
+									<AlertCircleIcon className="size-3" />
+								</span>
+							)}
+						</div>
+					))}
+				</div>
+			)}
 		</div>
 	)
 }

--- a/apps/web/components/add-document/note.tsx
+++ b/apps/web/components/add-document/note.tsx
@@ -18,13 +18,9 @@ function detectContentType(plainText: string): "note" | "link" {
 	if (!trimmed) return "note"
 	// Must be a single token (no whitespace)
 	if (/\s/.test(trimmed)) return "note"
-	// Try as-is first (has protocol)
-	if (
-		trimmed.startsWith("http://") ||
-		trimmed.startsWith("https://") ||
-		trimmed.startsWith("HTTP://") ||
-		trimmed.startsWith("HTTPS://")
-	) {
+	// Try as-is first (has protocol — case-insensitive check)
+	const lower = trimmed.toLowerCase()
+	if (lower.startsWith("http://") || lower.startsWith("https://")) {
 		if (isValidUrl(trimmed)) return "link"
 		return "note"
 	}
@@ -38,12 +34,14 @@ function detectContentType(plainText: string): "note" | "link" {
 interface NoteContentProps {
 	onSubmit?: (content: string, contentType: "note" | "link") => void
 	onContentChange?: (content: string) => void
+	onPlainTextChange?: (text: string) => void
 	onContentTypeChange?: (type: "note" | "link") => void
 	onRequestSubmit?: () => void
 	isSubmitting?: boolean
 	isOpen?: boolean
 	onFilesDropped?: (files: File[]) => void
 	onRemoveFile?: (id: string) => void
+	onRetryFile?: (id: string) => void
 	droppedFiles?: {
 		id: string
 		name: string
@@ -56,12 +54,14 @@ interface NoteContentProps {
 export function NoteContent({
 	onSubmit,
 	onContentChange,
+	onPlainTextChange,
 	onContentTypeChange,
 	onRequestSubmit,
 	isSubmitting,
 	isOpen,
 	onFilesDropped,
 	onRemoveFile,
+	onRetryFile,
 	droppedFiles,
 }: NoteContentProps) {
 	const [content, setContent] = useState("")
@@ -150,6 +150,7 @@ export function NoteContent({
 					onContentChange={handleContentChange}
 					onPlainTextChange={(text) => {
 						setPlainText(text)
+						onPlainTextChange?.(text)
 						const type = detectContentType(text)
 						onContentTypeChange?.(type)
 					}}
@@ -177,15 +178,16 @@ export function NoteContent({
 							<span className="text-[#737373]">
 								{(file.size / 1024 / 1024).toFixed(1)}MB
 							</span>
-							{file.status === "pending" && onRemoveFile && (
-								<button
-									type="button"
-									onClick={() => onRemoveFile(file.id)}
-									className="ml-0.5 text-[#737373] hover:text-white"
-								>
-									<XIcon className="size-3" />
-								</button>
-							)}
+							{(file.status === "pending" || file.status === "error") &&
+								onRemoveFile && (
+									<button
+										type="button"
+										onClick={() => onRemoveFile(file.id)}
+										className="ml-0.5 text-[#737373] hover:text-white"
+									>
+										<XIcon className="size-3" />
+									</button>
+								)}
 							{file.status === "uploading" && (
 								<Loader2 className="size-3 animate-spin text-[#4BA0FA]" />
 							)}
@@ -193,9 +195,20 @@ export function NoteContent({
 								<CheckIcon className="size-3 text-green-500" />
 							)}
 							{file.status === "error" && (
-								<span className="text-red-400" title={file.errorMessage}>
-									<AlertCircleIcon className="size-3" />
-								</span>
+								<>
+									<span className="text-red-400" title={file.errorMessage}>
+										<AlertCircleIcon className="size-3" />
+									</span>
+									{onRetryFile && (
+										<button
+											type="button"
+											onClick={() => onRetryFile(file.id)}
+											className="ml-0.5 text-xs text-[#4BA0FA] hover:underline"
+										>
+											Retry
+										</button>
+									)}
+								</>
 							)}
 						</div>
 					))}

--- a/apps/web/components/add-document/note.tsx
+++ b/apps/web/components/add-document/note.tsx
@@ -137,6 +137,7 @@ export function NoteContent({
 
 	return (
 		<div className="flex h-full flex-col">
+			{/* biome-ignore lint/a11y/noStaticElementInteractions: drag-and-drop zone requires event handlers on a div */}
 			<div
 				className="relative flex min-h-[45dvh] w-full flex-1 overflow-y-auto rounded-[14px] bg-[#10151C] p-3 shadow-inside-out ring-1 ring-[#202A36] md:mb-4! md:bg-[#14161A] md:p-4 md:ring-0"
 				onDragEnter={handleDragEnter}

--- a/apps/web/components/text-editor/index.tsx
+++ b/apps/web/components/text-editor/index.tsx
@@ -16,11 +16,13 @@ const extensions = [...defaultExtensions, slashCommand, Markdown]
 export function TextEditor({
 	content: initialContent,
 	onContentChange,
+	onPlainTextChange,
 	onSubmit,
 	debounceMs = 500,
 }: {
 	content: string | undefined
 	onContentChange: (content: string) => void
+	onPlainTextChange?: (text: string) => void
 	onSubmit: () => void
 	debounceMs?: number
 }) {
@@ -38,6 +40,8 @@ export function TextEditor({
 		const json = editor.getJSON()
 		const markdown = editor.storage.markdown?.manager?.serialize(json) ?? ""
 		onContentChange?.(markdown)
+		const plainText = editor.getText()
+		onPlainTextChange?.(plainText)
 	}, debounceMs)
 
 	const editor = useEditor({
@@ -55,6 +59,8 @@ export function TextEditor({
 				const json = editor.getJSON()
 				const markdown = editor.storage.markdown?.manager?.serialize(json) ?? ""
 				onContentChange?.(markdown)
+				const plainText = editor.getText()
+				onPlainTextChange?.(plainText)
 				return
 			}
 			debouncedUpdates(editor)


### PR DESCRIPTION
## Add Memory Modal Improvements

Addresses the 72% abandonment rate on the Add Memory modal by improving UX across multiple areas.

### Changes

**1. Simplified Link Tab**
- Removed the broken preview section (disabled title/description/image fields that were never sent to the API)
- URL input is now full-width with clearer placeholder
- Uses shared `normalizeUrl` helper instead of inline protocol-prepend
- Simplified `LinkData` interface to just `{ url: string }`

**2. Smart Note Tab with URL Detection**
- Note tab auto-detects when content is a single URL and changes CTA to "Save link"
- Detection uses plain text (not markdown) to avoid Tiptap serialization issues
- Requires a dot in hostname for protocol-less URLs to prevent false positives (e.g., "idea", "todo" stay as notes)
- Case-insensitive protocol matching (handles `Http://`, `HTTPS://`, etc.)

**3. File Drag-and-Drop in Note Tab**
- Dragging files over the note editor shows a blue dashed overlay
- Dropped files appear as compact chips below the editor with status indicators
- CTA dynamically updates: "Save file", "Save N files", "Save all" (text + files)
- Combined text+file submission uses coordinated `Promise.all` — modal only closes when all operations succeed
- Failed uploads show retry and remove buttons
- Duplicate files are detected and skipped with a toast

**4. Close Confirmation**
- All close paths (outside click, Escape, Cancel, mobile X) now check for unsaved content
- Shows `window.confirm` dialog when content exists in any tab
- Close is blocked entirely during active submissions
- Successful saves bypass the confirmation

**5. Usage Bar Removal**
- Removed plan usage bar and "Upgrade to Pro" CTA from the modal sidebar (both desktop and mobile)
- Eliminates billing anxiety during the content-adding flow

**6. Global File Drag-and-Drop**
- Dropping files anywhere on the main page opens the Add Memory modal with files pre-loaded in the file tab
- Full-screen overlay with "Drop files to add as memories" appears during drag
- Only intercepts file drags — non-file drags (text, links) pass through to child elements
- Unsupported file types show error toast, accepted files are queued automatically
- Settings page is excluded (separate page component)

### Files Changed

| File | What changed |
|------|-------------|
| `apps/web/app/(app)/page.tsx` | Global file drag-and-drop handlers, overlay UI, `initialFiles` state |
| `apps/web/components/add-document/index.tsx` | Modal shell, submission routing, close confirmation, CTA logic, usage bar removal, `initialFiles` prop |
| `apps/web/components/add-document/note.tsx` | URL detection, file drag-and-drop, file chips UI |
| `apps/web/components/add-document/link.tsx` | Removed preview section, simplified interface |
| `apps/web/components/add-document/file.tsx` | Exported `isAcceptedFile` and `fileQueueKey` helpers |
| `apps/web/components/text-editor/index.tsx` | Added `onPlainTextChange` callback |

## Testing

### Static Analysis
- **Biome lint** (`npx biome check --changed --since=origin/main`): All 6 changed files pass
- **TypeScript** (`npx tsc --noEmit --project apps/web/tsconfig.json`): No new type errors in changed files (pre-existing errors in unrelated files exist on main)

### Browser Tests (44 passed, 0 failed, 2 skipped)

**Link Tab Simplification (11/11 passed)**
- Preview section (button, title, description, image) confirmed absent
- URL input present with correct placeholder
- CTA reads "Save link"
- Empty URL submission blocked with error toast
- Bare domain accepted, `https://` alone blocked
- Cmd+Enter hint visible

**Note Tab URL Detection (8/8 passed)**
- Empty editor → "Save note"
- Single word without dot → "Save note"
- Sentence with spaces → "Save note"
- Bare domain with dot (`example.com`) → "Save link"
- Full URL → "Save link"
- Two URLs with space → "Save note" (whitespace rule)
- Clearing URL reverts CTA to "Save note"

**File Drag-and-Drop (9/9 passed, 2 skipped)**
- Drag overlay appears/disappears correctly
- File chip renders with correct CTA ("Save file")
- Multiple files → "Save 2 files"
- Unsupported file type → error toast
- Mixed drop → rejected toast + accepted chip
- Text + file → "Save all"
- Empty submit → error toast

Skipped tests (headless browser limitations, not code bugs):
- D-5 (duplicate detection): `DataTransfer`-created `File` objects have non-deterministic `lastModified` in headless mode, so same-name files get different queue keys
- D-8 (remove chip): Chip identity changes across accumulated drag-and-drop state, making text-based locator unreliable

**Usage Bar Removal (5/5 passed)**
- "Plan usage" text absent on desktop and mobile
- `data-testid="usage-counter"` element absent from DOM
- "Upgrade to Pro" button absent
- Usage absent across all tabs (Note, Link, File, Connect)

**Close Confirmation (9/9 passed)**
- Empty modal closes without confirmation (X, Cancel, Escape)
- Content in editor triggers confirmation dialog
- Dismissing dialog keeps modal open
- Accepting dialog closes modal
- Escape with content triggers confirmation
- Link URL triggers confirmation
- File chip triggers confirmation
- Cleared content → no confirmation

**Cross-cutting (1/1 passed)**
- Reopening modal resets all state (empty editor, "Save note" CTA, no chips)

**Global Drag-and-Drop (static analysis only)**
- Biome lint passes (biome-ignore for drag zone div)
- TypeScript passes (no new errors)
- All drag handlers guarded behind `Files` type check to avoid breaking non-file drops
- `initialFilesConsumed` ref prevents double-seeding on re-renders


---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/c3167bf4-d044-435c-8100-039331a3fd8f)
- Requested by: Mahesh Sanikommu (mahesh@supermemory.com)
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
