### PR TITLE
fix(web): bust memory-of-day localStorage cache on deploy

### DIFF
--- a/apps/web/app/(app)/page.tsx
+++ b/apps/web/app/(app)/page.tsx
@@ -363,7 +363,7 @@ export default function NewPage() {
 			new Date().toISOString().slice(0, 10),
 		],
 		queryFn: async (): Promise<MemoryOfDay | null> => {
-			const cacheKey = `memory-of-day:${user?.id}:${new Date().toISOString().slice(0, 10)}`
+			const cacheKey = `memory-of-day:v2:${user?.id}:${new Date().toISOString().slice(0, 10)}`
 			try {
 				const stored = localStorage.getItem(cacheKey)
 				if (stored) return JSON.parse(stored) as MemoryOfDay


### PR DESCRIPTION
Pairs with the API change that populates sourceDocumentId. The dashboard reads memory-of-day from localStorage first, so without a cache-key bump users would keep seeing the stale null-sourceDocument response for the rest of today. Bumping to :v2: forces a refetch on next load.