### PR TITLE
Address nova feedback bugs

### DIFF
--- a/apps/web/app/(app)/page.tsx
+++ b/apps/web/app/(app)/page.tsx
@@ -554,20 +554,20 @@ export default function NewPage() {
 				)}
 			>
 				{showNovaBackdrop && (
-					<>
+					<div className="pointer-events-none fixed inset-0 z-0">
 						<AnimatedGradientBackground
 							animateFromBottom={false}
 							topPosition={gradientTopPosition}
 						/>
 						<div
-							className="pointer-events-none absolute inset-0 z-0 bg-[#05080D]/50"
+							className="absolute inset-0 bg-[#05080D]/50"
 							aria-hidden
 						/>
 						<div
 							id="graph-dotted-grid"
-							className="pointer-events-none absolute inset-0 z-[1] bg-[radial-gradient(circle_at_center,rgba(105,167,240,0.25)_1px,transparent_1px)] bg-size-[32px_32px] mask-[radial-gradient(ellipse_at_center,black_60%,transparent_100%)]"
+							className="absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(105,167,240,0.25)_1px,transparent_1px)] bg-size-[32px_32px] mask-[radial-gradient(ellipse_at_center,black_60%,transparent_100%)]"
 						/>
-					</>
+					</div>
 				)}
 				{!session && viewMode === "mcp" ? (
 					<PublicHeader />

--- a/apps/web/app/(app)/page.tsx
+++ b/apps/web/app/(app)/page.tsx
@@ -559,10 +559,7 @@ export default function NewPage() {
 							animateFromBottom={false}
 							topPosition={gradientTopPosition}
 						/>
-						<div
-							className="absolute inset-0 bg-[#05080D]/50"
-							aria-hidden
-						/>
+						<div className="absolute inset-0 bg-[#05080D]/50" aria-hidden />
 						<div
 							id="graph-dotted-grid"
 							className="absolute inset-0 bg-[radial-gradient(circle_at_center,rgba(105,167,240,0.25)_1px,transparent_1px)] bg-size-[32px_32px] mask-[radial-gradient(ellipse_at_center,black_60%,transparent_100%)]"

--- a/apps/web/components/chat/index.tsx
+++ b/apps/web/components/chat/index.tsx
@@ -952,100 +952,101 @@ export function ChatSidebar({
 					{chatToolbarActions}
 				</div>
 			) : null}
-			<div
-				ref={messagesContainerRef}
-				className={cn(
-					"relative flex-1 overflow-y-auto scrollbar-thin",
-					isPageDesktop && "min-h-0",
-					"px-4",
-					dmSansClassName(),
-				)}
-			>
-				{isInputExpanded && (
-					<div
-						className={cn(
-							"absolute inset-0 z-10! pointer-events-none",
-							isPageDesktop ? "rounded-none" : "rounded-2xl",
-						)}
-						style={{ backgroundColor: "#000000E5" }}
-					/>
-				)}
-				{messages.length === 0 && (
-					<ChatEmptyStatePlaceholder
-						onSuggestionClick={handleSuggestedQuestion}
-						suggestions={emptyStateSuggestions}
-						subtitle={emptyStateSubtitle}
-					/>
-				)}
+			<div className="relative flex-1 min-h-0">
 				<div
-					className={
-						messages.length > 0
-							? cn(
-									"flex flex-col space-y-3 min-h-full justify-end",
-									isPageDesktop ? "pt-2" : "pt-14",
-								)
-							: ""
-					}
-				>
-					{messages.map((message, index) => (
-						// biome-ignore lint/a11y/noStaticElementInteractions: Hover detection for message actions
-						<div
-							key={message.id}
-							className={cn(
-								"flex gap-2 w-full",
-								message.role === "user" ? "justify-end" : "justify-start",
-							)}
-							onMouseEnter={() =>
-								message.role === "assistant" && setHoveredMessageId(message.id)
-							}
-							onMouseLeave={() =>
-								message.role === "assistant" && setHoveredMessageId(null)
-							}
-						>
-							{message.role === "user" ? (
-								<UserMessage
-									message={message}
-									copiedMessageId={copiedMessageId}
-									onCopy={handleCopyMessage}
-								/>
-							) : (
-								<AgentMessage
-									message={message}
-									index={index}
-									messagesLength={messages.length}
-									hoveredMessageId={hoveredMessageId}
-									copiedMessageId={copiedMessageId}
-									messageFeedback={messageFeedback}
-									expandedMemories={expandedMemories}
-									onCopy={handleCopyMessage}
-									onLike={handleLikeMessage}
-									onDislike={handleDislikeMessage}
-									onToggleMemories={handleToggleMemories}
-								/>
-							)}
-						</div>
-					))}
-					{(status === "submitted" || status === "streaming") && (
-						<div className="flex gap-2">
-							<SuperLoader label="Thinking…" />
-						</div>
+					ref={messagesContainerRef}
+					className={cn(
+						"relative h-full overflow-y-auto scrollbar-thin",
+						"px-4",
+						dmSansClassName(),
 					)}
-				</div>
-			</div>
-
-			{!isScrolledToBottom && messages.length > 0 && (
-				<div className="absolute bottom-24 left-0 right-0 flex justify-center z-50 pointer-events-none">
-					<button
-						type="button"
-						className="cursor-pointer pointer-events-auto"
-						onClick={scrollToBottom}
+				>
+					{isInputExpanded && (
+						<div
+							className={cn(
+								"absolute inset-0 z-10! pointer-events-none",
+								isPageDesktop ? "rounded-none" : "rounded-2xl",
+							)}
+							style={{ backgroundColor: "#000000E5" }}
+						/>
+					)}
+					{messages.length === 0 && (
+						<ChatEmptyStatePlaceholder
+							onSuggestionClick={handleSuggestedQuestion}
+							suggestions={emptyStateSuggestions}
+							subtitle={emptyStateSubtitle}
+						/>
+					)}
+					<div
+						className={
+							messages.length > 0
+								? cn(
+										"flex flex-col space-y-3 min-h-full justify-end",
+										isPageDesktop ? "pt-2" : "pt-14",
+									)
+								: ""
+						}
 					>
-						<div className="rounded-full p-2 bg-[#0D121A] shadow-[1.5px_1.5px_4.5px_0_rgba(0,0,0,0.70)_inset] hover:bg-[#0F1620] transition-colors">
-							<ChevronDownIcon className="size-4 text-white" />
-						</div>
-					</button>
+						{messages.map((message, index) => (
+							// biome-ignore lint/a11y/noStaticElementInteractions: Hover detection for message actions
+							<div
+								key={message.id}
+								className={cn(
+									"flex gap-2 w-full",
+									message.role === "user" ? "justify-end" : "justify-start",
+								)}
+								onMouseEnter={() =>
+									message.role === "assistant" && setHoveredMessageId(message.id)
+								}
+								onMouseLeave={() =>
+									message.role === "assistant" && setHoveredMessageId(null)
+								}
+							>
+								{message.role === "user" ? (
+									<UserMessage
+										message={message}
+										copiedMessageId={copiedMessageId}
+										onCopy={handleCopyMessage}
+									/>
+								) : (
+									<AgentMessage
+										message={message}
+										index={index}
+										messagesLength={messages.length}
+										hoveredMessageId={hoveredMessageId}
+										copiedMessageId={copiedMessageId}
+										messageFeedback={messageFeedback}
+										expandedMemories={expandedMemories}
+										onCopy={handleCopyMessage}
+										onLike={handleLikeMessage}
+										onDislike={handleDislikeMessage}
+										onToggleMemories={handleToggleMemories}
+									/>
+								)}
+							</div>
+						))}
+						{(status === "submitted" || status === "streaming") && (
+							<div className="flex gap-2">
+								<SuperLoader label="Thinking…" />
+							</div>
+						)}
+					</div>
 				</div>
-			)}
+
+				{!isScrolledToBottom && messages.length > 0 && (
+					<div className="absolute bottom-3 left-0 right-0 flex justify-center z-50 pointer-events-none">
+						<button
+							type="button"
+							className="cursor-pointer pointer-events-auto"
+							onClick={scrollToBottom}
+						>
+							<div className="rounded-full p-2 bg-[#0D121A] shadow-[1.5px_1.5px_4.5px_0_rgba(0,0,0,0.70)_inset] hover:bg-[#0F1620] transition-colors">
+								<ChevronDownIcon className="size-4 text-white" />
+							</div>
+						</button>
+					</div>
+				)}
+			</div>
 
 			{chatStreamError && (
 				<div
@@ -1103,7 +1104,7 @@ export function ChatSidebar({
 				className={cn(
 					"shrink-0",
 					isStackedInput &&
-						"px-4 pb-[max(1.25rem,calc(env(safe-area-inset-bottom)+1rem))] md:pb-6",
+						"pb-[max(1.25rem,calc(env(safe-area-inset-bottom)+1rem))] md:pb-6",
 				)}
 			>
 				<ChatInput

--- a/apps/web/components/chat/index.tsx
+++ b/apps/web/components/chat/index.tsx
@@ -996,7 +996,8 @@ export function ChatSidebar({
 									message.role === "user" ? "justify-end" : "justify-start",
 								)}
 								onMouseEnter={() =>
-									message.role === "assistant" && setHoveredMessageId(message.id)
+									message.role === "assistant" &&
+									setHoveredMessageId(message.id)
 								}
 								onMouseLeave={() =>
 									message.role === "assistant" && setHoveredMessageId(null)


### PR DESCRIPTION
- Memories page background The blue gradient no longer cuts off when you scroll to the bottom; the background stays consistent instead of showing a black strip.
- Chat layout Message content and the input box at the bottom now line up to the same width.
- Scroll-to-bottom button When you scroll up in chat, the “jump to bottom” control sits above the input instead of covering the message text.

## Width of response and text box same
<img width="751" height="464" alt="Screenshot 2026-05-19 at 3 59 08 PM" src="https://github.com/user-attachments/assets/2b0c4859-5594-4640-831e-759b59b592ae" />

## No black line at bottom
<img width="1680" height="170" alt="Screenshot 2026-05-19 at 3 59 38 PM" src="https://github.com/user-attachments/assets/e3bffeec-0278-4ede-a9c1-33cd734625de" />

## Fix the positon of scroll down button earlier used to come on the input box
<br>
<h3>Before</h3>
<img width="771" height="232" alt="Screenshot 2026-05-19 at 4 00 46 PM" src="https://github.com/user-attachments/assets/d1576199-d8ac-44bd-aa01-bd1f41f7f91c" />
<br>
<h3>After</h3>
<img width="748" height="402" alt="Screenshot 2026-05-19 at 4 00 13 PM" src="https://github.com/user-attachments/assets/caab2405-f9d9-4699-80bf-eb6a78b7a15b" />
