### PR TITLE
fix: dashboard Notion/Google Drive suggestions open connect modal

### DIFF
--- a/apps/web/app/(app)/page.tsx
+++ b/apps/web/app/(app)/page.tsx
@@ -514,9 +514,13 @@ export default function NewPage() {
 
 	const handleOpenIntegrations = useCallback(
 		(integration?: IntegrationParamValue) => {
+			if (integration === "notion" || integration === "google-drive") {
+				void setAddDoc("connect")
+				return
+			}
 			void setViewMode(integration ?? "integrations")
 		},
-		[setViewMode],
+		[setViewMode, setAddDoc],
 	)
 
 	const handleOpenPlugins = useCallback(() => {

--- a/apps/web/lib/search-params.ts
+++ b/apps/web/lib/search-params.ts
@@ -42,7 +42,8 @@ export type ViewParamValue = (typeof viewLiterals)[number]
 export const viewParam =
 	parseAsStringLiteral(viewLiterals).withDefault("dashboard")
 
-// Kept for backwards compat with components that pass integration hints
+// Kept for backwards compat with components that pass integration hints.
+// "notion"/"google-drive" are connection providers, not view modes — they open the connect modal.
 export type IntegrationParamValue =
 	| "mcp"
 	| "plugins"
@@ -51,6 +52,8 @@ export type IntegrationParamValue =
 	| "shortcuts"
 	| "raycast"
 	| "import"
+	| "notion"
+	| "google-drive"
 export const categoriesParam = parseAsArrayOf(parseAsString, ",").withDefault(
 	[],
 )


### PR DESCRIPTION
The home dashboard suggestion cards routed Notion/Google Drive clicks through setViewMode("notion"|"google-drive"), but those values aren't in viewLiterals, so nuqs rejected them and silently fell back to the dashboard view — the click did nothing.

Route those two providers to the connect modal (setAddDoc("connect")), matching the Integrations 'Connections' card, and widen IntegrationParamValue to include them.