### PR TITLE
feat(web): overhaul integrations page with featured hero, category rails and MCP setup modal

### DIFF
--- a/apps/web/app/(app)/settings/integrations/page.tsx
+++ b/apps/web/app/(app)/settings/integrations/page.tsx
@@ -8,8 +8,9 @@ export default function SettingsIntegrationsPage() {
 	const searchParams = useSearchParams()
 
 	useEffect(() => {
-		const qs = searchParams.toString()
-		router.replace(`/settings${qs ? `?${qs}` : ""}#integrations`)
+		const params = new URLSearchParams(searchParams.toString())
+		params.set("view", "integrations")
+		router.replace(`/?${params.toString()}`)
 	}, [router, searchParams])
 
 	return null

--- a/apps/web/components/integrations-view.tsx
+++ b/apps/web/components/integrations-view.tsx
@@ -1,9 +1,9 @@
 "use client"
 
-import { useQuery } from "@tanstack/react-query"
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query"
 import { useCustomer } from "autumn-js/react"
 import { cn } from "@lib/utils"
-import { dmSansClassName } from "@/lib/fonts"
+import { dmSans125ClassName } from "@/lib/fonts"
 import { hasActivePlan } from "@lib/queries"
 import { $fetch } from "@lib/api"
 import { authClient } from "@lib/auth"
@@ -16,127 +16,381 @@ import {
 	AppleShortcutsIcon,
 	RaycastIcon,
 } from "@/components/integration-icons"
-import { GoogleDrive, Notion, OneDrive } from "@ui/assets/icons"
-import { ArrowLeft, Sun } from "lucide-react"
-import { CHROME_EXTENSION_URL } from "@repo/lib/constants"
+import { GoogleDrive, Notion, OneDrive, MCPIcon } from "@ui/assets/icons"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import {
+	ArrowLeft,
+	ArrowRight,
+	BookOpen,
+	Check,
+	ChevronDown,
+	Loader,
+	Search,
+	X,
+	Zap,
+} from "lucide-react"
+import { CHROME_EXTENSION_URL } from "@lib/constants"
 import { analytics } from "@/lib/analytics"
 import Image from "next/image"
-import { IntegrationGridCard } from "@/components/integrations/integration-grid-card"
 import { useViewMode } from "@/lib/view-mode-context"
-import { addDocumentParam, type ViewParamValue } from "@/lib/search-params"
-import { useQueryState } from "nuqs"
+import type { ViewParamValue } from "@/lib/search-params"
+import { parseAsString, parseAsStringEnum, useQueryState } from "nuqs"
+import {
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+	type ReactNode,
+} from "react"
+import { AnimatePresence, motion } from "motion/react"
+import { toast } from "sonner"
+import { Dialog, DialogContent, DialogTitle } from "@ui/components/dialog"
+import { Popover, PopoverContent, PopoverTrigger } from "@ui/components/popover"
+import {
+	PLUGIN_CATALOG,
+	FREE_TIER_PLUGIN_IDS,
+	isFreeTierPlugin,
+	type InstallStep,
+} from "@/lib/plugin-catalog"
+import { INSET, InstallSteps, PillButton } from "./integrations/install-steps"
+import { MCPSteps } from "./mcp-modal/mcp-detail-view"
 
 type Connection = z.infer<typeof ConnectionResponseSchema>
 
-type CardId =
-	| "mcp"
-	| "chrome"
-	| "connections"
-	| "shortcuts"
-	| "raycast"
-	| "import"
-	| "plugins"
+type ConnectorProvider = "google-drive" | "notion" | "onedrive"
 
-interface IntegrationCardDef {
-	id: CardId
-	title: string
-	description: string
-	icon: React.ReactNode
-	pro?: boolean
-	externalHref?: string
+interface ConnectedKey {
+	keyId: string
+	keyStart: string | null
+	pluginId: string
 }
 
-const cards: IntegrationCardDef[] = [
+type ItemKind = "plugin" | "connector" | "client" | "mcp-client" | "import"
+
+type MCPClientKey =
+	| "chatgpt"
+	| "codex"
+	| "cursor"
+	| "claude"
+	| "vscode"
+	| "cline"
+	| "gemini-cli"
+	| "claude-code"
+	| "mcp-url"
+
+const MCP_CLIENTS: Array<{
+	key: MCPClientKey
+	name: string
+	tagline: string
+	simpleTitle?: string
+	dev?: boolean
+}> = [
 	{
-		id: "plugins",
-		title: "Plugins",
-		description:
-			"Hermes on every plan; Claude Code, Codex, OpenCode, OpenClaw, and more with Pro",
-		icon: (
-			<div className="flex items-center -space-x-1.5">
-				<Image
-					src="/images/plugins/claude-code.svg"
-					alt="Claude Code"
-					width={24}
-					height={24}
-					className="size-6 rounded"
-				/>
-				<Image
-					src="/images/plugins/codex.png"
-					alt="Codex"
-					width={24}
-					height={24}
-					className="size-6 rounded"
-				/>
-				<Image
-					src="/images/plugins/opencode.svg"
-					alt="OpenCode"
-					width={24}
-					height={24}
-					className="size-6 rounded"
-				/>
-				<Image
-					src="/images/plugins/openclaw.svg"
-					alt="OpenClaw"
-					width={24}
-					height={24}
-					className="size-6 rounded"
-				/>
-				<Image
-					src="/images/plugins/hermes.svg"
-					alt="Hermes"
-					width={24}
-					height={24}
-					className="size-6 rounded"
-				/>
-			</div>
-		),
+		key: "cursor",
+		name: "Cursor",
+		tagline: "One-click MCP install in Cursor",
+		simpleTitle: "Code with your saved knowledge nearby",
 	},
 	{
-		id: "connections",
-		title: "Connections",
-		description: "Link Notion, Google Drive, or OneDrive to import your docs",
-		pro: true,
-		icon: (
-			<div className="flex items-center -space-x-1">
-				<GoogleDrive className="size-5" />
-				<Notion className="size-5" />
-				<OneDrive className="size-5" />
-			</div>
-		),
+		key: "claude",
+		name: "Claude Desktop",
+		tagline: "Connect supermemory in Claude Desktop",
+		simpleTitle: "Reference your notes during any Claude chat",
 	},
 	{
-		id: "mcp",
-		title: "Connect to AI",
-		description: "Set up MCP to use your memory in Cursor, Claude, and more",
-		icon: (
-			<img src="/onboarding/mcp.png" alt="MCP" className="size-20 h-auto" />
-		),
+		key: "chatgpt",
+		name: "ChatGPT",
+		tagline: "Apps via ChatGPT developer mode",
+		simpleTitle: "Let ChatGPT recall what you've saved",
 	},
 	{
-		id: "chrome",
-		title: "Chrome Extension",
-		description: "Save any webpage, import bookmarks, sync ChatGPT memories",
-		icon: <ChromeIcon className="size-14" />,
-		externalHref: CHROME_EXTENSION_URL,
+		key: "vscode",
+		name: "VS Code",
+		tagline: "Native MCP support in VS Code",
+		simpleTitle: "Pull your knowledge into VS Code while coding",
+		dev: true,
 	},
 	{
-		id: "shortcuts",
-		title: "Apple Shortcuts",
-		description: "Add memories directly from iPhone, iPad or Mac",
-		icon: <AppleShortcutsIcon />,
+		key: "cline",
+		name: "Cline",
+		tagline: "MCP via the Cline VS Code extension",
+		simpleTitle: "Cline can read and add to your memory",
+		dev: true,
 	},
 	{
-		id: "raycast",
-		title: "Raycast",
-		description: "Add and search memories from Raycast on Mac",
-		icon: <RaycastIcon className="size-10" />,
+		key: "gemini-cli",
+		name: "Gemini CLI",
+		tagline: "Google Gemini terminal client",
+		simpleTitle: "Bring your memory into Gemini sessions",
+		dev: true,
 	},
 	{
-		id: "import",
-		title: "Import Bookmarks",
-		description: "Bring in X/Twitter bookmarks and turn them into memories",
-		icon: <img src="/onboarding/x.png" alt="X" className="size-10" />,
+		key: "codex",
+		name: "Codex (MCP)",
+		tagline: "OpenAI Codex CLI via MCP config",
+		simpleTitle: "Codex with access to your saved context",
+		dev: true,
+	},
+	{
+		key: "claude-code",
+		name: "Claude Code (MCP)",
+		tagline: "Connect via Claude Code MCP config",
+		simpleTitle: "Claude Code with your project context",
+		dev: true,
+	},
+	{
+		key: "mcp-url",
+		name: "MCP URL",
+		tagline: "Use the URL in any custom MCP client",
+		simpleTitle: "Connect any MCP-capable app to supermemory",
+		dev: true,
+	},
+]
+
+function mcpClientIconSrc(key: MCPClientKey): string {
+	if (key === "mcp-url") return "/mcp-icon.svg"
+	const file = key === "claude-code" ? "claude" : key
+	return `/mcp-supported-tools/${file}.png`
+}
+
+const PLUGIN_SIMPLE_TITLES: Record<string, string> = {
+	claude_code: "Remembers your code conventions and decisions",
+	codex: "Codex sessions that remember your project",
+	opencode: "OpenCode with persistent project memory",
+	openclaw: "Save chats from Telegram, Discord and Slack",
+	hermes: "Persistent memory for the Hermes agent",
+}
+
+type CategoryFilter =
+	| "all"
+	| "connected"
+	| "plugins"
+	| "knowledge-bases"
+	| "apps-extensions"
+	| "ai-clients"
+
+const CATEGORY_VALUES: readonly CategoryFilter[] = [
+	"all",
+	"connected",
+	"ai-clients",
+	"plugins",
+	"knowledge-bases",
+	"apps-extensions",
+] as const
+
+const catParam = parseAsStringEnum<CategoryFilter>([
+	...CATEGORY_VALUES,
+]).withDefault("all")
+
+const CATEGORY_LABEL: Record<CategoryFilter, string> = {
+	all: "All",
+	connected: "Connected",
+	plugins: "Plugins",
+	"knowledge-bases": "Knowledge bases",
+	"apps-extensions": "Apps & extensions",
+	"ai-clients": "MCP",
+}
+
+const SECTION_ORDER: Array<Exclude<CategoryFilter, "all" | "connected">> = [
+	"ai-clients",
+	"plugins",
+	"knowledge-bases",
+	"apps-extensions",
+]
+
+function itemCategory(
+	item: Item,
+): Exclude<CategoryFilter, "all" | "connected"> {
+	switch (item.kind) {
+		case "plugin":
+			return "plugins"
+		case "connector":
+			return "knowledge-bases"
+		case "mcp-client":
+			return "ai-clients"
+		case "client":
+		case "import":
+			return "apps-extensions"
+	}
+}
+
+interface BaseItem {
+	id: string
+	name: string
+	tagline: string
+	icon: ReactNode
+	docsUrl?: string
+	pro?: boolean
+	kind: ItemKind
+	simpleTitle?: string
+	dev?: boolean
+}
+
+interface PluginItem extends BaseItem {
+	kind: "plugin"
+	pluginId: string
+}
+
+interface ConnectorItem extends BaseItem {
+	kind: "connector"
+	provider: ConnectorProvider
+}
+
+interface ClientItem extends BaseItem {
+	kind: "client"
+	action:
+		| { type: "external"; href: string }
+		| { type: "view"; viewMode: ViewParamValue }
+}
+
+interface MCPClientItem extends BaseItem {
+	kind: "mcp-client"
+	clientKey: MCPClientKey
+}
+
+interface ImportItem extends BaseItem {
+	kind: "import"
+	viewMode: ViewParamValue
+}
+
+type Item = PluginItem | ConnectorItem | ClientItem | MCPClientItem | ImportItem
+
+const SECTIONS: Array<{
+	label: string
+	items: (plugin: typeof PLUGIN_CATALOG) => Item[]
+}> = [
+	{
+		label: "MCP",
+		items: () =>
+			MCP_CLIENTS.map<MCPClientItem>((c) => ({
+				kind: "mcp-client",
+				clientKey: c.key,
+				id: `mcp-${c.key}`,
+				name: c.name,
+				tagline: c.tagline,
+				simpleTitle: c.simpleTitle,
+				dev: c.dev,
+				icon:
+					c.key === "mcp-url" ? (
+						<MCPIcon className="size-6" />
+					) : (
+						<Image
+							src={mcpClientIconSrc(c.key)}
+							alt={c.name}
+							width={24}
+							height={24}
+							unoptimized
+							className="size-6 rounded object-contain"
+						/>
+					),
+				docsUrl: "https://docs.supermemory.ai/supermemory-mcp/introduction",
+			})),
+	},
+	{
+		label: "Plugins",
+		items: (catalog) =>
+			Object.keys(catalog).map<PluginItem>((id) => {
+				const plugin = catalog[id]
+				if (!plugin) throw new Error(`Missing plugin ${id}`)
+				return {
+					kind: "plugin",
+					id: `plugin-${id}`,
+					pluginId: id,
+					name: plugin.name,
+					tagline: plugin.tagline,
+					icon: (
+						<Image
+							src={plugin.icon}
+							alt={plugin.name}
+							width={24}
+							height={24}
+							className="size-6 rounded"
+						/>
+					),
+					docsUrl: plugin.docsUrl,
+					pro: !FREE_TIER_PLUGIN_IDS.includes(id),
+					simpleTitle: PLUGIN_SIMPLE_TITLES[id],
+					dev: true,
+				}
+			}),
+	},
+	{
+		label: "Knowledge bases",
+		items: () => [
+			{
+				kind: "connector",
+				id: "google-drive",
+				provider: "google-drive",
+				name: "Google Drive",
+				tagline: "Sync Docs, Sheets and Slides into your memory",
+				simpleTitle: "Your Docs, Sheets and Slides, searchable",
+				icon: <GoogleDrive className="size-6" />,
+				pro: true,
+			},
+			{
+				kind: "connector",
+				id: "notion",
+				provider: "notion",
+				name: "Notion",
+				tagline: "Import Notion pages and databases",
+				simpleTitle: "All your Notion pages, in supermemory",
+				icon: <Notion className="size-6" />,
+				pro: true,
+			},
+			{
+				kind: "connector",
+				id: "onedrive",
+				provider: "onedrive",
+				name: "OneDrive",
+				tagline: "Bring in Office documents from OneDrive",
+				simpleTitle: "Your OneDrive files, ready to recall",
+				icon: <OneDrive className="size-6" />,
+				pro: true,
+			},
+		],
+	},
+	{
+		label: "Apps & extensions",
+		items: () => [
+			{
+				kind: "client",
+				id: "chrome",
+				name: "Chrome Extension",
+				tagline: "Save webpages, import bookmarks, sync ChatGPT memories",
+				simpleTitle: "Save any webpage with one click",
+				icon: <ChromeIcon className="size-6" />,
+				action: { type: "external", href: CHROME_EXTENSION_URL },
+			},
+			{
+				kind: "client",
+				id: "shortcuts",
+				name: "Apple Shortcuts",
+				tagline: "Add memories from iPhone, iPad or Mac",
+				simpleTitle: "Save anything from your phone or Mac",
+				icon: <AppleShortcutsIcon />,
+				action: { type: "view", viewMode: "shortcuts" as ViewParamValue },
+			},
+			{
+				kind: "client",
+				id: "raycast",
+				name: "Raycast",
+				tagline: "Add and search memories from Raycast on Mac",
+				simpleTitle: "Save and search from Raycast on Mac",
+				icon: <RaycastIcon className="size-6" />,
+				action: { type: "view", viewMode: "raycast" as ViewParamValue },
+				dev: true,
+			},
+			{
+				kind: "import",
+				id: "x-bookmarks",
+				name: "Import X bookmarks",
+				tagline: "Turn your X/Twitter bookmarks into memories",
+				simpleTitle: "Turn your X bookmarks into memory",
+				icon: <Image src="/onboarding/x.png" alt="X" width={24} height={24} />,
+				viewMode: "import" as ViewParamValue,
+			},
+		],
 	},
 ]
 
@@ -145,7 +399,7 @@ export function DetailWrapper({
 	children,
 }: {
 	onBack: () => void
-	children: React.ReactNode
+	children: ReactNode
 }) {
 	return (
 		<div className="flex-1 p-4 md:p-6 pt-2">
@@ -164,20 +418,603 @@ export function DetailWrapper({
 	)
 }
 
-const CARD_GROUPS: Array<{ label: string; ids: CardId[] }> = [
-	{ label: "AI tools", ids: ["plugins", "mcp"] },
-	{
-		label: "Apps & extensions",
-		ids: ["connections", "chrome", "shortcuts", "raycast", "import"],
-	},
-]
+function ProChip() {
+	return (
+		<span
+			className={cn(
+				dmSans125ClassName(),
+				"shrink-0 rounded-[4px] border border-[#4BA0FA]/25 bg-[#4BA0FA]/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-[#4BA0FA]",
+			)}
+		>
+			Pro
+		</span>
+	)
+}
+
+function IconBox({ children }: { children: ReactNode }) {
+	return (
+		<div
+			className={cn(
+				"flex size-10 shrink-0 items-center justify-center rounded-[10px] bg-[#080B0F]",
+				"shadow-[inset_1.5px_1.5px_4.5px_rgba(0,0,0,0.6)]",
+			)}
+		>
+			{children}
+		</div>
+	)
+}
+
+function DocsLink({ href }: { href: string }) {
+	return (
+		<a
+			aria-label="Open docs"
+			href={href}
+			target="_blank"
+			rel="noopener noreferrer"
+			onClick={(e) => e.stopPropagation()}
+			className={cn(
+				dmSans125ClassName(),
+				"flex size-8 shrink-0 items-center justify-center rounded-full text-[12px] text-[#A1A1AA] transition-colors hover:text-white sm:h-auto sm:w-auto sm:gap-1.5 sm:rounded-none",
+			)}
+		>
+			<BookOpen className="size-3.5" />
+			<span className="hidden sm:inline">Docs</span>
+		</a>
+	)
+}
+
+function DisconnectButton({ onConfirm }: { onConfirm: () => void }) {
+	const [confirming, setConfirming] = useState(false)
+	useEffect(() => {
+		if (!confirming) return
+		const t = setTimeout(() => setConfirming(false), 3000)
+		return () => clearTimeout(t)
+	}, [confirming])
+	return (
+		<button
+			type="button"
+			onClick={() => (confirming ? onConfirm() : setConfirming(true))}
+			className={cn(
+				dmSans125ClassName(),
+				"shrink-0 rounded-md px-2 py-1 text-[11px] font-medium transition-colors",
+				confirming
+					? "bg-red-500/15 text-red-400"
+					: "text-[#737373] hover:bg-white/5 hover:text-red-400",
+			)}
+		>
+			{confirming ? "Confirm" : "Disconnect"}
+		</button>
+	)
+}
+
+function ConnectedPill({
+	keys,
+	onRevoke,
+}: {
+	keys: ConnectedKey[]
+	onRevoke: (keyId: string) => void
+}) {
+	return (
+		<Popover>
+			<PopoverTrigger asChild>
+				<button
+					type="button"
+					onClick={(e) => e.stopPropagation()}
+					className={cn(
+						dmSans125ClassName(),
+						"flex h-8 min-w-[104px] shrink-0 cursor-pointer items-center justify-center gap-1.5 rounded-full bg-[#0D121A] px-3 text-[12px] font-medium text-[#00AC3F] sm:h-9 sm:min-w-[116px] sm:gap-2 sm:px-4 sm:text-[13px]",
+						"shadow-[inset_1.5px_1.5px_4.5px_rgba(0,0,0,0.7)] transition-opacity hover:opacity-80",
+					)}
+				>
+					<span className="size-[7px] rounded-full bg-[#00AC3F]" />
+					Connected
+					<ChevronDown className="size-3 text-[#737373]" />
+				</button>
+			</PopoverTrigger>
+			<PopoverContent
+				align="end"
+				onClick={(e) => e.stopPropagation()}
+				className={cn(
+					dmSans125ClassName(),
+					"w-[260px] rounded-xl border border-white/10 bg-[#1B1F24] p-2 text-[#FAFAFA]",
+				)}
+			>
+				<p className="px-2 pb-1.5 pt-1 text-[11px] font-medium uppercase tracking-wide text-[#737373]">
+					{keys.length > 1 ? `${keys.length} connections` : "Connection"}
+				</p>
+				<div className="flex flex-col">
+					{keys.map((k) => (
+						<div
+							key={k.keyId}
+							className="flex items-center justify-between gap-2 rounded-lg px-2 py-1.5"
+						>
+							<span className="min-w-0 flex-1 truncate font-mono text-[12px] text-[#A1A1AA]">
+								{k.keyStart ? `${k.keyStart}…` : "API key"}
+							</span>
+							<DisconnectButton onConfirm={() => onRevoke(k.keyId)} />
+						</div>
+					))}
+				</div>
+			</PopoverContent>
+		</Popover>
+	)
+}
+
+function ConnectionsCountPill({ count }: { count: number }) {
+	return (
+		<span
+			className={cn(
+				dmSans125ClassName(),
+				"flex h-8 min-w-[104px] shrink-0 items-center justify-center gap-1.5 rounded-full bg-[#0D121A] px-3 text-[12px] font-medium text-[#00AC3F] sm:h-9 sm:min-w-[116px] sm:gap-2 sm:px-4 sm:text-[13px]",
+				"shadow-[inset_1.5px_1.5px_4.5px_rgba(0,0,0,0.7)]",
+			)}
+		>
+			<span className="size-[7px] rounded-full bg-[#00AC3F]" />
+			{count > 1 ? `${count} connected` : "Connected"}
+		</span>
+	)
+}
+
+function ItemCard({
+	icon,
+	name,
+	tagline,
+	pro,
+	docsUrl,
+	leftIndicator,
+	rightSlot,
+}: {
+	icon: ReactNode
+	name: string
+	tagline: string
+	pro?: boolean
+	docsUrl?: string
+	leftIndicator?: ReactNode
+	rightSlot: ReactNode
+}) {
+	return (
+		<div
+			className={cn(
+				"flex h-full flex-col gap-4 rounded-[12px] bg-[#14161A] p-4 transition-colors hover:bg-[#16181D]",
+				"shadow-[inset_2.42px_2.42px_4.263px_rgba(11,15,21,0.7)]",
+			)}
+		>
+			<div className="flex items-start justify-between gap-2">
+				<IconBox>{icon}</IconBox>
+				{docsUrl && (
+					// biome-ignore lint/a11y/noStaticElementInteractions: wrapper to stop event propagation
+					<div
+						role="presentation"
+						onClick={(e) => e.stopPropagation()}
+						onKeyDown={(e) => e.stopPropagation()}
+					>
+						<DocsLink href={docsUrl} />
+					</div>
+				)}
+			</div>
+			<div className="flex flex-1 flex-col justify-end gap-3">
+				<div className="min-w-0">
+					<div className="flex min-w-0 items-center gap-1.5">
+						{leftIndicator}
+						<span
+							className={cn(
+								dmSans125ClassName(),
+								"min-w-0 truncate text-[14px] font-medium text-[#FAFAFA]",
+							)}
+						>
+							{name}
+						</span>
+						{pro && <ProChip />}
+					</div>
+					<p
+						className={cn(
+							dmSans125ClassName(),
+							"mt-1 line-clamp-2 text-[12px] leading-snug text-[#A1A1AA]",
+						)}
+					>
+						{tagline}
+					</p>
+				</div>
+				<div className="flex justify-end">{rightSlot}</div>
+			</div>
+		</div>
+	)
+}
+
+interface FeaturedPick {
+	id: string
+	name: string
+	headline: string
+	support: string
+	tagline: string
+	icon: ReactNode
+	backdrop?: ReactNode
+	docsUrl?: string
+	ctaLabel: string
+	onCta: () => void
+}
+
+const FEATURED_ROTATE_MS = 7000
+
+function FeaturedHero({ picks }: { picks: FeaturedPick[] }) {
+	const [index, setIndex] = useState(0)
+	const [paused, setPaused] = useState(false)
+	const [manualOverride, setManualOverride] = useState(false)
+
+	useEffect(() => {
+		if (picks.length <= 1) return
+		if (paused || manualOverride) return
+		const t = setInterval(() => {
+			setIndex((i) => (i + 1) % picks.length)
+		}, FEATURED_ROTATE_MS)
+		return () => clearInterval(t)
+	}, [picks.length, paused, manualOverride])
+
+	if (picks.length === 0) return null
+	const pick = picks[index] ?? picks[0]
+	if (!pick) return null
+
+	return (
+		<button
+			type="button"
+			onClick={pick.onCta}
+			onMouseEnter={() => setPaused(true)}
+			onMouseLeave={() => setPaused(false)}
+			onFocus={() => setPaused(true)}
+			onBlur={() => setPaused(false)}
+			className={cn(
+				"group relative w-full overflow-hidden rounded-[14px] px-5 py-5 sm:px-6 sm:py-6 text-left cursor-pointer",
+				"bg-[#191D24]",
+				"shadow-[inset_2.42px_2.42px_4.263px_rgba(11,15,21,0.7)]",
+				"min-h-[160px]",
+			)}
+		>
+			{pick.backdrop && (
+				<AnimatePresence mode="wait">
+					<motion.div
+						key={`bg-${pick.id}`}
+						initial={{ opacity: 0, x: 12 }}
+						animate={{ opacity: 1, x: 0 }}
+						exit={{ opacity: 0, x: 8 }}
+						transition={{ duration: 0.45, ease: [0.4, 0, 0.2, 1] }}
+						aria-hidden
+						className="pointer-events-none absolute inset-y-0 right-0 w-3/5 sm:w-2/3"
+					>
+						<div className="absolute -right-8 -top-10 sm:right-0 sm:-top-4 opacity-55">
+							{pick.backdrop}
+						</div>
+						<div className="absolute inset-0 bg-gradient-to-l from-transparent via-[#191D24]/40 to-[#191D24]" />
+						<div className="absolute inset-0 bg-gradient-to-t from-[#191D24]/60 via-transparent to-transparent" />
+					</motion.div>
+				</AnimatePresence>
+			)}
+			<div
+				aria-hidden
+				className="pointer-events-none absolute inset-0 opacity-[0.06] mix-blend-overlay"
+				style={{
+					backgroundImage:
+						"url(\"data:image/svg+xml;utf8,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E\")",
+				}}
+			/>
+
+			<span
+				className={cn(
+					dmSans125ClassName(),
+					"relative z-1 mb-3 inline-flex items-center rounded-full px-2.5 py-1 text-[10px] font-bold uppercase tracking-[0.14em] text-[#06121A]",
+					"shadow-[0_0_14px_rgba(54,253,253,0.30)]",
+				)}
+				style={{
+					background:
+						"linear-gradient(94deg, #369BFD 4.8%, #36FDFD 77.04%, #36FDB5 143.99%)",
+				}}
+			>
+				Featured
+			</span>
+			{picks.length > 1 && (
+				<div className="absolute right-5 top-5 sm:right-6 sm:top-6 z-1 flex shrink-0 items-center gap-1.5">
+					{picks.map((p, i) => {
+						const active = i === index
+						return (
+							<button
+								key={p.id}
+								type="button"
+								aria-label={`Show featured ${p.name}`}
+								onClick={(e) => {
+									e.stopPropagation()
+									setIndex(i)
+									setManualOverride(true)
+								}}
+								className={cn(
+									"rounded-full transition-all cursor-pointer",
+									active
+										? "w-3 h-1 bg-[#4BA0FA]"
+										: "size-1 bg-[#2A3040] hover:bg-[#3A4455]",
+								)}
+							/>
+						)
+					})}
+				</div>
+			)}
+
+			<AnimatePresence mode="wait">
+				<motion.div
+					key={pick.id}
+					initial={{ opacity: 0, y: 4 }}
+					animate={{ opacity: 1, y: 0 }}
+					exit={{ opacity: 0, y: -3 }}
+					transition={{ duration: 0.2, ease: [0.4, 0, 0.2, 1] }}
+					className="relative flex max-w-[55%] flex-col gap-1.5"
+				>
+					<h3
+						className={cn(
+							dmSans125ClassName(),
+							"text-[18px] font-semibold leading-tight tracking-[-0.15px] text-[#FAFAFA]",
+						)}
+					>
+						{pick.headline}
+					</h3>
+					<p
+						className={cn(
+							dmSans125ClassName(),
+							"text-[13px] leading-snug text-[#A1A1AA]",
+						)}
+					>
+						<span className="font-medium text-[#CBD5E1]">{pick.name}</span> ·{" "}
+						{pick.support}
+					</p>
+				</motion.div>
+			</AnimatePresence>
+		</button>
+	)
+}
+
+function SearchToggle({
+	value,
+	onChange,
+	expanded,
+	setExpanded,
+}: {
+	value: string
+	onChange: (next: string) => void
+	expanded: boolean
+	setExpanded: (next: boolean) => void
+}) {
+	const inputRef = useRef<HTMLInputElement>(null)
+
+	const open = () => {
+		setExpanded(true)
+		requestAnimationFrame(() => inputRef.current?.focus())
+	}
+
+	const close = () => {
+		onChange("")
+		setExpanded(false)
+	}
+
+	if (!expanded && !value) {
+		return (
+			<button
+				type="button"
+				aria-label="Search integrations"
+				onClick={open}
+				className={cn(
+					"flex size-8 shrink-0 items-center justify-center rounded-full bg-[#0D121A] text-[#A1A1AA] transition-colors hover:text-[#FAFAFA]",
+					"shadow-[inset_1.5px_1.5px_4.5px_rgba(0,0,0,0.5)]",
+				)}
+			>
+				<Search className="size-3.5" />
+			</button>
+		)
+	}
+
+	return (
+		<div
+			className={cn(
+				"flex h-8 min-w-0 flex-1 items-center gap-1.5 rounded-full bg-[#0D121A] px-3",
+				"shadow-[inset_1.5px_1.5px_4.5px_rgba(0,0,0,0.5)]",
+			)}
+		>
+			<Search className="size-3.5 shrink-0 text-[#A1A1AA]" />
+			<input
+				ref={inputRef}
+				type="text"
+				value={value}
+				onChange={(e) => onChange(e.target.value)}
+				onKeyDown={(e) => {
+					if (e.key === "Escape") close()
+				}}
+				onBlur={() => {
+					if (!value) setExpanded(false)
+				}}
+				placeholder="Search integrations"
+				className={cn(
+					dmSans125ClassName(),
+					"min-w-0 flex-1 bg-transparent text-[12px] text-[#FAFAFA] placeholder:text-[#525D6E] focus:outline-none",
+				)}
+			/>
+			{value && (
+				<button
+					type="button"
+					aria-label="Clear search"
+					onClick={close}
+					className="shrink-0 text-[#737373] transition-colors hover:text-[#FAFAFA]"
+				>
+					<X className="size-3.5" />
+				</button>
+			)}
+		</div>
+	)
+}
+
+function CategoryFilterToggle({
+	value,
+	onChange,
+	counts,
+	compact,
+}: {
+	value: CategoryFilter
+	onChange: (next: CategoryFilter) => void
+	counts: Record<CategoryFilter, number>
+	compact?: boolean
+}) {
+	const visible = compact
+		? [value]
+		: CATEGORY_VALUES.filter((v) => v === "all" || counts[v] > 0)
+	return (
+		<div
+			className={cn(
+				"scrollbar-none flex items-center gap-0.5 overflow-x-auto rounded-full bg-[#0D121A] p-0.5",
+				"shadow-[inset_1.5px_1.5px_4.5px_rgba(0,0,0,0.5)]",
+			)}
+		>
+			{visible.map((v) => {
+				const active = value === v
+				return (
+					<button
+						key={v}
+						type="button"
+						onClick={() => onChange(v)}
+						className={cn(
+							dmSans125ClassName(),
+							"flex h-7 shrink-0 items-center gap-1.5 rounded-full px-3 text-[12px] font-medium transition-colors",
+							active
+								? "bg-white/[0.10] text-[#FAFAFA]"
+								: "text-[#A1A1AA] hover:text-[#FAFAFA]",
+						)}
+					>
+						{CATEGORY_LABEL[v]}
+						{v !== "all" && (
+							<span
+								className={cn(
+									"text-[10px] font-semibold tabular-nums",
+									active ? "text-[#A1A1AA]" : "text-[#525D6E]",
+								)}
+							>
+								{counts[v]}
+							</span>
+						)}
+					</button>
+				)
+			})}
+		</div>
+	)
+}
+
+function SectionRail({
+	label,
+	children,
+}: {
+	label: string
+	children: ReactNode
+}) {
+	const scrollRef = useRef<HTMLDivElement>(null)
+	const [canScrollLeft, setCanScrollLeft] = useState(false)
+	const [canScrollRight, setCanScrollRight] = useState(false)
+
+	const update = useCallback(() => {
+		const el = scrollRef.current
+		if (!el) return
+		setCanScrollLeft(el.scrollLeft > 4)
+		setCanScrollRight(el.scrollLeft + el.clientWidth < el.scrollWidth - 4)
+	}, [])
+
+	useEffect(() => {
+		update()
+		const el = scrollRef.current
+		if (!el) return
+		el.addEventListener("scroll", update, { passive: true })
+		el.addEventListener("scrollend", update)
+		const ro = new ResizeObserver(update)
+		ro.observe(el)
+		return () => {
+			el.removeEventListener("scroll", update)
+			el.removeEventListener("scrollend", update)
+			ro.disconnect()
+		}
+	}, [update])
+
+	const scrollBy = (dir: 1 | -1) => {
+		scrollRef.current?.scrollBy({ left: 292 * dir, behavior: "smooth" })
+		setTimeout(update, 450)
+	}
+
+	const arrowClass = cn(
+		"flex size-7 items-center justify-center rounded-full bg-[#0D121A] text-[#FAFAFA] transition-opacity",
+		"shadow-[inset_1.5px_1.5px_4.5px_rgba(0,0,0,0.6)]",
+		"hover:opacity-90 disabled:cursor-not-allowed disabled:opacity-30",
+	)
+
+	return (
+		<section className="flex flex-col gap-3">
+			<div className="flex items-center justify-between gap-3">
+				<h3
+					className={cn(
+						dmSans125ClassName(),
+						"text-[13px] font-semibold tracking-[-0.01em] text-[#A1A1AA]",
+					)}
+				>
+					{label}
+				</h3>
+				<div className="flex items-center gap-1.5">
+					<button
+						type="button"
+						aria-label="Show previous"
+						disabled={!canScrollLeft}
+						onClick={() => scrollBy(-1)}
+						className={arrowClass}
+					>
+						<ArrowLeft className="size-3.5" />
+					</button>
+					<button
+						type="button"
+						aria-label="Show more"
+						disabled={!canScrollRight}
+						onClick={() => scrollBy(1)}
+						className={arrowClass}
+					>
+						<ArrowRight className="size-3.5" />
+					</button>
+				</div>
+			</div>
+			<div
+				ref={scrollRef}
+				className="scrollbar-none flex gap-3 overflow-x-auto -mx-1 px-1"
+			>
+				{children}
+			</div>
+		</section>
+	)
+}
 
 export function IntegrationsView() {
 	const { setViewMode } = useViewMode()
-	const [, setAddDoc] = useQueryState("add", addDocumentParam)
+	const queryClient = useQueryClient()
 	const { org } = useAuth()
 	const autumn = useCustomer()
 	const hasProProduct = hasActivePlan(autumn.data?.subscriptions, "api_pro")
+	const isAutumnLoading = autumn.isLoading
+
+	const [connectingPlugin, setConnectingPlugin] = useState<string | null>(null)
+	const [connectingProvider, setConnectingProvider] =
+		useState<ConnectorProvider | null>(null)
+	const [newKey, setNewKey] = useState<{
+		open: boolean
+		key: string
+		pluginId: string | null
+	}>({ open: false, key: "", pluginId: null })
+
+	const { data: pluginsData } = useQuery({
+		queryFn: async () => {
+			const API_URL =
+				process.env.NEXT_PUBLIC_BACKEND_URL ?? "https://api.supermemory.ai"
+			const res = await fetch(`${API_URL}/v3/auth/plugins`, {
+				credentials: "include",
+			})
+			if (!res.ok) throw new Error("Failed to fetch plugins")
+			return (await res.json()) as { plugins: string[] }
+		},
+		queryKey: ["plugins"],
+	})
 
 	const { data: connections = [] } = useQuery({
 		queryKey: ["connections"],
@@ -193,25 +1030,12 @@ export function IntegrationsView() {
 		enabled: hasProProduct,
 	})
 
-	const { data: facetsData } = useQuery({
-		queryKey: ["document-facets", []],
-		queryFn: async () => {
-			const response = await $fetch("@post/documents/documents/facets", {
-				body: { containerTags: [] },
-				disableValidation: true,
-			})
-			if (response.error)
-				throw new Error(response.error?.message || "Failed to fetch facets")
-			return response.data as {
-				facets: Array<{ category: string; count: number }>
-				total: number
-			}
-		},
-		staleTime: 5 * 60 * 1000,
-	})
-
-	type ApiKey = { metadata: Record<string, unknown> | null }
-	const { data: apiKeys = [] } = useQuery({
+	type ApiKey = {
+		id: string
+		metadata: Record<string, unknown> | null
+		start: string | null
+	}
+	const { data: apiKeys = [], refetch: refetchKeys } = useQuery({
 		queryKey: ["api-keys", org?.id],
 		queryFn: async () => {
 			if (!org?.id) return []
@@ -224,96 +1048,724 @@ export function IntegrationsView() {
 		staleTime: 30 * 1000,
 	})
 
-	const connectedPluginCount = apiKeys.filter(
-		(key) => key.metadata?.sm_type === "plugin_auth",
-	).length
+	const connectedPlugins = useMemo<ConnectedKey[]>(() => {
+		const out: ConnectedKey[] = []
+		for (const key of apiKeys) {
+			if (!key.metadata) continue
+			try {
+				const metadata =
+					typeof key.metadata === "string"
+						? (JSON.parse(key.metadata) as {
+								sm_type?: string
+								sm_client?: string
+							})
+						: (key.metadata as { sm_type?: string; sm_client?: string })
+				if (metadata.sm_type === "plugin_auth" && metadata.sm_client) {
+					out.push({
+						keyId: key.id,
+						keyStart: key.start ?? null,
+						pluginId: metadata.sm_client,
+					})
+				}
+			} catch {}
+		}
+		return out
+	}, [apiKeys])
 
-	const tweetCount =
-		facetsData?.facets.find((f) => f.category === "tweet")?.count ?? 0
+	const connectionsByProvider = useMemo(() => {
+		const out: Record<ConnectorProvider, Connection[]> = {
+			"google-drive": [],
+			notion: [],
+			onedrive: [],
+		}
+		for (const c of connections) {
+			const p = c.provider as ConnectorProvider
+			if (p in out) out[p].push(c)
+		}
+		return out
+	}, [connections])
 
-	const getStatusLabel = (
-		id: CardId,
-	): { label: string; variant: "connected" | "neutral" } | undefined => {
-		if (id === "connections" && hasProProduct) {
-			return connections.length > 0
-				? { label: `${connections.length} connected`, variant: "connected" }
-				: { label: "Not connected", variant: "neutral" }
+	const createPluginKeyMutation = useMutation({
+		mutationFn: async (pluginId: string) => {
+			const API_URL =
+				process.env.NEXT_PUBLIC_BACKEND_URL ?? "https://api.supermemory.ai"
+			const params = new URLSearchParams({ client: pluginId })
+			const res = await fetch(`${API_URL}/v3/auth/key?${params}`, {
+				credentials: "include",
+			})
+			if (!res.ok) {
+				if (res.status === 403) {
+					throw new Error(
+						"This plugin requires a Pro plan. Hermes and Codex are available on the Free plan.",
+					)
+				}
+				const errorData = (await res.json().catch(() => ({}))) as {
+					message?: string
+				}
+				throw new Error(errorData.message || "Failed to create plugin key")
+			}
+			return (await res.json()) as { key: string }
+		},
+		onMutate: (pluginId) => setConnectingPlugin(pluginId),
+		onError: (err) => {
+			toast.error("Failed to connect plugin", {
+				description: err instanceof Error ? err.message : "Unknown error",
+			})
+		},
+		onSettled: () => {
+			setConnectingPlugin(null)
+			queryClient.invalidateQueries({ queryKey: ["api-keys", org?.id] })
+		},
+		onSuccess: (data, pluginId) => {
+			setNewKey({ open: true, key: data.key, pluginId })
+		},
+	})
+
+	const addConnectionMutation = useMutation({
+		mutationFn: async (provider: ConnectorProvider) => {
+			const response = await $fetch("@post/connections/:provider", {
+				params: { provider },
+				body: {
+					redirectUrl: window.location.href,
+					containerTags: [],
+				},
+			})
+			if ("data" in response && response.data && !("error" in response.data)) {
+				return response.data
+			}
+			throw new Error(response.error?.message || "Failed to connect")
+		},
+		onMutate: (provider) => setConnectingProvider(provider),
+		onError: (err) => {
+			setConnectingProvider(null)
+			toast.error("Failed to connect", {
+				description: err instanceof Error ? err.message : "Unknown error",
+			})
+		},
+		onSuccess: (data) => {
+			if (data?.authLink) {
+				window.location.href = data.authLink
+				return
+			}
+			setConnectingProvider(null)
+			toast.error("Connect link missing — try again.")
+		},
+	})
+
+	const handleRevokePluginKey = async (keyId: string) => {
+		try {
+			await authClient.apiKey.delete({ keyId })
+			toast.success("Plugin disconnected")
+			refetchKeys()
+		} catch {
+			toast.error("Failed to disconnect plugin")
 		}
-		if (id === "import") {
-			return tweetCount > 0
-				? { label: `${tweetCount} tweets imported`, variant: "connected" }
-				: undefined
-		}
-		if (id === "plugins") {
-			return connectedPluginCount > 0
-				? { label: `${connectedPluginCount} connected`, variant: "connected" }
-				: undefined
-		}
-		return undefined
 	}
+
+	const handleUpgrade = async () => {
+		try {
+			const result = await autumn.attach({
+				planId: "api_pro",
+				successUrl: `${window.location.origin}/?view=integrations`,
+			})
+			if (result?.paymentUrl) {
+				window.open(result.paymentUrl, "_self")
+				return
+			}
+			autumn.refetch?.()
+		} catch (error) {
+			console.error(error)
+			toast.error("Failed to start checkout. Please try again.")
+		}
+	}
+
+	const availablePluginIds = pluginsData?.plugins ?? Object.keys(PLUGIN_CATALOG)
+	const enabledPluginIds = new Set(
+		availablePluginIds.filter((id) => PLUGIN_CATALOG[id]),
+	)
+
+	const [category, setCategory] = useQueryState("cat", catParam)
+	const [mcpClient, setMcpClient] = useQueryState("mcpClient", parseAsString)
+	const [mcpModalOpen, setMcpModalOpen] = useState(false)
+	const [search, setSearch] = useState("")
+	const [searchExpanded, setSearchExpanded] = useState(false)
+
+	const openMcpClient = (key: MCPClientKey) => {
+		void setMcpClient(key)
+		setMcpModalOpen(true)
+	}
+
+	const closeMcpModal = () => {
+		setMcpModalOpen(false)
+		void setMcpClient(null)
+	}
+
+	const activeMcpClient = mcpClient
+		? MCP_CLIENTS.find((c) => c.key === mcpClient)
+		: undefined
+
+	const allItems = useMemo<Item[]>(
+		() =>
+			SECTIONS.flatMap((s) => s.items(PLUGIN_CATALOG)).filter(
+				(item) => item.kind !== "plugin" || enabledPluginIds.has(item.pluginId),
+			),
+		[enabledPluginIds],
+	)
+
+	const isItemConnected = useCallback(
+		(item: Item): boolean => {
+			if (item.kind === "plugin") {
+				return connectedPlugins.some((k) => k.pluginId === item.pluginId)
+			}
+			if (item.kind === "connector") {
+				return connectionsByProvider[item.provider].length > 0
+			}
+			return false
+		},
+		[connectedPlugins, connectionsByProvider],
+	)
+
+	const counts = useMemo<Record<CategoryFilter, number>>(
+		() => ({
+			all: allItems.length,
+			connected: allItems.filter(isItemConnected).length,
+			plugins: allItems.filter((i) => itemCategory(i) === "plugins").length,
+			"knowledge-bases": allItems.filter(
+				(i) => itemCategory(i) === "knowledge-bases",
+			).length,
+			"apps-extensions": allItems.filter(
+				(i) => itemCategory(i) === "apps-extensions",
+			).length,
+			"ai-clients": allItems.filter((i) => itemCategory(i) === "ai-clients")
+				.length,
+		}),
+		[allItems, isItemConnected],
+	)
+
+	useEffect(() => {
+		if (category !== "all" && counts[category] === 0) {
+			void setCategory("all")
+		}
+	}, [category, counts, setCategory])
+
+	const claudeCodeConnected = connectedPlugins.some(
+		(k) => k.pluginId === "claude_code",
+	)
+	const claudeCodeNeedsPro =
+		!isAutumnLoading && !hasProProduct && !isFreeTierPlugin("claude_code")
+
+	const featuredPicks: FeaturedPick[] = [
+		{
+			id: "feat-mcp",
+			name: "Supermemory MCP",
+			headline: "Your AI tools forget everything between chats.",
+			support: "one setup gives Cursor, Claude & ChatGPT your memory",
+			tagline: "Plug your memory into any MCP client.",
+			icon: <MCPIcon className="size-8" />,
+			backdrop: (
+				<Image
+					src="/onboarding/mcp.png"
+					alt=""
+					width={380}
+					height={380}
+					className="object-contain"
+				/>
+			),
+			docsUrl: "https://docs.supermemory.ai/supermemory-mcp/introduction",
+			ctaLabel: "Connect",
+			onCta: () => {
+				void setMcpClient(null)
+				setViewMode("mcp")
+			},
+		},
+		{
+			id: "feat-claude-code",
+			name: "Claude Code plugin",
+			headline: "Stop re-explaining your codebase every session.",
+			support: "remembers your conventions, decisions & project context",
+			tagline: "Long-term memory for your Claude Code sessions.",
+			icon: (
+				<Image
+					src="/images/plugins/claude-code.svg"
+					alt="Claude Code"
+					width={32}
+					height={32}
+					className="rounded"
+				/>
+			),
+			backdrop: (
+				<Image
+					src="/images/plugins/claude-code.svg"
+					alt=""
+					width={360}
+					height={360}
+					className="object-contain"
+				/>
+			),
+			docsUrl: "https://docs.supermemory.ai/integrations/claude-code",
+			ctaLabel: claudeCodeConnected
+				? "Connected"
+				: claudeCodeNeedsPro
+					? "Upgrade"
+					: "Connect",
+			onCta: () => {
+				if (claudeCodeConnected) return
+				if (claudeCodeNeedsPro) {
+					handleUpgrade()
+					return
+				}
+				createPluginKeyMutation.mutate("claude_code")
+			},
+		},
+		{
+			id: "feat-chrome",
+			name: "Chrome Extension",
+			headline: "That article you'll “read later”? Gone by next week.",
+			support: "save anything on the web in one click",
+			tagline: "Save anything on the web, straight from your browser.",
+			icon: <ChromeIcon className="size-8" />,
+			backdrop: <ChromeIcon className="size-96" />,
+			ctaLabel: "Connect",
+			onCta: () => {
+				window.open(CHROME_EXTENSION_URL, "_blank", "noopener,noreferrer")
+				analytics.onboardingChromeExtensionClicked({ source: "integrations" })
+			},
+		},
+	]
+
+	const q = search.trim().toLowerCase()
+	const visibleItems = allItems.filter((item) => {
+		if (category === "connected" && !isItemConnected(item)) return false
+		if (
+			category !== "all" &&
+			category !== "connected" &&
+			itemCategory(item) !== category
+		)
+			return false
+		if (q) {
+			const hay = `${item.name} ${item.tagline}`.toLowerCase()
+			if (!hay.includes(q)) return false
+		}
+		return true
+	})
+
+	const renderRight = (item: Item): ReactNode => {
+		switch (item.kind) {
+			case "plugin": {
+				const keys = connectedPlugins.filter(
+					(k) => k.pluginId === item.pluginId,
+				)
+				const needsProUpgrade =
+					!isAutumnLoading && !hasProProduct && !isFreeTierPlugin(item.pluginId)
+				if (keys.length > 0) {
+					return <ConnectedPill keys={keys} onRevoke={handleRevokePluginKey} />
+				}
+				if (needsProUpgrade) {
+					return (
+						<PillButton onClick={handleUpgrade}>
+							<Zap className="size-3.5 text-[#4BA0FA]" /> Upgrade
+						</PillButton>
+					)
+				}
+				const busy = connectingPlugin === item.pluginId
+				return (
+					<PillButton
+						onClick={() => createPluginKeyMutation.mutate(item.pluginId)}
+						disabled={!!connectingPlugin}
+					>
+						{busy ? (
+							<>
+								<Loader className="size-3.5 animate-spin" /> Connecting…
+							</>
+						) : (
+							"Connect"
+						)}
+					</PillButton>
+				)
+			}
+			case "connector": {
+				const count = connectionsByProvider[item.provider].length
+				const needsProUpgrade = !isAutumnLoading && !hasProProduct
+				if (count > 0) return <ConnectionsCountPill count={count} />
+				if (needsProUpgrade) {
+					return (
+						<PillButton onClick={handleUpgrade}>
+							<Zap className="size-3.5 text-[#4BA0FA]" /> Upgrade
+						</PillButton>
+					)
+				}
+				const busy = connectingProvider === item.provider
+				return (
+					<PillButton
+						onClick={() => addConnectionMutation.mutate(item.provider)}
+						disabled={!!connectingProvider}
+					>
+						{busy ? (
+							<>
+								<Loader className="size-3.5 animate-spin" /> Connecting…
+							</>
+						) : (
+							"Connect"
+						)}
+					</PillButton>
+				)
+			}
+			case "client": {
+				if (item.action.type === "external") {
+					return (
+						<PillButton
+							onClick={() => {
+								window.open(
+									(item.action as { type: "external"; href: string }).href,
+									"_blank",
+									"noopener,noreferrer",
+								)
+								analytics.onboardingChromeExtensionClicked({
+									source: "integrations",
+								})
+							}}
+						>
+							Connect
+						</PillButton>
+					)
+				}
+				return (
+					<PillButton
+						onClick={() =>
+							setViewMode(
+								(item.action as { type: "view"; viewMode: ViewParamValue })
+									.viewMode,
+							)
+						}
+					>
+						Connect
+					</PillButton>
+				)
+			}
+			case "mcp-client":
+				return (
+					<PillButton onClick={() => openMcpClient(item.clientKey)}>
+						Connect
+					</PillButton>
+				)
+			case "import":
+				return (
+					<PillButton onClick={() => setViewMode(item.viewMode)}>
+						Connect
+					</PillButton>
+				)
+		}
+	}
+
+	const renderItemCard = (item: Item) => (
+		<ItemCard
+			key={item.id}
+			icon={item.icon}
+			name={item.name}
+			tagline={item.tagline}
+			pro={item.pro}
+			docsUrl={item.docsUrl}
+			leftIndicator={renderLeftIndicator(item)}
+			rightSlot={renderRight(item)}
+		/>
+	)
+
+	const renderLeftIndicator = (item: Item): ReactNode => {
+		if (item.kind === "plugin") {
+			const isConnected = connectedPlugins.some(
+				(k) => k.pluginId === item.pluginId,
+			)
+			return isConnected ? (
+				<span className="size-1.5 shrink-0 rounded-full bg-[#00AC3F]" />
+			) : null
+		}
+		if (item.kind === "connector") {
+			const count = connectionsByProvider[item.provider].length
+			return count > 0 ? (
+				<span className="size-1.5 shrink-0 rounded-full bg-[#00AC3F]" />
+			) : null
+		}
+		return null
+	}
+
+	const dialogPlugin = newKey.pluginId
+		? PLUGIN_CATALOG[newKey.pluginId]
+		: undefined
+	const pluginSteps = dialogPlugin?.installSteps ?? []
+	const stepsEmbedKey = pluginSteps.some((s) => s.code?.includes("sm_..."))
+	const setupSteps: InstallStep[] = stepsEmbedKey
+		? pluginSteps
+		: [
+				{
+					title: "Copy your API key",
+					description:
+						"You won't be able to see it again — store it somewhere safe.",
+					code: newKey.key,
+					copyLabel: "API key",
+					secret: true,
+				},
+				...pluginSteps,
+			]
 
 	return (
 		<div className="flex-1 p-4 md:p-6 pt-2">
-			<div className="max-w-3xl mx-auto">
-				<div className="mb-6 space-y-1">
-					<div className="flex items-center gap-2">
-						<Sun className="size-5 text-white" />
-						<h2 className="text-white text-xl font-medium">Integrations</h2>
-					</div>
-					<p className={cn("text-[#8B8B8B] text-sm", dmSansClassName())}>
-						Connect supermemory to your tools and workflows
-					</p>
-				</div>
+			<div className="mx-auto flex max-w-5xl flex-col gap-5">
+				{!q && category !== "connected" && (
+					<FeaturedHero picks={featuredPicks} />
+				)}
 
-				<div className="space-y-6">
-					{CARD_GROUPS.map((group) => {
-						const groupCards = cards.filter((c) => group.ids.includes(c.id))
-						return (
-							<div key={group.label}>
-								<div className="flex items-center gap-3 mb-3">
-									<span className="text-[10px] font-medium uppercase tracking-[0.12em] text-[#3A4455] shrink-0">
-										{group.label}
-									</span>
-									<div className="flex-1 h-px bg-[#0F1621]" />
-								</div>
-								<div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-									{groupCards.map((card) => {
-										const status = getStatusLabel(card.id)
-										return (
-											<IntegrationGridCard
-												key={card.id}
-												title={card.title}
-												description={card.description}
-												icon={card.icon}
-												pro={card.pro}
-												statusLabel={status?.label}
-												statusVariant={status?.variant}
-												isExternal={!!card.externalHref}
-												onClick={() => {
-													if (card.externalHref) {
-														window.open(
-															card.externalHref,
-															"_blank",
-															"noopener,noreferrer",
-														)
-														analytics.onboardingChromeExtensionClicked({
-															source: "integrations",
-														})
-													} else if (card.id === "connections") {
-														void setAddDoc("connect")
-													} else {
-														void setViewMode(card.id as ViewParamValue)
-													}
-												}}
-											/>
-										)
-									})}
-								</div>
-							</div>
-						)
-					})}
+				<div
+					className={cn(
+						"relative overflow-hidden rounded-[14px] bg-[#191D24] p-4 sm:p-6",
+						"shadow-[inset_2.42px_2.42px_4.263px_rgba(11,15,21,0.7)]",
+					)}
+				>
+					<div className="mb-4 flex items-center justify-between gap-2">
+						<div className="min-w-0 shrink">
+							<CategoryFilterToggle
+								value={category}
+								onChange={(v) => void setCategory(v)}
+								counts={counts}
+								compact={searchExpanded || !!search}
+							/>
+						</div>
+						<SearchToggle
+							value={search}
+							onChange={setSearch}
+							expanded={searchExpanded}
+							setExpanded={setSearchExpanded}
+						/>
+					</div>
+					{visibleItems.length === 0 ? (
+						<p
+							className={cn(
+								dmSans125ClassName(),
+								"py-6 text-center text-[13px] text-[#A1A1AA]",
+							)}
+						>
+							{q
+								? `No integrations match “${search}”.`
+								: "Nothing in this category yet."}
+						</p>
+					) : q ? (
+						<div className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-3">
+							{visibleItems.map((item) => renderItemCard(item))}
+						</div>
+					) : (
+						<div className="flex flex-col gap-6">
+							{SECTION_ORDER.map((cat) => {
+								const items = visibleItems.filter(
+									(i) => itemCategory(i) === cat,
+								)
+								if (items.length === 0) return null
+								return (
+									<SectionRail key={cat} label={CATEGORY_LABEL[cat]}>
+										{items.map((item) => (
+											<div key={item.id} className="w-[280px] shrink-0">
+												{renderItemCard(item)}
+											</div>
+										))}
+									</SectionRail>
+								)
+							})}
+						</div>
+					)}
 				</div>
 			</div>
+
+			<Dialog
+				open={newKey.open}
+				onOpenChange={(open) =>
+					setNewKey((s) => ({
+						open,
+						key: open ? s.key : "",
+						pluginId: open ? s.pluginId : null,
+					}))
+				}
+			>
+				<DialogContent
+					showCloseButton={false}
+					style={{
+						boxShadow:
+							"0 2.842px 14.211px 0 rgba(0,0,0,0.25), 0.711px 0.711px 0.711px 0 rgba(255,255,255,0.10) inset",
+					}}
+					className={cn(
+						dmSans125ClassName(),
+						"flex max-h-[88dvh] flex-col gap-3 overflow-hidden border border-white/[0.12] bg-[#1B1F24] p-0 px-3 pt-3 pb-4 rounded-2xl md:px-4 sm:max-w-[560px] sm:rounded-[22px]",
+					)}
+				>
+					<DialogTitle className="sr-only">
+						Set up {dialogPlugin?.name ?? "your plugin"}
+					</DialogTitle>
+					<div className="flex shrink-0 items-center gap-3">
+						{dialogPlugin && (
+							<IconBox>
+								<Image
+									src={dialogPlugin.icon}
+									alt={dialogPlugin.name}
+									width={24}
+									height={24}
+								/>
+							</IconBox>
+						)}
+						<div className="min-w-0 flex-1">
+							<p className="truncate text-[16px] font-semibold leading-tight text-[#FAFAFA]">
+								Set up {dialogPlugin?.name ?? "your plugin"}
+							</p>
+							<p className="mt-0.5 truncate text-[12px] text-[#A1A1AA]">
+								Copy your key and run these steps to finish.
+							</p>
+						</div>
+						<div className="flex shrink-0 items-center gap-2">
+							{dialogPlugin?.docsUrl && (
+								<a
+									href={dialogPlugin.docsUrl}
+									target="_blank"
+									rel="noopener noreferrer"
+									className={cn(
+										dmSans125ClassName(),
+										"flex h-7 items-center gap-1.5 rounded-full bg-[#0D121A] px-3 text-[12px] text-[#A1A1AA] transition-colors hover:text-white",
+										INSET,
+									)}
+								>
+									<BookOpen className="size-3.5" /> Docs
+								</a>
+							)}
+							<DialogPrimitive.Close
+								type="button"
+								aria-label="Close"
+								className={cn(
+									"flex size-7 items-center justify-center rounded-full bg-[#0D121A] transition-opacity hover:opacity-80 focus:outline-none",
+									INSET,
+								)}
+							>
+								<X className="size-4 text-[#737373]" />
+							</DialogPrimitive.Close>
+						</div>
+					</div>
+					<div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+						<div
+							className={cn(
+								"min-w-0 rounded-[14px] bg-[#14161A] p-4 sm:p-5",
+								INSET,
+							)}
+						>
+							<InstallSteps steps={setupSteps} apiKey={newKey.key} />
+						</div>
+					</div>
+					<div className="flex shrink-0 items-center justify-end">
+						<button
+							type="button"
+							onClick={() =>
+								setNewKey({ open: false, key: "", pluginId: null })
+							}
+							className={cn(
+								dmSans125ClassName(),
+								"flex h-9 items-center gap-1.5 rounded-full bg-[#0D121A] px-5 text-[13px] font-medium text-[#FAFAFA] transition-opacity hover:opacity-80",
+								INSET,
+							)}
+						>
+							<Check className="size-3.5 text-[#4BA0FA]" /> Done
+						</button>
+					</div>
+				</DialogContent>
+			</Dialog>
+
+			<Dialog
+				open={mcpModalOpen}
+				onOpenChange={(open) => {
+					if (!open) closeMcpModal()
+					else setMcpModalOpen(true)
+				}}
+			>
+				<DialogContent
+					showCloseButton={false}
+					style={{
+						boxShadow:
+							"0 2.842px 14.211px 0 rgba(0,0,0,0.25), 0.711px 0.711px 0.711px 0 rgba(255,255,255,0.10) inset",
+					}}
+					className={cn(
+						dmSans125ClassName(),
+						"flex max-h-[88dvh] flex-col gap-3 overflow-hidden border border-white/[0.12] bg-[#1B1F24] p-0 px-3 pt-3 pb-4 rounded-2xl md:px-4 sm:max-w-[640px] sm:rounded-[22px]",
+					)}
+				>
+					<DialogTitle className="sr-only">
+						Set up {activeMcpClient?.name ?? "MCP client"}
+					</DialogTitle>
+					<div className="flex shrink-0 items-center gap-3">
+						<IconBox>
+							{activeMcpClient && activeMcpClient.key !== "mcp-url" ? (
+								<Image
+									src={mcpClientIconSrc(activeMcpClient.key)}
+									alt={activeMcpClient.name}
+									width={24}
+									height={24}
+									unoptimized
+									className="size-6 rounded object-contain"
+								/>
+							) : (
+								<MCPIcon className="size-6" />
+							)}
+						</IconBox>
+						<div className="min-w-0 flex-1">
+							<p className="truncate text-[16px] font-semibold leading-tight text-[#FAFAFA]">
+								Set up {activeMcpClient?.name ?? "MCP client"}
+							</p>
+							<p className="mt-0.5 truncate text-[12px] text-[#A1A1AA]">
+								Connect supermemory MCP to{" "}
+								{activeMcpClient?.name ?? "your client"}.
+							</p>
+						</div>
+						<div className="flex shrink-0 items-center gap-2">
+							<a
+								href="https://docs.supermemory.ai/supermemory-mcp/introduction"
+								target="_blank"
+								rel="noopener noreferrer"
+								className={cn(
+									dmSans125ClassName(),
+									"flex h-7 items-center gap-1.5 rounded-full bg-[#0D121A] px-3 text-[12px] text-[#A1A1AA] transition-colors hover:text-white",
+									INSET,
+								)}
+							>
+								<BookOpen className="size-3.5" /> Docs
+							</a>
+							<DialogPrimitive.Close
+								type="button"
+								aria-label="Close"
+								className={cn(
+									"flex size-7 items-center justify-center rounded-full bg-[#0D121A] transition-opacity hover:opacity-80 focus:outline-none",
+									INSET,
+								)}
+							>
+								<X className="size-4 text-[#737373]" />
+							</DialogPrimitive.Close>
+						</div>
+					</div>
+					<div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+						<div
+							className={cn(
+								"min-w-0 rounded-[14px] bg-[#14161A] p-4 sm:p-5",
+								INSET,
+							)}
+						>
+							<MCPSteps variant="embedded" />
+						</div>
+					</div>
+					<div className="flex shrink-0 items-center justify-end">
+						<button
+							type="button"
+							onClick={closeMcpModal}
+							className={cn(
+								dmSans125ClassName(),
+								"flex h-9 items-center gap-1.5 rounded-full bg-[#0D121A] px-5 text-[13px] font-medium text-[#FAFAFA] transition-opacity hover:opacity-80",
+								INSET,
+							)}
+						>
+							<Check className="size-3.5 text-[#4BA0FA]" /> Done
+						</button>
+					</div>
+				</DialogContent>
+			</Dialog>
 		</div>
 	)
 }

--- a/apps/web/components/mcp-modal/claude-desktop-manual-timeline.tsx
+++ b/apps/web/components/mcp-modal/claude-desktop-manual-timeline.tsx
@@ -69,52 +69,76 @@ export function ClaudeDesktopManualTimeline({
 }: ClaudeDesktopManualTimelineProps) {
 	const isDetail = variant === "detail"
 
-	const textMuted = isDetail ? "text-[#B0B0B0]" : "text-muted-foreground"
-	const border = isDetail ? "border-[#3D434D]" : "border-border"
-	const spine = isDetail ? "bg-[#7C8C9E]" : "bg-muted-foreground/40"
+	const textMuted = isDetail ? "text-[#A1A1AA]" : "text-muted-foreground"
+	const border = isDetail ? "border-white/[0.07]" : "border-border"
+	const spine = isDetail ? "bg-white/[0.14]" : "bg-muted-foreground/40"
 	const circleBorder = isDetail
-		? "border-[#9CA8B8]"
+		? "border-white/[0.12]"
 		: "border-muted-foreground/50"
-	const circleBg = isDetail ? "bg-[#080B0F]" : "bg-background"
-	const codeBg = isDetail ? "bg-[#050608]" : "bg-muted"
-	const imgBorder = isDetail ? "border-[#3D434D]" : "border-border"
-	const screenshotBed = isDetail ? "bg-[#2A2D35]" : "bg-muted"
+	const circleBg = isDetail ? "bg-[#0D121A]" : "bg-background"
+	const codeBg = isDetail ? "bg-[#0B0E13]" : "bg-muted"
+	const imgBorder = isDetail ? "border-white/[0.07]" : "border-border"
+	const screenshotBed = isDetail ? "bg-[#0B0E13]" : "bg-muted"
 
 	return (
 		<div
 			className={cn(
 				"space-y-0",
 				isDetail
-					? "rounded-2xl border border-[#3D434D] bg-[#080B0F] p-5 sm:p-6"
+					? ""
 					: "rounded-xl border border-border bg-muted/50 p-4 sm:p-5",
 			)}
 		>
 			<div className="relative">
 				<div
 					className={cn(
-						"absolute top-4.5 bottom-4.5 left-4.5 w-0.5 rounded-full",
+						isDetail
+							? "absolute top-3 bottom-3 left-[10.5px] w-px"
+							: "absolute top-4.5 bottom-4.5 left-4.5 w-0.5 rounded-full",
 						spine,
 					)}
 					aria-hidden
 				/>
 
-				<ol className="relative m-0 list-none space-y-10">
+				<ol className="relative m-0 list-none space-y-7">
 					{STEPS.map((item) => (
 						<li className="relative flex gap-4 sm:gap-5" key={item.step}>
-							<div className="relative z-1 flex w-9 shrink-0 justify-center pt-0.5">
-								<div
-									className={cn(
-										"flex size-9 items-center justify-center rounded-full border-2 text-sm font-semibold tabular-nums shadow-sm",
-										circleBorder,
-										circleBg,
-										isDetail ? "text-[#FAFAFA]" : "text-foreground",
-									)}
-								>
-									{item.step}
-								</div>
+							<div
+								className={cn(
+									"relative z-1 flex shrink-0 justify-center pt-0.5",
+									isDetail ? "w-[22px]" : "w-9",
+								)}
+							>
+								{isDetail ? (
+									<div
+										className={cn(
+											"flex size-[22px] items-center justify-center rounded-full bg-[#0D121A] text-[11px] font-semibold tabular-nums text-[#4BA0FA]",
+											"shadow-[inset_0_2px_4px_rgba(0,0,0,0.3),inset_0_1px_2px_rgba(0,0,0,0.1)]",
+										)}
+									>
+										{item.step}
+									</div>
+								) : (
+									<div
+										className={cn(
+											"flex size-9 items-center justify-center rounded-full border-2 text-sm font-semibold tabular-nums shadow-sm",
+											circleBorder,
+											circleBg,
+											"text-foreground",
+										)}
+									>
+										{item.step}
+									</div>
+								)}
 							</div>
 							<div className="min-w-0 flex-1 space-y-3">
-								<p className={cn("text-sm leading-relaxed", textMuted)}>
+								<p
+									className={cn(
+										isDetail
+											? "text-[13px] leading-relaxed text-[#A1A1AA]"
+											: cn("text-sm leading-relaxed", textMuted),
+									)}
+								>
 									{item.body}
 								</p>
 
@@ -123,14 +147,14 @@ export function ClaudeDesktopManualTimeline({
 										<div className="relative">
 											<pre
 												className={cn(
-													"max-w-full overflow-x-auto rounded-lg border p-4 pr-12 text-xs",
+													"max-w-full overflow-x-auto rounded-[10px] border p-4 pr-12 text-xs",
 													border,
 													codeBg,
 												)}
 											>
 												<code
 													className={cn(
-														"block font-mono whitespace-pre-wrap break-all text-emerald-400",
+														"block font-mono whitespace-pre-wrap break-all text-[#E4E4E7]",
 														dmMonoClassName(),
 													)}
 												>
@@ -139,13 +163,13 @@ export function ClaudeDesktopManualTimeline({
 											</pre>
 											<button
 												type="button"
-												className="absolute top-2 right-2 flex size-8 cursor-pointer items-center justify-center rounded-md border border-[#3D434D] bg-[#121820] hover:bg-[#1a2230]"
+												className="absolute top-2 right-2 flex size-7 cursor-pointer items-center justify-center rounded-full bg-[#0D121A] shadow-[inset_1.5px_1.5px_4.5px_rgba(0,0,0,0.6)] transition-opacity hover:opacity-80"
 												onClick={onCopySnippet}
 											>
 												{snippetCopied ? (
-													<span className="text-xs text-emerald-500">✓</span>
+													<CheckIcon className="size-3.5 text-[#4BA0FA]" />
 												) : (
-													<CopyIcon className="size-3.5 text-[#8B8B8B] hover:text-white" />
+													<CopyIcon className="size-3.5 text-[#737373]" />
 												)}
 											</button>
 										</div>

--- a/apps/web/components/mcp-modal/mcp-detail-view.tsx
+++ b/apps/web/components/mcp-modal/mcp-detail-view.tsx
@@ -30,6 +30,67 @@ import {
 	getManualInstallEntry,
 } from "@/lib/mcp-manual-instructions"
 import { ClaudeDesktopManualTimeline } from "@/components/mcp-modal/claude-desktop-manual-timeline"
+import { INSET } from "@/components/integrations/install-steps"
+
+function McpCodeBlock({
+	code,
+	multiline,
+	onCopy,
+}: {
+	code: string
+	multiline?: boolean
+	onCopy?: () => void
+}) {
+	const [copied, setCopied] = useState(false)
+	const copy = () => {
+		navigator.clipboard.writeText(code)
+		setCopied(true)
+		toast.success("Copied to clipboard!")
+		setTimeout(() => setCopied(false), 2000)
+		onCopy?.()
+	}
+	return (
+		<div
+			className={cn(
+				"group flex min-w-0 gap-2 rounded-[10px] border border-white/[0.07] bg-[#0B0E13] px-3 py-2.5",
+				multiline ? "items-start" : "items-center",
+			)}
+		>
+			<div className="relative min-w-0 flex-1">
+				<pre
+					className={cn(
+						"scrollbar-none min-w-0 overflow-x-auto font-mono text-[12px] leading-[1.6] text-[#E4E4E7]",
+						multiline ? "whitespace-pre-wrap break-all" : "whitespace-pre pr-4",
+						dmMonoClassName(),
+					)}
+				>
+					{code}
+				</pre>
+				{!multiline && (
+					<div
+						aria-hidden
+						className="pointer-events-none absolute inset-y-0 right-0 w-8 bg-gradient-to-l from-[#0B0E13] to-transparent"
+					/>
+				)}
+			</div>
+			<button
+				type="button"
+				aria-label="Copy"
+				onClick={copy}
+				className={cn(
+					"flex size-7 shrink-0 items-center justify-center rounded-full bg-[#0D121A] transition-opacity hover:opacity-80",
+					INSET,
+				)}
+			>
+				{copied ? (
+					<Check className="size-3.5 text-[#4BA0FA]" />
+				) : (
+					<CopyIcon className="size-3.5 text-[#737373]" />
+				)}
+			</button>
+		</div>
+	)
+}
 
 const clients = {
 	chatgpt: "ChatGPT",
@@ -101,7 +162,8 @@ function ClientToolIcon({
 	return (
 		<div
 			className={cn(
-				"size-10 shrink-0 rounded-[10px] bg-[#0D121A] border border-[#242A33] flex items-center justify-center overflow-hidden",
+				"size-10 shrink-0 rounded-[10px] bg-[#080B0F] flex items-center justify-center overflow-hidden",
+				"shadow-[inset_1.5px_1.5px_4.5px_rgba(0,0,0,0.6)]",
 			)}
 		>
 			{failed ? (
@@ -137,7 +199,6 @@ export function MCPSteps({ variant = "full" }: MCPStepsProps) {
 		"mcpTab",
 		parseAsStringLiteral(["oneClick", "manual"] as const).withDefault("manual"),
 	)
-	const [isCommandCopied, setIsCommandCopied] = useState(false)
 	const [isManualCopied, setIsManualCopied] = useState(false)
 	const [activeStep, setActiveStep] = useQueryState(
 		"mcpStep",
@@ -170,15 +231,6 @@ export function MCPSteps({ variant = "full" }: MCPStepsProps) {
 		return command
 	}
 
-	const copyToClipboard = () => {
-		const command = generateInstallCommand()
-		navigator.clipboard.writeText(command)
-		analytics.mcpInstallCmdCopied()
-		setIsCommandCopied(true)
-		setActiveStep(3)
-		setTimeout(() => setIsCommandCopied(false), 2000)
-	}
-
 	const copyManualSnippet = (text: string) => {
 		navigator.clipboard.writeText(text)
 		analytics.mcpInstallCmdCopied()
@@ -203,17 +255,6 @@ export function MCPSteps({ variant = "full" }: MCPStepsProps) {
 					? "manual"
 					: setupTab
 
-	const gradientStep3 =
-		activeStep === 3
-			? {
-					background:
-						"linear-gradient(94deg, #369BFD 4.8%, #36FDFD 77.04%, #36FDB5 143.99%)",
-					backgroundClip: "text",
-					WebkitBackgroundClip: "text",
-					WebkitTextFillColor: "transparent",
-				}
-			: undefined
-
 	return (
 		<div
 			className={cn(
@@ -228,11 +269,11 @@ export function MCPSteps({ variant = "full" }: MCPStepsProps) {
 							key={category.label}
 							className={cn(
 								"flex flex-col gap-4 py-5 sm:flex-row sm:items-start sm:gap-8",
-								rowIndex > 0 && "border-t border-[#242A33]",
+								rowIndex > 0 && "border-t border-white/[0.06]",
 							)}
 						>
 							<div className="w-full shrink-0 sm:w-30">
-								<p className="text-[13px] font-semibold tracking-[-0.01em] text-[#8B8B8B]">
+								<p className="text-[13px] font-semibold tracking-[-0.01em] text-[#A1A1AA]">
 									{category.label}
 								</p>
 							</div>
@@ -249,9 +290,9 @@ export function MCPSteps({ variant = "full" }: MCPStepsProps) {
 											setActiveStep(2)
 										}}
 										className={cn(
-											"group flex w-full min-w-0 items-center gap-3 rounded-xl border border-[#242A33] bg-[#080B0F] p-3.5 text-left transition-colors",
-											"hover:border-[#3273FC4D] hover:bg-[#08142D]",
-											"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#3273FC]/40",
+											"group flex w-full min-w-0 items-center gap-3 rounded-[12px] bg-[#0D121A] p-3.5 text-left transition-colors",
+											"shadow-[inset_1.5px_1.5px_4.5px_rgba(0,0,0,0.5)] hover:bg-[#10151D]",
+											"focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#4BA0FA]/40",
 										)}
 									>
 										<ClientToolIcon clientKey={item.key} title={item.title} />
@@ -259,10 +300,12 @@ export function MCPSteps({ variant = "full" }: MCPStepsProps) {
 											<p className="text-sm font-medium text-[#FAFAFA]">
 												{item.title}
 											</p>
-											<p className="text-xs text-[#737373]">{item.subtitle}</p>
+											<p className="text-[12px] text-[#737373]">
+												{item.subtitle}
+											</p>
 										</div>
 										<ChevronRight
-											className="size-4 shrink-0 text-[#525866] transition-transform group-hover:translate-x-0.5"
+											className="size-4 shrink-0 text-[#525D6E] transition-transform group-hover:translate-x-0.5"
 											aria-hidden
 										/>
 									</button>
@@ -270,51 +313,63 @@ export function MCPSteps({ variant = "full" }: MCPStepsProps) {
 							</div>
 						</div>
 					))}
-					<p className="pt-1 text-sm text-[#8B8B8B]">
+					<p className="pt-1 text-[13px] text-[#A1A1AA]">
 						You can connect several clients; setup is different for each one.
 					</p>
 				</div>
 			) : (
 				<div className={cn("space-y-4", dmSansClassName())}>
-					<button
-						type="button"
-						onClick={() => {
-							setSelectedClient(null)
-							setActiveStep(1)
-						}}
-						className="text-sm font-medium text-[#8B8B8B] transition-colors hover:text-[#FAFAFA]"
+					{!isEmbedded && (
+						<>
+							<button
+								type="button"
+								onClick={() => {
+									setSelectedClient(null)
+									setActiveStep(1)
+								}}
+								className="text-sm font-medium text-[#A1A1AA] transition-colors hover:text-[#FAFAFA]"
+							>
+								← All clients
+							</button>
+
+							<div className="flex flex-wrap items-center gap-3">
+								<ClientToolIcon
+									clientKey={selectedKey}
+									title={clients[selectedKey]}
+								/>
+								<div>
+									<p className="text-lg font-medium text-[#FAFAFA]">
+										{clients[selectedKey]}
+									</p>
+									<p className="text-sm text-[#737373]">
+										{detailSetup ? setupInstructionsSubtitle(detailSetup) : ""}
+									</p>
+								</div>
+							</div>
+						</>
+					)}
+
+					<div
+						className={cn(
+							"space-y-4",
+							!isEmbedded && "border-t border-white/[0.06] pt-8",
+						)}
 					>
-						← All clients
-					</button>
-
-					<div className="flex flex-wrap items-center gap-3">
-						<ClientToolIcon
-							clientKey={selectedKey}
-							title={clients[selectedKey]}
-						/>
-						<div>
-							<p className="text-lg font-medium text-[#FAFAFA]">
-								{clients[selectedKey]}
-							</p>
-							<p className="text-sm text-[#737373]">
-								{detailSetup ? setupInstructionsSubtitle(detailSetup) : ""}
-							</p>
-						</div>
-					</div>
-
-					<div className="space-y-4 border-t border-[#242A33] pt-8">
 						{detailSetup && mcpClientSetupShowsTabs(detailSetup) ? (
 							<div
-								className="flex w-full max-w-md flex-row gap-1 rounded-full border border-[#3D434D] bg-[#0D121A] p-1"
+								className={cn(
+									"flex w-full flex-row gap-0.5 rounded-full bg-[#0D121A] p-0.5",
+									"shadow-[inset_1.5px_1.5px_4.5px_rgba(0,0,0,0.5)]",
+								)}
 								role="tablist"
 								aria-label="Setup method"
 							>
 								<button
 									className={cn(
-										"min-h-9 flex-1 rounded-full px-3 py-2 text-center text-xs font-medium transition-all",
+										"min-h-8 flex-1 rounded-full px-3 text-center text-[12px] font-medium transition-colors",
 										effectiveSetupTab === "manual"
-											? "border border-[#3D434D] bg-[#080B0F] text-white"
-											: "text-[#8B8B8B] hover:text-white",
+											? "bg-white/[0.10] text-[#FAFAFA]"
+											: "text-[#A1A1AA] hover:text-[#FAFAFA]",
 									)}
 									onClick={() => setSetupTab("manual")}
 									role="tab"
@@ -325,10 +380,10 @@ export function MCPSteps({ variant = "full" }: MCPStepsProps) {
 								</button>
 								<button
 									className={cn(
-										"min-h-9 flex-1 rounded-full px-3 py-2 text-center text-xs font-medium transition-all",
+										"min-h-8 flex-1 rounded-full px-3 text-center text-[12px] font-medium transition-colors",
 										effectiveSetupTab === "oneClick"
-											? "border border-[#3D434D] bg-[#080B0F] text-white"
-											: "text-[#8B8B8B] hover:text-white",
+											? "bg-white/[0.10] text-[#FAFAFA]"
+											: "text-[#A1A1AA] hover:text-[#FAFAFA]",
 									)}
 									onClick={() => setSetupTab("oneClick")}
 									role="tab"
@@ -345,47 +400,31 @@ export function MCPSteps({ variant = "full" }: MCPStepsProps) {
 								<>
 									{selectedClient === "mcp-url" && (
 										<div className="space-y-2">
-											<p className="text-sm text-[#8B8B8B]">
+											<p className="text-[13px] leading-relaxed text-[#A1A1AA]">
 												Paste this URL into any MCP client that supports remote
 												servers over HTTPS.
 											</p>
-											<div className="relative">
-												<input
-													className={cn(
-														"w-full rounded-lg border border-[#3D434D] bg-black p-2 pr-10 font-mono text-xs text-emerald-400",
-														dmMonoClassName(),
-													)}
-													readOnly
-													value="https://mcp.supermemory.ai/mcp"
-												/>
-												<button
-													type="button"
-													className="absolute top-1 right-1 cursor-pointer p-1"
-													onClick={() => {
-														navigator.clipboard.writeText(
-															"https://mcp.supermemory.ai/mcp",
-														)
-														analytics.mcpInstallCmdCopied()
-														toast.success("Copied to clipboard!")
-														setActiveStep(3)
-													}}
-												>
-													<CopyIcon className="size-4 text-[#8B8B8B] hover:text-white" />
-												</button>
-											</div>
+											<McpCodeBlock
+												code="https://mcp.supermemory.ai/mcp"
+												onCopy={() => {
+													analytics.mcpInstallCmdCopied()
+													toast.success("Copied to clipboard!")
+													setActiveStep(3)
+												}}
+											/>
 										</div>
 									)}
 									{selectedClient === "cursor" && (
 										<div className="space-y-4">
-											<p className="text-sm text-[#8B8B8B]">
+											<p className="text-[13px] leading-relaxed text-[#A1A1AA]">
 												Open the link below to add supermemory in Cursor, or use
 												Manual instructions to edit{" "}
-												<code className="text-xs text-emerald-400/90">
+												<code className="font-mono text-[12px] text-[#8BC6FF]">
 													~/.cursor/mcp.json
 												</code>
 												.
 											</p>
-											<div className="flex flex-col items-center gap-4 rounded-xl border border-[#1e3a2f] bg-[#0a1510] p-6">
+											<div className="flex flex-col items-center gap-4 rounded-[10px] border border-white/[0.07] bg-[#0B0E13] p-6">
 												<a
 													href={getCursorDeeplink()}
 													onClick={() => {
@@ -411,50 +450,18 @@ export function MCPSteps({ variant = "full" }: MCPStepsProps) {
 									{selectedClient !== "mcp-url" &&
 										selectedClient !== "cursor" && (
 											<div className="space-y-2">
-												<p className="text-sm text-[#8B8B8B]">
+												<p className="text-[13px] leading-relaxed text-[#A1A1AA]">
 													Run this command in your terminal. It installs the MCP
 													for {clients[selectedKey]} and starts OAuth when
 													needed.
 												</p>
-												<div className="relative">
-													<input
-														className={cn(
-															"w-full overflow-hidden text-ellipsis whitespace-nowrap rounded-xl py-4 pr-28 pl-3 text-xs text-white",
-															dmMonoClassName(),
-														)}
-														style={{
-															border: "1px solid rgba(61, 67, 77, 0.10)",
-															background: "#0D121A",
-														}}
-														readOnly
-														value={generateInstallCommand()}
-													/>
-													<button
-														type="button"
-														className={cn(
-															"absolute top-[5px] right-1 flex cursor-pointer items-center gap-2 rounded-[10px] px-3 py-2",
-															dmSansClassName(),
-														)}
-														style={{
-															background:
-																"linear-gradient(180deg, #267BF1 40.23%, #15468B 100%), linear-gradient(180deg, #0D121A -26.14%, #000 100%)",
-															border: "1px solid #000",
-														}}
-														onClick={copyToClipboard}
-													>
-														{isCommandCopied ? (
-															<>
-																<Check className="size-4 text-white" />
-																<span className="text-white">Copied</span>
-															</>
-														) : (
-															<>
-																<CopyIcon className="size-5 text-white stroke-[2px]" />
-																<span className="text-white">Copy</span>
-															</>
-														)}
-													</button>
-												</div>
+												<McpCodeBlock
+													code={generateInstallCommand()}
+													onCopy={() => {
+														analytics.mcpInstallCmdCopied()
+														setActiveStep(3)
+													}}
+												/>
 											</div>
 										)}
 								</>
@@ -464,7 +471,7 @@ export function MCPSteps({ variant = "full" }: MCPStepsProps) {
 									if (manual.kind === "chatgpt") {
 										return (
 											<div className="space-y-3">
-												<ol className="list-decimal space-y-2 pl-5 text-sm text-[#8B8B8B]">
+												<ol className="list-decimal space-y-2 pl-5 text-[13px] leading-relaxed text-[#A1A1AA]">
 													<li>Open ChatGPT in your browser.</li>
 													<li>
 														Go to Settings → Apps → Advanced settings → enable
@@ -478,27 +485,15 @@ export function MCPSteps({ variant = "full" }: MCPStepsProps) {
 														Paste the URL below and complete OAuth in ChatGPT.
 													</li>
 												</ol>
-												<div className="relative">
-													<input
-														className={cn(
-															"w-full rounded-lg border border-[#3D434D] bg-black p-2 pr-10 font-mono text-xs text-emerald-400",
-															dmMonoClassName(),
-														)}
-														readOnly
-														value={CHATGPT_REMOTE_MCP_URL}
-													/>
-													<button
-														type="button"
-														className="absolute top-1 right-1 cursor-pointer p-1"
-														onClick={() =>
-															copyManualSnippet(CHATGPT_REMOTE_MCP_URL)
-														}
-													>
-														<CopyIcon className="size-4 text-[#8B8B8B] hover:text-white" />
-													</button>
-												</div>
+												<McpCodeBlock
+													code={CHATGPT_REMOTE_MCP_URL}
+													onCopy={() => {
+														analytics.mcpInstallCmdCopied()
+														setActiveStep(3)
+													}}
+												/>
 												<a
-													className="inline-block text-sm text-[#4BA0FA] underline hover:text-[#6BB8FF]"
+													className="inline-block text-[13px] text-[#4BA0FA] underline hover:text-[#8BC6FF]"
 													href="https://developers.openai.com/api/docs/guides/developer-mode/"
 													rel="noopener noreferrer"
 													target="_blank"
@@ -523,36 +518,21 @@ export function MCPSteps({ variant = "full" }: MCPStepsProps) {
 										const snippet = buildMcpUrlRemoteJson("your-api-key-here")
 										return (
 											<div className="space-y-3">
-												<p className="text-sm text-[#8B8B8B]">
+												<p className="text-[13px] leading-relaxed text-[#A1A1AA]">
 													Add this to your client&apos;s MCP config. Replace the
 													placeholder with an API key from supermemory settings
 													(Integrations).
 												</p>
-												<div className="relative">
-													<pre className="max-w-full overflow-x-auto rounded-lg border border-[#3D434D] bg-black p-4 pr-12 text-xs">
-														<code
-															className={cn(
-																"block font-mono whitespace-pre-wrap break-all text-emerald-400",
-																dmMonoClassName(),
-															)}
-														>
-															{snippet}
-														</code>
-													</pre>
-													<button
-														type="button"
-														className="absolute top-2 right-2 flex size-8 cursor-pointer items-center justify-center rounded bg-[#0D121A] hover:bg-[#1a1a1a]"
-														onClick={() => copyManualSnippet(snippet)}
-													>
-														{isManualCopied ? (
-															<span className="text-emerald-500">✓</span>
-														) : (
-															<CopyIcon className="size-3.5" />
-														)}
-													</button>
-												</div>
+												<McpCodeBlock
+													code={snippet}
+													multiline
+													onCopy={() => {
+														analytics.mcpInstallCmdCopied()
+														setActiveStep(3)
+													}}
+												/>
 												{detailSetup?.oneClick ? (
-													<p className="text-xs text-[#737373]">
+													<p className="text-[12px] text-[#737373]">
 														Use Bearer auth in headers, or switch to One click
 														setup and paste the HTTPS URL if your client
 														supports OAuth only.
@@ -563,35 +543,22 @@ export function MCPSteps({ variant = "full" }: MCPStepsProps) {
 									}
 									return (
 										<div className="space-y-3">
-											<p className="text-sm text-[#8B8B8B]">{manual.paths}</p>
-											<p className="text-sm text-[#8B8B8B]">
+											<p className="text-[13px] leading-relaxed text-[#A1A1AA]">
+												{manual.paths}
+											</p>
+											<p className="text-[13px] leading-relaxed text-[#A1A1AA]">
 												Merge the snippet with your existing file (create it if
 												needed). Restart the client and complete OAuth when
 												prompted.
 											</p>
-											<div className="relative">
-												<pre className="max-w-full overflow-x-auto rounded-lg border border-[#3D434D] bg-black p-4 pr-12 text-xs">
-													<code
-														className={cn(
-															"block font-mono whitespace-pre-wrap break-all text-emerald-400",
-															dmMonoClassName(),
-														)}
-													>
-														{manual.snippet}
-													</code>
-												</pre>
-												<button
-													type="button"
-													className="absolute top-2 right-2 flex size-8 cursor-pointer items-center justify-center rounded bg-[#0D121A] hover:bg-[#1a1a1a]"
-													onClick={() => copyManualSnippet(manual.snippet)}
-												>
-													{isManualCopied ? (
-														<span className="text-emerald-500">✓</span>
-													) : (
-														<CopyIcon className="size-3.5" />
-													)}
-												</button>
-											</div>
+											<McpCodeBlock
+												code={manual.snippet}
+												multiline
+												onCopy={() => {
+													analytics.mcpInstallCmdCopied()
+													setActiveStep(3)
+												}}
+											/>
 										</div>
 									)
 								})()
@@ -599,47 +566,47 @@ export function MCPSteps({ variant = "full" }: MCPStepsProps) {
 						</div>
 					</div>
 
-					<div className="border-t border-[#242A33] pt-8">
-						<h3
-							className="mb-4 text-lg font-medium text-white"
-							style={gradientStep3}
-						>
-							{detailSetup != null &&
-							mcpClientShowsManual(detailSetup, effectiveSetupTab)
-								? selectedClient === "chatgpt"
-									? "Finish in ChatGPT"
-									: selectedClient === "claude"
-										? "Finish in Claude Desktop"
-										: "Save and restart"
-								: selectedClient === "cursor"
-									? "Finish in Cursor"
-									: "Run in terminal"}
-						</h3>
-						{activeStep === 3 && (
-							<p
+					{!isEmbedded && (
+						<div className="border-t border-white/[0.06] pt-6">
+							<h3
 								className={cn(
-									"flex items-center gap-2 rounded-xl p-4 pl-3 font-mono text-xs text-white",
-									dmMonoClassName(),
+									dmSansClassName(),
+									"mb-3 text-[15px] font-semibold tracking-[-0.01em] text-[#FAFAFA]",
 								)}
-								style={{
-									border: "1px solid rgba(61, 67, 77, 0.10)",
-									background: "#0D121A",
-								}}
 							>
-								<SyncLogoIcon className="size-4" />
 								{detailSetup != null &&
 								mcpClientShowsManual(detailSetup, effectiveSetupTab)
 									? selectedClient === "chatgpt"
-										? "Complete app setup in ChatGPT, then enable it for your chat."
+										? "Finish in ChatGPT"
 										: selectedClient === "claude"
-											? "After Connectors, complete any prompts so supermemory is enabled for chat."
-											: "Save your config, restart the client, and sign in if prompted."
+											? "Finish in Claude Desktop"
+											: "Save and restart"
 									: selectedClient === "cursor"
-										? "Complete the install in Cursor and sign in with OAuth if asked."
-										: "Waiting for installation"}
-							</p>
-						)}
-					</div>
+										? "Finish in Cursor"
+										: "Run in terminal"}
+							</h3>
+							{activeStep === 3 && (
+								<p
+									className={cn(
+										dmSansClassName(),
+										"flex items-center gap-2 rounded-[10px] border border-white/[0.07] bg-[#0B0E13] p-3 text-[12px] text-[#A1A1AA]",
+									)}
+								>
+									<SyncLogoIcon className="size-4 shrink-0 text-[#4BA0FA]" />
+									{detailSetup != null &&
+									mcpClientShowsManual(detailSetup, effectiveSetupTab)
+										? selectedClient === "chatgpt"
+											? "Complete app setup in ChatGPT, then enable it for your chat."
+											: selectedClient === "claude"
+												? "After Connectors, complete any prompts so supermemory is enabled for chat."
+												: "Save your config, restart the client, and sign in if prompted."
+										: selectedClient === "cursor"
+											? "Complete the install in Cursor and sign in with OAuth if asked."
+											: "Waiting for installation"}
+								</p>
+							)}
+						</div>
+					)}
 				</div>
 			)}
 		</div>


### PR DESCRIPTION
- Rebuild the integrations catalog as horizontally-scrollable category rails
  (MCP, Plugins, Knowledge bases, Apps & extensions) with header chevrons
- Add an auto-rotating Featured hero with problem-led headlines, backdrop
  imagery and a gradient FEATURED badge
- Surface all 9 MCP clients as individual cards that open a setup modal
  styled like the plugin connect flow (reuses MCPSteps embedded variant)
- Align MCP setup steps and the Claude Desktop timeline to the design system
- Merge the Integrations and Connections settings tabs into one entry