### PR TITLE
fix: Add plugin document rendering and MCP preview support

### DIFF
--- a/apps/web/components/document-cards/mcp-preview.tsx
+++ b/apps/web/components/document-cards/mcp-preview.tsx
@@ -5,11 +5,24 @@ import type { z } from "zod"
 import { dmSansClassName } from "@/lib/fonts"
 import { cn } from "@lib/utils"
 import { ClaudeDesktopIcon, MCPIcon } from "@ui/assets/icons"
+import { parsePluginDocument } from "@/lib/plugin-document"
+import { PluginPreview } from "./plugin-preview"
 
 type DocumentsResponse = z.infer<typeof DocumentsWithMemoriesResponseSchema>
 type DocumentWithMemories = DocumentsResponse["documents"][0]
 
 export function McpPreview({ document }: { document: DocumentWithMemories }) {
+	const pluginDocument = parsePluginDocument(document)
+	if (pluginDocument) {
+		return <PluginPreview parsed={pluginDocument} />
+	}
+	const clientName =
+		typeof document.metadata?.sm_internal_mcp_client_name === "string"
+			? document.metadata.sm_internal_mcp_client_name
+					.replace(/[_-]+/g, " ")
+					.replace(/\b\w/g, (match) => match.toUpperCase())
+			: "MCP Client"
+
 	return (
 		<div className="bg-[#0B1017] p-3 rounded-[18px] space-y-2">
 			<div className="flex items-center justify-between gap-1">
@@ -20,7 +33,7 @@ export function McpPreview({ document }: { document: DocumentWithMemories }) {
 					)}
 				>
 					<ClaudeDesktopIcon className="size-3" />
-					Claude Desktop
+					{clientName}
 				</p>
 				<MCPIcon className="size-6" />
 			</div>

--- a/apps/web/components/document-cards/note-preview.tsx
+++ b/apps/web/components/document-cards/note-preview.tsx
@@ -5,11 +5,18 @@ import type { z } from "zod"
 import { dmSansClassName } from "@/lib/fonts"
 import { cn } from "@lib/utils"
 import { DocumentIcon } from "@/components/document-icon"
+import { parsePluginDocument } from "@/lib/plugin-document"
+import { PluginPreview } from "./plugin-preview"
 
 type DocumentsResponse = z.infer<typeof DocumentsWithMemoriesResponseSchema>
 type DocumentWithMemories = DocumentsResponse["documents"][0]
 
 export function NotePreview({ document }: { document: DocumentWithMemories }) {
+	const pluginDocument = parsePluginDocument(document)
+	if (pluginDocument) {
+		return <PluginPreview parsed={pluginDocument} />
+	}
+
 	return (
 		<div className="bg-[#0B1017] p-3 rounded-[18px] space-y-2">
 			<div className="flex items-center gap-1">

--- a/apps/web/components/document-cards/plugin-preview.tsx
+++ b/apps/web/components/document-cards/plugin-preview.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import { dmSansClassName } from "@/lib/fonts"
+import { cn } from "@lib/utils"
+import type { ParsedPluginDocument } from "@/lib/plugin-document"
+
+export function PluginPreview({ parsed }: { parsed: ParsedPluginDocument }) {
+	return (
+		<div className="bg-[#0B1017] p-3 rounded-[18px] space-y-2">
+			<div className="flex items-center justify-between gap-2">
+				<div className="flex items-center gap-2 min-w-0">
+					<span
+						className={cn(
+							dmSansClassName(),
+							"inline-flex items-center rounded-full border border-[#2261CA33] bg-[#0D1A2E] px-2 py-1 text-[10px] font-medium text-[#8FC8FF]",
+						)}
+					>
+						{parsed.pluginLabel}
+					</span>
+					<p className="text-[11px] text-[#737373] truncate">
+						{parsed.formatLabel}
+					</p>
+				</div>
+				{parsed.identifierValue && (
+					<p className="text-[10px] text-[#737373] truncate max-w-[45%]">
+						{parsed.identifierValue}
+					</p>
+				)}
+			</div>
+			<div className="space-y-[6px]">
+				<p
+					className={cn(
+						dmSansClassName(),
+						"text-[13px] font-semibold line-clamp-2 leading-[125%]",
+					)}
+				>
+					{parsed.title}
+				</p>
+				<p className="text-[11px] text-[#737373] line-clamp-4">
+					{parsed.preview || parsed.summary}
+				</p>
+			</div>
+		</div>
+	)
+}

--- a/apps/web/components/document-modal/content/index.tsx
+++ b/apps/web/components/document-modal/content/index.tsx
@@ -12,6 +12,8 @@ import { WebPageContent } from "./web-page"
 import { TextEditorContent } from "./text-editor-content"
 import { GoogleDocViewer } from "./google-doc"
 import type { TextEditorProps } from "./text-editor-content"
+import type { ParsedPluginDocument } from "@/lib/plugin-document"
+import { PluginContent } from "./plugin-content"
 
 export type { TextEditorProps }
 
@@ -33,6 +35,7 @@ type DocumentWithMemories = DocumentsResponse["documents"][0]
 interface DocumentContentProps {
 	document: DocumentWithMemories | null
 	textEditorProps: TextEditorProps
+	pluginDocument?: ParsedPluginDocument | null
 }
 
 type ContentType =
@@ -73,10 +76,14 @@ function getContentType(document: DocumentWithMemories | null): ContentType {
 export function DocumentContent({
 	document,
 	textEditorProps,
+	pluginDocument,
 }: DocumentContentProps) {
 	const contentType = getContentType(document)
 
 	if (!document || !contentType) return null
+	if (pluginDocument) {
+		return <PluginContent parsed={pluginDocument} />
+	}
 
 	switch (contentType) {
 		case "image":

--- a/apps/web/components/document-modal/content/plugin-content.tsx
+++ b/apps/web/components/document-modal/content/plugin-content.tsx
@@ -1,0 +1,218 @@
+"use client"
+
+import { useState } from "react"
+import { cn } from "@lib/utils"
+import { dmSansClassName } from "@/lib/fonts"
+import type {
+	ParsedPluginDocument,
+	PluginDocumentMessage,
+	PluginDocumentSection,
+} from "@/lib/plugin-document"
+
+function roleLabel(role: PluginDocumentMessage["role"]): string {
+	switch (role) {
+		case "user":
+			return "User"
+		case "assistant":
+			return "Assistant"
+		case "tool":
+			return "Tool"
+		case "system":
+			return "System"
+		default:
+			return "Message"
+	}
+}
+
+function roleClasses(role: PluginDocumentMessage["role"]): string {
+	switch (role) {
+		case "user":
+			return "border-[#2261CA33] bg-[#0D1A2E] text-[#8FC8FF]"
+		case "assistant":
+			return "border-[#1E3E33] bg-[#0E1915] text-[#8EF0B2]"
+		case "tool":
+			return "border-[#554116] bg-[#171208] text-[#F4C97A]"
+		case "system":
+			return "border-[#3B3B3B] bg-[#151515] text-[#D4D4D4]"
+		default:
+			return "border-[#2A2F37] bg-[#12151A] text-[#D4D4D4]"
+	}
+}
+
+function sectionClasses(tone: PluginDocumentSection["tone"]): string {
+	switch (tone) {
+		case "accent":
+			return "border-[#2261CA33] bg-[#0C1829]"
+		case "muted":
+			return "border-[#252A31] bg-[#11151A]"
+		default:
+			return "border-[#1E232B] bg-[#0F1318]"
+	}
+}
+
+function PluginHeader({ parsed }: { parsed: ParsedPluginDocument }) {
+	return (
+		<div className="px-4 pt-4 pb-3 border-b border-white/6 bg-[#14181E]">
+			<div className="flex flex-wrap items-center gap-2">
+				<span
+					className={cn(
+						dmSansClassName(),
+						"inline-flex items-center rounded-full border border-[#2261CA33] bg-[#0D1A2E] px-2.5 py-1 text-[11px] font-medium text-[#8FC8FF]",
+					)}
+				>
+					{parsed.pluginLabel}
+				</span>
+				<span
+					className={cn(
+						dmSansClassName(),
+						"inline-flex items-center rounded-full border border-[#1F242C] bg-[#0F1318] px-2.5 py-1 text-[11px] font-medium text-[#B7BDC7]",
+					)}
+				>
+					{parsed.formatLabel}
+				</span>
+				{parsed.identifierLabel && parsed.identifierValue && (
+					<span
+						className={cn(
+							dmSansClassName(),
+							"inline-flex items-center rounded-full border border-[#1F242C] bg-[#0F1318] px-2.5 py-1 text-[11px] font-medium text-[#8E97A3]",
+						)}
+					>
+						{parsed.identifierLabel}: {parsed.identifierValue}
+					</span>
+				)}
+			</div>
+			<p
+				className={cn(
+					dmSansClassName(),
+					"mt-3 text-[18px] font-semibold text-[#FAFAFA] leading-[120%]",
+				)}
+			>
+				{parsed.title}
+			</p>
+			<p className="mt-1 text-sm text-[#8E97A3] leading-[150%]">
+				{parsed.summary}
+			</p>
+		</div>
+	)
+}
+
+function ConversationView({ parsed }: { parsed: ParsedPluginDocument }) {
+	return (
+		<div className="flex-1 overflow-y-auto scrollbar-thin px-4 py-4 space-y-3">
+			{parsed.messages.map((message) => (
+				<div
+					key={message.id}
+					className="rounded-[16px] border border-[#1C2128] bg-[#101419] overflow-hidden"
+				>
+					<div className="px-3 py-2 border-b border-white/6 bg-[#131820] flex items-center justify-between">
+						<span
+							className={cn(
+								dmSansClassName(),
+								"inline-flex items-center rounded-full border px-2.5 py-1 text-[11px] font-medium",
+								roleClasses(message.role),
+							)}
+						>
+							{roleLabel(message.role)}
+						</span>
+					</div>
+					<div className="px-3 py-3">
+						<p className="whitespace-pre-wrap text-[14px] leading-[1.55] text-[#E7EAF0]">
+							{message.text}
+						</p>
+					</div>
+				</div>
+			))}
+		</div>
+	)
+}
+
+function SectionsView({ parsed }: { parsed: ParsedPluginDocument }) {
+	return (
+		<div className="flex-1 overflow-y-auto scrollbar-thin px-4 py-4 space-y-3">
+			{parsed.sections.map((section, index) => (
+				<div
+					key={`${section.label}-${index}`}
+					className={cn(
+						"rounded-[16px] border px-4 py-4",
+						sectionClasses(section.tone),
+					)}
+				>
+					<p
+						className={cn(
+							dmSansClassName(),
+							"text-[12px] font-medium uppercase tracking-[0.08em] text-[#8E97A3]",
+						)}
+					>
+						{section.label}
+					</p>
+					<p className="mt-2 whitespace-pre-wrap text-[15px] leading-[1.6] text-[#F1F3F5]">
+						{section.value}
+					</p>
+				</div>
+			))}
+		</div>
+	)
+}
+
+function RawView({ parsed }: { parsed: ParsedPluginDocument }) {
+	return (
+		<div className="flex-1 overflow-y-auto scrollbar-thin p-4">
+			<pre className="rounded-[16px] border border-[#1E232B] bg-[#0D1116] p-4 whitespace-pre-wrap break-words text-[13px] leading-[1.6] text-[#C7CDD6]">
+				{parsed.rawContent}
+			</pre>
+		</div>
+	)
+}
+
+export function PluginContent({ parsed }: { parsed: ParsedPluginDocument }) {
+	const [mode, setMode] = useState<"structured" | "raw">("structured")
+	const hasMessages = parsed.messages.length > 0
+
+	return (
+		<div className="flex h-full flex-col">
+			<PluginHeader parsed={parsed} />
+			<div className="px-4 pt-3">
+				<div
+					className={cn(
+						dmSansClassName(),
+						"inline-flex h-9 items-center gap-0.5 rounded-full border border-[#161F2C] bg-[#0D121A] p-0.5",
+					)}
+				>
+					<button
+						type="button"
+						aria-pressed={mode === "structured"}
+						className={cn(
+							"inline-flex h-full items-center justify-center rounded-full border px-3 text-xs font-medium cursor-pointer transition-colors",
+							mode === "structured"
+								? "border-[#2261CA33] bg-[#00173C] text-white"
+								: "border-transparent text-[#737373] hover:bg-white/5",
+						)}
+						onClick={() => setMode("structured")}
+					>
+						{hasMessages ? "Conversation" : "Structured"}
+					</button>
+					<button
+						type="button"
+						aria-pressed={mode === "raw"}
+						className={cn(
+							"inline-flex h-full items-center justify-center rounded-full border px-3 text-xs font-medium cursor-pointer transition-colors",
+							mode === "raw"
+								? "border-[#2261CA33] bg-[#00173C] text-white"
+								: "border-transparent text-[#737373] hover:bg-white/5",
+						)}
+						onClick={() => setMode("raw")}
+					>
+						Raw
+					</button>
+				</div>
+			</div>
+			{mode === "raw" ? (
+				<RawView parsed={parsed} />
+			) : hasMessages ? (
+				<ConversationView parsed={parsed} />
+			) : (
+				<SectionsView parsed={parsed} />
+			)}
+		</div>
+	)
+}

--- a/apps/web/components/document-modal/index.tsx
+++ b/apps/web/components/document-modal/index.tsx
@@ -23,6 +23,8 @@ import { useDocumentMutations } from "@/hooks/use-document-mutations"
 import type { UseMutationResult } from "@tanstack/react-query"
 import { toast } from "sonner"
 import { useIsMobile } from "@hooks/use-mobile"
+import { parsePluginDocument } from "@/lib/plugin-document"
+import { PluginDetails } from "./plugin-details"
 
 type DocumentsResponse = z.infer<typeof DocumentsWithMemoriesResponseSchema>
 type DocumentWithMemories = DocumentsResponse["documents"][0]
@@ -168,6 +170,10 @@ export function DocumentModal({
 			initialEditorString: content ?? "",
 		}
 	}, [_document?.content])
+	const pluginDocument = useMemo(
+		() => parsePluginDocument(_document),
+		[_document],
+	)
 
 	const [draftContentString, setDraftContentString] =
 		useState(initialEditorString)
@@ -298,6 +304,7 @@ export function DocumentModal({
 						<DocumentContent
 							document={_document}
 							textEditorProps={textEditorProps}
+							pluginDocument={pluginDocument}
 						/>
 					</div>
 					<div
@@ -307,10 +314,11 @@ export function DocumentModal({
 							dmSansClassName(),
 						)}
 					>
-						{_document?.summary && (
+						{pluginDocument && <PluginDetails parsed={pluginDocument} />}
+						{_document && (_document.summary || pluginDocument?.summary) && (
 							<DocumentSummary
 								memoryEntries={_document.memoryEntries}
-								summary={_document.summary}
+								summary={pluginDocument?.summary ?? _document.summary}
 								createdAt={_document.createdAt}
 							/>
 						)}

--- a/apps/web/components/document-modal/plugin-details.tsx
+++ b/apps/web/components/document-modal/plugin-details.tsx
@@ -1,0 +1,82 @@
+import { cn } from "@lib/utils"
+import { dmSansClassName } from "@/lib/fonts"
+import type { ParsedPluginDocument } from "@/lib/plugin-document"
+
+function DetailPill({
+	label,
+	value,
+}: {
+	label: string
+	value: string
+}) {
+	return (
+		<div className="rounded-[12px] border border-[#1E232B] bg-[#0F1318] px-3 py-2">
+			<p
+				className={cn(
+					dmSansClassName(),
+					"text-[10px] uppercase tracking-[0.08em] text-[#737373]",
+				)}
+			>
+				{label}
+			</p>
+			<p className="mt-1 text-[13px] text-[#F3F4F6] break-all">{value}</p>
+		</div>
+	)
+}
+
+export function PluginDetails({
+	parsed,
+}: {
+	parsed: ParsedPluginDocument
+}) {
+	return (
+		<div className="bg-[#14161A] p-3 rounded-[14px] space-y-3 shadow-[inset_0_2px_4px_rgba(0,0,0,0.3),inset_0_1px_2px_rgba(0,0,0,0.1)]">
+			<div className="flex items-center justify-between gap-2">
+				<p className="text-[16px] font-semibold text-[#FAFAFA] leading-[125%]">
+					Details
+				</p>
+				<span
+					className={cn(
+						dmSansClassName(),
+						"inline-flex items-center rounded-full border border-[#2261CA33] bg-[#0D1A2E] px-2 py-1 text-[10px] font-medium text-[#8FC8FF]",
+					)}
+				>
+					{parsed.pluginLabel}
+				</span>
+			</div>
+			<div className="grid grid-cols-1 gap-2">
+				<DetailPill label="Format" value={parsed.formatLabel} />
+				{parsed.identifierLabel && parsed.identifierValue && (
+					<DetailPill
+						label={parsed.identifierLabel}
+						value={parsed.identifierValue}
+					/>
+				)}
+				{parsed.clientLabel && parsed.clientValue && (
+					<DetailPill label={parsed.clientLabel} value={parsed.clientValue} />
+				)}
+			</div>
+			{parsed.artifacts.length > 0 && (
+				<div className="space-y-2">
+					<p
+						className={cn(
+							dmSansClassName(),
+							"text-[11px] font-medium uppercase tracking-[0.08em] text-[#737373]",
+						)}
+					>
+						Outputs
+					</p>
+					<div className="space-y-2">
+						{parsed.artifacts.map((artifact, index) => (
+							<DetailPill
+								key={`${artifact.label}-${artifact.value}-${index}`}
+								label={artifact.label}
+								value={artifact.value}
+							/>
+						))}
+					</div>
+				</div>
+			)}
+		</div>
+	)
+}

--- a/apps/web/lib/plugin-document.ts
+++ b/apps/web/lib/plugin-document.ts
@@ -1,0 +1,373 @@
+import type { DocumentsWithMemoriesResponseSchema } from "@repo/validation/api"
+import type { z } from "zod"
+
+type DocumentsResponse = z.infer<typeof DocumentsWithMemoriesResponseSchema>
+type DocumentWithMemories = DocumentsResponse["documents"][0]
+
+export type PluginDocumentKind =
+	| "codex-session"
+	| "codex-save"
+	| "amp-thread"
+	| "openclaw-session"
+
+export interface PluginArtifact {
+	label: string
+	value: string
+}
+
+export interface PluginDocumentMessage {
+	id: string
+	role: "user" | "assistant" | "tool" | "system" | "unknown"
+	text: string
+}
+
+export interface PluginDocumentSection {
+	label: string
+	value: string
+	tone?: "default" | "accent" | "muted"
+}
+
+export interface ParsedPluginDocument {
+	kind: PluginDocumentKind
+	pluginLabel: string
+	formatLabel: string
+	title: string
+	preview: string
+	summary: string
+	identifierLabel?: string
+	identifierValue?: string
+	clientLabel?: string
+	clientValue?: string
+	artifacts: PluginArtifact[]
+	messages: PluginDocumentMessage[]
+	sections: PluginDocumentSection[]
+	rawContent: string
+}
+
+const TRANSCRIPT_ROLE_PATTERN = "user|assistant|tool|system"
+
+function normalizeContent(content: string | null | undefined): string {
+	if (!content) return ""
+
+	return content
+		.replace(/\r\n?/g, "\n")
+		.replace(/\\n/g, "\n")
+		.replace(/\u0000/g, "")
+		.trim()
+}
+
+function formatClientName(value: string | null | undefined): string | null {
+	if (!value) return null
+
+	const trimmed = value.trim()
+	if (!trimmed) return null
+
+	const normalized = trimmed.replace(/[_-]+/g, " ")
+	const lower = normalized.toLowerCase()
+
+	if (lower === "codex") return "Codex"
+	if (lower === "claude desktop") return "Claude Desktop"
+	if (lower === "claude code") return "Claude Code"
+	if (lower === "opencode") return "OpenCode"
+	if (lower === "openclaw") return "OpenClaw"
+	if (lower === "amp") return "Amp"
+
+	return normalized.replace(/\b\w/g, (match) => match.toUpperCase())
+}
+
+function extractArtifacts(text: string): {
+	cleanText: string
+	artifacts: PluginArtifact[]
+} {
+	const artifacts: PluginArtifact[] = []
+	const cleanLines: string[] = []
+
+	for (const line of text.split("\n")) {
+		const trimmed = line.trim()
+		if (!trimmed) {
+			cleanLines.push(line)
+			continue
+		}
+
+		const memoryIdMatch = trimmed.match(/^memory id:\s*(.+)$/i)
+		if (memoryIdMatch?.[1]) {
+			artifacts.push({ label: "Memory ID", value: memoryIdMatch[1].trim() })
+			continue
+		}
+
+		cleanLines.push(line)
+	}
+
+	return {
+		cleanText: cleanLines.join("\n").trim(),
+		artifacts,
+	}
+}
+
+function parseTranscriptMessages(content: string): {
+	messages: PluginDocumentMessage[]
+	artifacts: PluginArtifact[]
+} {
+	const messages: PluginDocumentMessage[] = []
+	const artifacts: PluginArtifact[] = []
+	const regex = new RegExp(
+		`^\\s*(\\d+)\\.\\s+\\[(${TRANSCRIPT_ROLE_PATTERN})\\]\\s*([\\s\\S]*?)(?=^\\s*\\d+\\.\\s+\\[(?:${TRANSCRIPT_ROLE_PATTERN})\\]\\s*|$)`,
+		"gm",
+	)
+
+	let match: RegExpExecArray | null
+	while ((match = regex.exec(content)) !== null) {
+		const ordinal = match[1] ?? `${messages.length + 1}`
+		const role = match[2] ?? "unknown"
+		const rawText = match[3] ?? ""
+		const { cleanText, artifacts: messageArtifacts } = extractArtifacts(
+			rawText.trim(),
+		)
+		artifacts.push(...messageArtifacts)
+
+		if (!cleanText) continue
+
+		messages.push({
+			id: `${ordinal}-${role}`,
+			role: role as PluginDocumentMessage["role"],
+			text: cleanText,
+		})
+	}
+
+	return { messages, artifacts }
+}
+
+function parseRoleBlockMessages(content: string): {
+	messages: PluginDocumentMessage[]
+	artifacts: PluginArtifact[]
+} {
+	const messages: PluginDocumentMessage[] = []
+	const artifacts: PluginArtifact[] = []
+	const regex = /\[role:\s*(user|assistant|tool|system)\]\s*([\s\S]*?)\s*\[\1:end\]/gi
+
+	let match: RegExpExecArray | null
+	let index = 0
+	while ((match = regex.exec(content)) !== null) {
+		const role = match[1] ?? "unknown"
+		const rawText = match[2] ?? ""
+		const { cleanText, artifacts: messageArtifacts } = extractArtifacts(
+			rawText.trim(),
+		)
+		artifacts.push(...messageArtifacts)
+
+		if (!cleanText) continue
+
+		messages.push({
+			id: `${role}-${index}`,
+			role: role.toLowerCase() as PluginDocumentMessage["role"],
+			text: cleanText,
+		})
+		index++
+	}
+
+	return { messages, artifacts }
+}
+
+function takePreview(text: string, maxLength = 180): string {
+	const normalized = text.replace(/\s+/g, " ").trim()
+	if (!normalized) return ""
+	if (normalized.length <= maxLength) return normalized
+	return `${normalized.slice(0, maxLength - 1).trimEnd()}...`
+}
+
+function parseSaveSections(content: string): ParsedPluginDocument | null {
+	const match = content.match(/\[SAVE:([^\]]+)\]([\s\S]*?)\[\/SAVE\]/i)
+	if (!match) return null
+
+	const savedAt = match[1] ?? ""
+	const rawBody = match[2] ?? ""
+	const sections: PluginDocumentSection[] = []
+	const artifacts: PluginArtifact[] = []
+
+	let overviewLines: string[] = []
+
+	for (const line of rawBody.split("\n")) {
+		const trimmed = line.trim()
+		if (!trimmed) continue
+
+		if (/^Decision:/i.test(trimmed)) {
+			sections.push({
+				label: "Decision",
+				value: trimmed.replace(/^Decision:\s*/i, "").trim(),
+				tone: "accent",
+			})
+			continue
+		}
+
+		if (/^Context:/i.test(trimmed)) {
+			sections.push({
+				label: "Context",
+				value: trimmed.replace(/^Context:\s*/i, "").trim(),
+				tone: "muted",
+			})
+			continue
+		}
+
+		if (/^Files:/i.test(trimmed)) {
+			sections.push({
+				label: "Files",
+				value: trimmed.replace(/^Files:\s*/i, "").trim(),
+				tone: "default",
+			})
+			continue
+		}
+
+		overviewLines.push(trimmed)
+	}
+
+	if (overviewLines.length > 0) {
+		sections.unshift({
+			label: "Summary",
+			value: overviewLines.join("\n\n"),
+		})
+	}
+
+	const summary =
+		sections.find((section) => section.label === "Decision")?.value ??
+		sections[0]?.value ??
+		"Saved project note"
+
+	return {
+		kind: "codex-save",
+		pluginLabel: "Codex",
+		formatLabel: "Saved note",
+		title: "Saved memory note",
+		preview: takePreview(
+			sections[0]?.value ?? "Saved project knowledge from Codex",
+			140,
+		),
+		summary: takePreview(summary, 220),
+		identifierLabel: "Saved",
+		identifierValue: savedAt.trim(),
+		artifacts,
+		messages: [],
+		sections,
+		rawContent: content,
+	}
+}
+
+function parseSessionTranscript(
+	content: string,
+	config: {
+		kind: "codex-session" | "amp-thread"
+		headerLabel: "Session" | "Amp thread"
+		pluginLabel: string
+		formatLabel: string
+	}
+): ParsedPluginDocument | null {
+	const headerRegex = new RegExp(`\\[${config.headerLabel} ([^\\]]+)\\]`, "i")
+	const headerMatch = content.match(headerRegex)
+	if (!headerMatch?.[1]) return null
+
+	const identifierValue = headerMatch[1].trim()
+	const withoutHeader = content.replace(
+		new RegExp(`\\[${config.headerLabel} [^\\]]+\\]\\s*`, "gi"),
+		"",
+	)
+	const { messages, artifacts } = parseTranscriptMessages(withoutHeader)
+	if (messages.length === 0) return null
+
+	const userCount = messages.filter((message) => message.role === "user").length
+	const assistantCount = messages.filter(
+		(message) => message.role === "assistant",
+	).length
+	const previewSource =
+		messages.find((message) => message.role === "user")?.text ??
+		messages[0]?.text ??
+		"Conversation"
+
+	return {
+		kind: config.kind,
+		pluginLabel: config.pluginLabel,
+		formatLabel: config.formatLabel,
+		title: `${config.pluginLabel} conversation`,
+		preview: takePreview(previewSource, 140),
+		summary: `${userCount} user message${userCount === 1 ? "" : "s"} and ${assistantCount} assistant message${assistantCount === 1 ? "" : "s"} captured from ${config.pluginLabel}.`,
+		identifierLabel: config.headerLabel,
+		identifierValue,
+		artifacts,
+		messages,
+		sections: [],
+		rawContent: content,
+	}
+}
+
+function parseOpenClawTranscript(content: string): ParsedPluginDocument | null {
+	const { messages, artifacts } = parseRoleBlockMessages(content)
+	if (messages.length === 0) return null
+
+	const previewSource =
+		messages.find((message) => message.role === "user")?.text ??
+		messages[0]?.text ??
+		"Conversation"
+
+	return {
+		kind: "openclaw-session",
+		pluginLabel: "OpenClaw",
+		formatLabel: "Conversation",
+		title: "OpenClaw conversation",
+		preview: takePreview(previewSource, 140),
+		summary: `${messages.length} message${messages.length === 1 ? "" : "s"} captured from OpenClaw.`,
+		artifacts,
+		messages,
+		sections: [],
+		rawContent: content,
+	}
+}
+
+export function parsePluginDocument(
+	document: DocumentWithMemories | null,
+): ParsedPluginDocument | null {
+	if (!document?.content) return null
+
+	const content = normalizeContent(document.content)
+	if (!content) return null
+
+	const metadata = (document.metadata ?? {}) as Record<string, unknown>
+	const clientName = formatClientName(
+		typeof metadata.sm_internal_mcp_client_name === "string"
+			? metadata.sm_internal_mcp_client_name
+			: null,
+	)
+
+	const codexSave = parseSaveSections(content)
+	if (codexSave) {
+		if (clientName) {
+			codexSave.clientLabel = "Client"
+			codexSave.clientValue = clientName
+		}
+		return codexSave
+	}
+
+	const codexSession = parseSessionTranscript(content, {
+		kind: "codex-session",
+		headerLabel: "Session",
+		pluginLabel: "Codex",
+		formatLabel: "Conversation",
+	})
+	if (codexSession) {
+		if (clientName) {
+			codexSession.clientLabel = "Client"
+			codexSession.clientValue = clientName
+		}
+		return codexSession
+	}
+
+	const ampThread = parseSessionTranscript(content, {
+		kind: "amp-thread",
+		headerLabel: "Amp thread",
+		pluginLabel: "Amp",
+		formatLabel: "Conversation",
+	})
+	if (ampThread) return ampThread
+
+	const openClawSession = parseOpenClawTranscript(content)
+	if (openClawSession) return openClawSession
+
+	return null
+}


### PR DESCRIPTION
<h3>Implement comprehensive plugin document rendering support including MCP previews and plugin specific content handling.</h3>
<br>
<br>

<img width="1680" height="471" alt="Screenshot 2026-05-12 at 8 24 49 PM" src="https://github.com/user-attachments/assets/f1294bc2-2841-4833-9f01-ac47b8c52c01" />

<br>
<br>

<img width="1680" height="963" alt="Screenshot 2026-05-12 at 8 28 25 PM" src="https://github.com/user-attachments/assets/9436c7ab-3b9b-4366-86fd-1465407ff0f9" />
