### PR TITLE
feat: PWA install instructions modal for mobile

### DIFF
--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -2,12 +2,14 @@
 
 import { EnsureWorkspace } from "@/components/ensure-workspace"
 import { NextAppResearchCta } from "@/components/next-app-research-cta"
+import { PWAInstallPrompt } from "@/components/pwa-install-prompt"
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
 	return (
 		<>
 			<EnsureWorkspace>{children}</EnsureWorkspace>
 			<NextAppResearchCta />
+			<PWAInstallPrompt />
 		</>
 	)
 }

--- a/apps/web/components/pwa-install-prompt.tsx
+++ b/apps/web/components/pwa-install-prompt.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useCallback } from "react"
+import { useState, useEffect, useCallback, useRef } from "react"
 import { cn } from "@lib/utils"
 import { dmSansClassName, dmSans125ClassName } from "@/lib/fonts"
 import { XIcon, Brain, Sparkles, Globe } from "lucide-react"
@@ -10,14 +10,32 @@ import { AnimatePresence, motion } from "motion/react"
 const PWA_DISMISS_KEY = "pwa-install-dismissed"
 const DISMISS_DURATION_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
 
-function getDeviceInfo() {
-	if (typeof window === "undefined") return { isIOS: false, isAndroid: false }
+type DeviceInfo = {
+	isIOS: boolean
+	isAndroid: boolean
+	isSafari: boolean
+	isChrome: boolean
+}
+
+/** In-memory fallback when localStorage is unavailable */
+let memoryDismissed = false
+
+function getDeviceInfo(): DeviceInfo {
+	if (typeof window === "undefined")
+		return { isIOS: false, isAndroid: false, isSafari: false, isChrome: false }
 	const ua = navigator.userAgent
 	const isIOS =
 		/iPad|iPhone|iPod/.test(ua) ||
-		(navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1)
+		(/Macintosh/.test(ua) && navigator.maxTouchPoints > 1)
 	const isAndroid = /Android/.test(ua)
-	return { isIOS, isAndroid }
+
+	// Safari: contains "Safari" but not "CriOS", "FxiOS", "Chrome", "Edg", etc.
+	const isSafari =
+		/Safari/.test(ua) && !/CriOS|FxiOS|Chrome|Chromium|Edg|OPR|Opera/.test(ua)
+	// Chrome on Android: contains "Chrome" but not "Edg", "OPR", "Opera"
+	const isChrome = /Chrome/.test(ua) && !/Edg|OPR|Opera/.test(ua)
+
+	return { isIOS, isAndroid, isSafari, isChrome }
 }
 
 function isStandalone() {
@@ -31,6 +49,7 @@ function isStandalone() {
 
 function isDismissed() {
 	if (typeof window === "undefined") return true
+	if (memoryDismissed) return true
 	try {
 		const dismissed = localStorage.getItem(PWA_DISMISS_KEY)
 		if (!dismissed) return false
@@ -51,27 +70,94 @@ const FEATURES = [
 
 export function PWAInstallPrompt() {
 	const [show, setShow] = useState(false)
-	const [device, setDevice] = useState<{ isIOS: boolean; isAndroid: boolean }>({
+	const [device, setDevice] = useState<DeviceInfo>({
 		isIOS: false,
 		isAndroid: false,
+		isSafari: false,
+		isChrome: false,
 	})
+	const [nativePrompt, setNativePrompt] =
+		useState<BeforeInstallPromptEvent | null>(null)
+	const panelRef = useRef<HTMLDivElement>(null)
 
 	useEffect(() => {
 		const info = getDeviceInfo()
 		setDevice(info)
+
+		// Listen for the native install prompt (Chromium browsers on Android)
+		const handleBeforeInstall = (e: Event) => {
+			e.preventDefault()
+			setNativePrompt(e as BeforeInstallPromptEvent)
+		}
+		window.addEventListener("beforeinstallprompt", handleBeforeInstall)
+
 		const isMobile = info.isIOS || info.isAndroid
 		if (isMobile && !isStandalone() && !isDismissed()) {
 			const timer = setTimeout(() => setShow(true), 1500)
-			return () => clearTimeout(timer)
+			return () => {
+				clearTimeout(timer)
+				window.removeEventListener("beforeinstallprompt", handleBeforeInstall)
+			}
+		}
+		return () => {
+			window.removeEventListener("beforeinstallprompt", handleBeforeInstall)
 		}
 	}, [])
 
 	const dismiss = useCallback(() => {
 		setShow(false)
+		memoryDismissed = true
 		try {
 			localStorage.setItem(PWA_DISMISS_KEY, Date.now().toString())
 		} catch {}
 	}, [])
+
+	// Escape key handler
+	useEffect(() => {
+		if (!show) return
+		const handler = (e: KeyboardEvent) => {
+			if (e.key === "Escape") dismiss()
+		}
+		document.addEventListener("keydown", handler)
+		return () => document.removeEventListener("keydown", handler)
+	}, [show, dismiss])
+
+	// Focus the panel when shown for accessibility
+	useEffect(() => {
+		if (show && panelRef.current) {
+			panelRef.current.focus()
+		}
+	}, [show])
+
+	const handleInstall = useCallback(async () => {
+		if (nativePrompt) {
+			nativePrompt.prompt()
+			const { outcome } = await nativePrompt.userChoice
+			if (outcome === "accepted") {
+				setShow(false)
+			}
+			setNativePrompt(null)
+		}
+		dismiss()
+	}, [nativePrompt, dismiss])
+
+	/**
+	 * Determine which instructions to show:
+	 * - iOS + Safari → standard iOS steps
+	 * - iOS + non-Safari → "open in Safari" hint
+	 * - Android + Chrome (with native prompt) → trigger native install
+	 * - Android + Chrome (no native prompt) → manual Chrome steps
+	 * - Android + non-Chrome → "open in Chrome" hint
+	 */
+	const renderSteps = () => {
+		if (device.isIOS) {
+			if (device.isSafari) return <IOSSteps />
+			return <IOSNonSafariSteps />
+		}
+		// Android
+		if (device.isChrome) return <AndroidSteps />
+		return <AndroidNonChromeSteps />
+	}
 
 	return (
 		<AnimatePresence>
@@ -85,13 +171,18 @@ export function PWAInstallPrompt() {
 					onClick={dismiss}
 				>
 					<motion.div
+						ref={panelRef}
 						initial={{ y: "100%" }}
 						animate={{ y: 0 }}
 						exit={{ y: "100%" }}
 						transition={{ type: "spring", damping: 28, stiffness: 300 }}
 						onClick={(e) => e.stopPropagation()}
+						role="dialog"
+						aria-modal="true"
+						aria-labelledby="pwa-install-title"
+						tabIndex={-1}
 						className={cn(
-							"w-full max-w-lg bg-[#1B1F24] rounded-t-[22px] p-6 pb-8 flex flex-col gap-5",
+							"w-full max-w-lg bg-[#1B1F24] rounded-t-[22px] p-6 pb-8 flex flex-col gap-5 outline-none",
 							dmSansClassName(),
 						)}
 						style={{
@@ -107,6 +198,7 @@ export function PWAInstallPrompt() {
 								</div>
 								<div>
 									<h2
+										id="pwa-install-title"
 										className={cn(
 											"text-[18px] font-semibold text-[#fafafa]",
 											dmSans125ClassName(),
@@ -158,30 +250,26 @@ export function PWAInstallPrompt() {
 							>
 								Install for a better experience
 							</p>
-							{device.isIOS ? <IOSSteps /> : <AndroidSteps />}
+							{renderSteps()}
 						</div>
 
-						{/* Actions */}
+						{/* Action */}
 						<div className="flex flex-col gap-2 mt-1">
 							<button
 								type="button"
-								onClick={dismiss}
+								onClick={
+									nativePrompt && device.isAndroid && device.isChrome
+										? handleInstall
+										: dismiss
+								}
 								className={cn(
 									"w-full py-3 rounded-[12px] bg-[#2261CA] text-white text-[15px] font-semibold transition-colors hover:bg-[#1a4fa0]",
 									dmSansClassName(),
 								)}
 							>
-								Got it
-							</button>
-							<button
-								type="button"
-								onClick={dismiss}
-								className={cn(
-									"w-full py-2 text-[14px] text-[#737373] font-medium transition-colors hover:text-[#fafafa]",
-									dmSansClassName(),
-								)}
-							>
-								Not now
+								{nativePrompt && device.isAndroid && device.isChrome
+									? "Install now"
+									: "Got it"}
 							</button>
 						</div>
 					</motion.div>
@@ -227,6 +315,23 @@ function IOSSteps() {
 	)
 }
 
+function IOSNonSafariSteps() {
+	return (
+		<div className="flex flex-col gap-3">
+			<StepRow step={1}>
+				Open this page in <strong className="text-[#fafafa]">Safari</strong>
+			</StepRow>
+			<StepRow step={2}>
+				Tap the share button{" "}
+				<ShareIcon className="inline-block size-4 align-text-bottom mx-0.5 text-[#4BA0FA]" />
+			</StepRow>
+			<StepRow step={3}>
+				Tap <strong className="text-[#fafafa]">Add to Home Screen</strong>
+			</StepRow>
+		</div>
+	)
+}
+
 function AndroidSteps() {
 	return (
 		<div className="flex flex-col gap-3">
@@ -240,6 +345,23 @@ function AndroidSteps() {
 			</StepRow>
 			<StepRow step={3}>
 				Tap <strong className="text-[#fafafa]">Install</strong> to confirm
+			</StepRow>
+		</div>
+	)
+}
+
+function AndroidNonChromeSteps() {
+	return (
+		<div className="flex flex-col gap-3">
+			<StepRow step={1}>
+				Open this page in <strong className="text-[#fafafa]">Chrome</strong>
+			</StepRow>
+			<StepRow step={2}>
+				Tap the menu button{" "}
+				<MoreVertIcon className="inline-block size-4 align-text-bottom mx-0.5 text-[#4BA0FA]" />
+			</StepRow>
+			<StepRow step={3}>
+				Tap <strong className="text-[#fafafa]">Add to Home screen</strong>
 			</StepRow>
 		</div>
 	)
@@ -279,4 +401,19 @@ function MoreVertIcon({ className }: { className?: string }) {
 			<circle cx="12" cy="19" r="2" />
 		</svg>
 	)
+}
+
+/**
+ * Type for the `beforeinstallprompt` event (not yet in TS lib).
+ * @see https://developer.mozilla.org/en-US/docs/Web/API/BeforeInstallPromptEvent
+ */
+interface BeforeInstallPromptEvent extends Event {
+	prompt(): Promise<void>
+	userChoice: Promise<{ outcome: "accepted" | "dismissed" }>
+}
+
+declare global {
+	interface WindowEventMap {
+		beforeinstallprompt: BeforeInstallPromptEvent
+	}
 }

--- a/apps/web/components/pwa-install-prompt.tsx
+++ b/apps/web/components/pwa-install-prompt.tsx
@@ -1,0 +1,282 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import { cn } from "@lib/utils"
+import { dmSansClassName, dmSans125ClassName } from "@/lib/fonts"
+import { XIcon, Brain, Sparkles, Globe } from "lucide-react"
+import { GradientLogo } from "@ui/assets/Logo"
+import { AnimatePresence, motion } from "motion/react"
+
+const PWA_DISMISS_KEY = "pwa-install-dismissed"
+const DISMISS_DURATION_MS = 7 * 24 * 60 * 60 * 1000 // 7 days
+
+function getDeviceInfo() {
+	if (typeof window === "undefined") return { isIOS: false, isAndroid: false }
+	const ua = navigator.userAgent
+	const isIOS =
+		/iPad|iPhone|iPod/.test(ua) ||
+		(navigator.platform === "MacIntel" && navigator.maxTouchPoints > 1)
+	const isAndroid = /Android/.test(ua)
+	return { isIOS, isAndroid }
+}
+
+function isStandalone() {
+	if (typeof window === "undefined") return false
+	return (
+		window.matchMedia("(display-mode: standalone)").matches ||
+		(window.navigator as unknown as { standalone?: boolean }).standalone ===
+			true
+	)
+}
+
+function isDismissed() {
+	if (typeof window === "undefined") return true
+	try {
+		const dismissed = localStorage.getItem(PWA_DISMISS_KEY)
+		if (!dismissed) return false
+		const timestamp = Number.parseInt(dismissed, 10)
+		if (Date.now() - timestamp < DISMISS_DURATION_MS) return true
+		localStorage.removeItem(PWA_DISMISS_KEY)
+		return false
+	} catch {
+		return false
+	}
+}
+
+const FEATURES = [
+	{ icon: Brain, label: "AI-powered memory" },
+	{ icon: Sparkles, label: "Chat with Nova" },
+	{ icon: Globe, label: "Access anywhere" },
+]
+
+export function PWAInstallPrompt() {
+	const [show, setShow] = useState(false)
+	const [device, setDevice] = useState<{ isIOS: boolean; isAndroid: boolean }>({
+		isIOS: false,
+		isAndroid: false,
+	})
+
+	useEffect(() => {
+		const info = getDeviceInfo()
+		setDevice(info)
+		const isMobile = info.isIOS || info.isAndroid
+		if (isMobile && !isStandalone() && !isDismissed()) {
+			const timer = setTimeout(() => setShow(true), 1500)
+			return () => clearTimeout(timer)
+		}
+	}, [])
+
+	const dismiss = useCallback(() => {
+		setShow(false)
+		try {
+			localStorage.setItem(PWA_DISMISS_KEY, Date.now().toString())
+		} catch {}
+	}, [])
+
+	return (
+		<AnimatePresence>
+			{show && (
+				<motion.div
+					initial={{ opacity: 0 }}
+					animate={{ opacity: 1 }}
+					exit={{ opacity: 0 }}
+					transition={{ duration: 0.2 }}
+					className="fixed inset-0 z-50 flex items-end justify-center bg-black/60 backdrop-blur-sm"
+					onClick={dismiss}
+				>
+					<motion.div
+						initial={{ y: "100%" }}
+						animate={{ y: 0 }}
+						exit={{ y: "100%" }}
+						transition={{ type: "spring", damping: 28, stiffness: 300 }}
+						onClick={(e) => e.stopPropagation()}
+						className={cn(
+							"w-full max-w-lg bg-[#1B1F24] rounded-t-[22px] p-6 pb-8 flex flex-col gap-5",
+							dmSansClassName(),
+						)}
+						style={{
+							boxShadow:
+								"0 -4px 24px 0 rgba(0, 0, 0, 0.4), 0.5px 0.5px 0.5px 0 rgba(255, 255, 255, 0.08) inset",
+						}}
+					>
+						{/* Header */}
+						<div className="flex items-start justify-between">
+							<div className="flex items-center gap-3">
+								<div className="size-12 rounded-[12px] bg-[#0D121A] flex items-center justify-center border border-[rgba(115,115,115,0.15)]">
+									<GradientLogo className="size-7" />
+								</div>
+								<div>
+									<h2
+										className={cn(
+											"text-[18px] font-semibold text-[#fafafa]",
+											dmSans125ClassName(),
+										)}
+									>
+										Supermemory
+									</h2>
+									<p className="text-[14px] text-[#737373] font-medium">
+										Your memories, wherever you are
+									</p>
+								</div>
+							</div>
+							<button
+								type="button"
+								onClick={dismiss}
+								className="bg-[#0D121A] size-7 flex items-center justify-center rounded-full border border-[rgba(115,115,115,0.2)] shrink-0"
+								style={{
+									boxShadow:
+										"0 0.711px 2.842px 0 rgba(0, 0, 0, 0.25), 0.178px 0.178px 0.178px 0 rgba(255, 255, 255, 0.10) inset",
+								}}
+							>
+								<XIcon className="size-4 text-[#737373]" />
+								<span className="sr-only">Close</span>
+							</button>
+						</div>
+
+						{/* Feature pills */}
+						<div className="flex gap-2">
+							{FEATURES.map((f) => (
+								<div
+									key={f.label}
+									className="flex-1 flex flex-col items-center gap-2 py-3 px-2 rounded-[12px] bg-[#0D121A] border border-[rgba(115,115,115,0.1)]"
+								>
+									<f.icon className="size-5 text-[#4BA0FA]" />
+									<span className="text-[12px] text-[#d0dae7] font-medium text-center leading-tight">
+										{f.label}
+									</span>
+								</div>
+							))}
+						</div>
+
+						{/* Install steps */}
+						<div className="flex flex-col gap-3">
+							<p
+								className={cn(
+									"text-[15px] font-semibold text-[#fafafa]",
+									dmSans125ClassName(),
+								)}
+							>
+								Install for a better experience
+							</p>
+							{device.isIOS ? <IOSSteps /> : <AndroidSteps />}
+						</div>
+
+						{/* Actions */}
+						<div className="flex flex-col gap-2 mt-1">
+							<button
+								type="button"
+								onClick={dismiss}
+								className={cn(
+									"w-full py-3 rounded-[12px] bg-[#2261CA] text-white text-[15px] font-semibold transition-colors hover:bg-[#1a4fa0]",
+									dmSansClassName(),
+								)}
+							>
+								Got it
+							</button>
+							<button
+								type="button"
+								onClick={dismiss}
+								className={cn(
+									"w-full py-2 text-[14px] text-[#737373] font-medium transition-colors hover:text-[#fafafa]",
+									dmSansClassName(),
+								)}
+							>
+								Not now
+							</button>
+						</div>
+					</motion.div>
+				</motion.div>
+			)}
+		</AnimatePresence>
+	)
+}
+
+function StepRow({
+	step,
+	children,
+}: {
+	step: number
+	children: React.ReactNode
+}) {
+	return (
+		<div className="flex items-center gap-3">
+			<span className="size-7 shrink-0 rounded-full bg-[#0D121A] border border-[rgba(115,115,115,0.15)] flex items-center justify-center text-[13px] font-semibold text-[#4BA0FA]">
+				{step}
+			</span>
+			<span className="text-[14px] text-[#d0dae7]">{children}</span>
+		</div>
+	)
+}
+
+function IOSSteps() {
+	return (
+		<div className="flex flex-col gap-3">
+			<StepRow step={1}>
+				Tap the share button{" "}
+				<ShareIcon className="inline-block size-4 align-text-bottom mx-0.5 text-[#4BA0FA]" />{" "}
+				in Safari
+			</StepRow>
+			<StepRow step={2}>
+				Scroll down and tap{" "}
+				<strong className="text-[#fafafa]">Add to Home Screen</strong>
+			</StepRow>
+			<StepRow step={3}>
+				Tap <strong className="text-[#fafafa]">Add</strong> to install
+			</StepRow>
+		</div>
+	)
+}
+
+function AndroidSteps() {
+	return (
+		<div className="flex flex-col gap-3">
+			<StepRow step={1}>
+				Tap the menu button{" "}
+				<MoreVertIcon className="inline-block size-4 align-text-bottom mx-0.5 text-[#4BA0FA]" />{" "}
+				in Chrome
+			</StepRow>
+			<StepRow step={2}>
+				Tap <strong className="text-[#fafafa]">Add to Home screen</strong>
+			</StepRow>
+			<StepRow step={3}>
+				Tap <strong className="text-[#fafafa]">Install</strong> to confirm
+			</StepRow>
+		</div>
+	)
+}
+
+function ShareIcon({ className }: { className?: string }) {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			fill="none"
+			stroke="currentColor"
+			strokeWidth={2}
+			strokeLinecap="round"
+			strokeLinejoin="round"
+			className={className}
+			aria-hidden="true"
+		>
+			<path d="M4 12v8a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2v-8" />
+			<polyline points="16 6 12 2 8 6" />
+			<line x1="12" y1="2" x2="12" y2="15" />
+		</svg>
+	)
+}
+
+function MoreVertIcon({ className }: { className?: string }) {
+	return (
+		<svg
+			xmlns="http://www.w3.org/2000/svg"
+			viewBox="0 0 24 24"
+			fill="currentColor"
+			className={className}
+			aria-hidden="true"
+		>
+			<circle cx="12" cy="5" r="2" />
+			<circle cx="12" cy="12" r="2" />
+			<circle cx="12" cy="19" r="2" />
+		</svg>
+	)
+}


### PR DESCRIPTION
## Summary

Adds a PWA install instructions modal that appears on mobile devices (iOS and Android) when the app is not already installed as a PWA. Inspired by the Chessiro-style install prompt pattern.

### What it does

- Shows a bottom-sheet modal after 1.5s on mobile browsers
- Displays the Supermemory branding, tagline, and three feature highlights (AI-powered memory, Chat with Nova, Access anywhere)
- Detects device (iOS/Android/iPadOS) **and browser** (Safari/Chrome/other) to show the correct install instructions
- iOS Safari: share button → Add to Home Screen → Add
- iOS non-Safari (Chrome, Firefox): guides user to open in Safari first
- Android Chrome: manual steps or native `beforeinstallprompt` flow when available
- Android non-Chrome: guides user to open in Chrome first
- Dismisses via "Got it" button, X button, backdrop click, or Escape key
- Persists dismissal in localStorage for 7 days (with in-memory fallback if storage is unavailable)
- Full accessibility: `role="dialog"`, `aria-modal`, `aria-labelledby`, focus management, Escape key support

### Files changed

- `apps/web/components/pwa-install-prompt.tsx` — new component
- `apps/web/app/(app)/layout.tsx` — renders the prompt in the app layout

## Testing

### Static Analysis
- `bunx biome ci --changed --since=origin/main` — **passed**, no issues
- `tsc --noEmit` — zero errors in changed files (pre-existing errors in other files are unrelated)

### Automated Tests (Playwright, 51/51 passed)

All tests run with Playwright headless Chromium against the live Next.js dev server, using spoofed mobile user agents and viewport sizes.

**Visibility Gate (5 tests):** Desktop UA hidden, standalone mode hidden, dismissed within 7 days hidden, expired 8-day key re-shows and cleans up localStorage.

**Appearance & Content (19 tests):** iOS Safari shows correct 3-step instructions, Android Chrome shows correct 3-step instructions, iOS non-Safari (CriOS) shows "Open in Safari" guidance, Android Firefox shows "Open in Chrome" guidance, iPadOS detected correctly via Macintosh UA + maxTouchPoints, all three feature pills rendered.

**Dismiss Behaviour (11 tests):** X button, "Got it" button, backdrop click, and Escape key all dismiss and persist to localStorage. Click inside sheet does not dismiss (stopPropagation working). Dismiss persists across hard reload. 8-day-old timestamp re-shows modal.

**Layout & Visual (5 tests):** Renders correctly on iPhone SE (375x667), sheet respects max-w-lg on wider viewports, backdrop covers full viewport, sheet is bottom-anchored.

**Route Scope (2 tests):** Shows on `/` (app layout), absent on `/login` (public layout).

**Accessibility (6 tests):** role="dialog", aria-modal="true", aria-labelledby references title, tabIndex="-1" for focus, sr-only Close label.

**Static Code Quality (2 tests):** Biome lint clean, TypeScript clean.

**Note:** The `beforeinstallprompt` native install path (Android Chrome) was not exercised because headless Chromium does not fire that event — this is expected behavior in automated environments.


---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/2ac19a10-59cd-41ee-8e79-60b93fe698aa)
- Requested by: Mahesh Sanikommu (mahesh@supermemory.com)
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
