### PR TITLE
Ensure mobile inputs use 16px font

### DIFF
--- a/packages/ui/globals.css
+++ b/packages/ui/globals.css
@@ -260,4 +260,17 @@
 		font-size: 14px;
 		letter-spacing: var(--tracking-normal);
 	}
+
+	@media (max-width: 767px) {
+		input:not([type="button"]):not([type="checkbox"]):not([type="color"]):not(
+				[type="file"]
+			):not([type="hidden"]):not([type="image"]):not([type="radio"]):not(
+				[type="range"]
+			):not([type="reset"]):not([type="submit"]),
+		textarea,
+		select,
+		[contenteditable]:not([contenteditable="false"]) {
+			font-size: 16px !important;
+		}
+	}
 }


### PR DESCRIPTION
## Summary
- Add a mobile-only global baseline so editable controls render at 16px or larger.
- Covers text inputs, textareas, selects, and contenteditable fields while excluding non-text input controls.

## Verification
- bunx biome check packages/ui/globals.css
- bun --filter @repo/web build