### PR TITLE
Brand own space as Nova chats

### DIFF
--- a/apps/web/components/select-spaces-modal.tsx
+++ b/apps/web/components/select-spaces-modal.tsx
@@ -46,6 +46,7 @@ import {
 import { InstallSteps, PillButton } from "./integrations/install-steps"
 import { useProjectMutations } from "@/hooks/use-project-mutations"
 import { AUTO_CHAT_SPACE_ID } from "@/lib/chat-auto-space"
+import NovaOrb from "@/components/nova/nova-orb"
 
 interface SelectSpacesModalProps {
 	isOpen: boolean
@@ -705,6 +706,8 @@ export function SelectSpacesModal({
 										{pluginInitial(plugin.label)}
 									</span>
 								)
+							) : isOwnSpace ? (
+								<NovaOrb size={20} className="shrink-0 blur-[0.55px]!" />
 							) : (
 								<span className="shrink-0 text-lg">
 									{project.emoji || "📁"}

--- a/apps/web/components/space-selector.tsx
+++ b/apps/web/components/space-selector.tsx
@@ -35,10 +35,12 @@ import { useAuth } from "@lib/auth-context"
 import { analytics } from "@/lib/analytics"
 import {
 	compareSpacesUserFirst,
+	isOwnConversationSpace,
 	spaceSelectorDisplayName,
 } from "@/lib/ingest-auto-space"
 import { detectPluginSpace, pluginInitial } from "@/lib/plugin-space"
 import { usePluginSpaceMeta } from "@/hooks/use-plugin-space-meta"
+import NovaOrb from "@/components/nova/nova-orb"
 
 export interface SpaceSelectorProps {
 	selectedProjects: string[]
@@ -182,18 +184,32 @@ export function SpaceSelector({
 		emoji: string | null
 		plugin: ReturnType<typeof detectPluginSpace>
 		isAuto: boolean
+		isOwnSpace: boolean
 	}>(() => {
 		const containerTag = selectedProjects[0] ?? ""
 		if (includeAuto && containerTag === AUTO_CHAT_SPACE_ID) {
-			return { name: "Auto", emoji: null, plugin: null, isAuto: true }
+			return {
+				name: "Auto",
+				emoji: null,
+				plugin: null,
+				isAuto: true,
+				isOwnSpace: false,
+			}
 		}
 		if (!containerTag || containerTag === DEFAULT_PROJECT_ID) {
-			return { name: "My Space", emoji: "📁", plugin: null, isAuto: false }
+			return {
+				name: "My Space",
+				emoji: "📁",
+				plugin: null,
+				isAuto: false,
+				isOwnSpace: false,
+			}
 		}
 		const found = allProjects.find(
 			(p: ContainerTagListType) => p.containerTag === containerTag,
 		)
 		const plugin = detectPluginSpace(containerTag)
+		const isOwnSpace = isOwnConversationSpace({ containerTag }, user?.id)
 		const projectName = pluginMetaMap.get(containerTag)?.projectName
 		const idForLabel = projectName || plugin?.projectId
 		return {
@@ -207,6 +223,7 @@ export function SpaceSelector({
 			emoji: found?.emoji || "📁",
 			plugin,
 			isAuto: false,
+			isOwnSpace,
 		}
 	}, [allProjects, selectedProjects, pluginMetaMap, includeAuto, user?.id])
 
@@ -370,6 +387,11 @@ export function SpaceSelector({
 					>
 						{displayInfo.isAuto ? (
 							<Sparkles className="size-3.5 shrink-0 text-[#4BA0FA]" />
+						) : displayInfo.isOwnSpace ? (
+							<NovaOrb
+								size={compact ? 14 : 16}
+								className="shrink-0 blur-[0.45px]!"
+							/>
 						) : displayInfo.plugin ? (
 							displayInfo.plugin.iconSrc ? (
 								<Image
@@ -578,6 +600,7 @@ export function SpaceSelector({
 											{availableTargetProjects.map(
 												(p: ContainerTagListType) => {
 													const plugin = detectPluginSpace(p.containerTag)
+													const isOwnSpace = isOwnConversationSpace(p, user?.id)
 													return (
 														<SelectItem
 															key={p.id}
@@ -603,6 +626,11 @@ export function SpaceSelector({
 																			{pluginInitial(plugin.label)}
 																		</span>
 																	)
+																) : isOwnSpace ? (
+																	<NovaOrb
+																		size={16}
+																		className="shrink-0 blur-[0.45px]!"
+																	/>
 																) : (
 																	<span>{p.emoji || "📁"}</span>
 																)}

--- a/apps/web/lib/ingest-auto-space.ts
+++ b/apps/web/lib/ingest-auto-space.ts
@@ -1,7 +1,7 @@
 import { DEFAULT_PROJECT_ID } from "@lib/constants"
 import type { ContainerTagListType } from "@lib/types"
 
-export const OWN_CONVERSATIONS_SPACE_NAME = "Your conversations"
+export const OWN_CHAT_SPACE_NAME = "Nova chats"
 
 /**
  * Spaces auto-created on first ingest use `name === \`Space ${containerTag}\``
@@ -40,7 +40,7 @@ export function spaceSelectorDisplayName(
 ): string {
 	const containerTag = p?.containerTag ?? fallback
 	if (containerTag === options?.currentUserId) {
-		return OWN_CONVERSATIONS_SPACE_NAME
+		return OWN_CHAT_SPACE_NAME
 	}
 	if (!p) return fallback
 	const name = p.name ?? p.containerTag


### PR DESCRIPTION
Renames the user-owned conversation space from "Your conversations" to "Nova chats".
Uses the existing Nova orb logo for that own-space entry in the space selector trigger, modal list, and delete target selector.

Testing: bunx biome check apps/web/lib/ingest-auto-space.ts apps/web/components/space-selector.tsx apps/web/components/select-spaces-modal.tsx