### PR TITLE
fix(onboarding): parse X URLs with www. and bare-domain prefixes

### DIFF
--- a/apps/web/app/api/onboarding/research/route.ts
+++ b/apps/web/app/api/onboarding/research/route.ts
@@ -7,16 +7,28 @@ interface ResearchRequest {
 	email?: string
 }
 
-function extractHandle(url: string): string {
-	const cleaned = url
-		.toLowerCase()
-		.replace("https://x.com/", "")
-		.replace("https://twitter.com/", "")
-		.replace("http://x.com/", "")
-		.replace("http://twitter.com/", "")
-		.replace("@", "")
+function extractHandle(input: string): string {
+	const trimmed = input.trim()
+	if (!trimmed) return ""
 
-	return (cleaned.split("/")[0] ?? cleaned).split("?")[0] ?? cleaned
+	let handle = trimmed.replace(/^@+/, "")
+	const lower = handle.toLowerCase()
+
+	if (lower.includes("x.com") || lower.includes("twitter.com")) {
+		try {
+			const parsed = new URL(
+				handle.startsWith("http://") || handle.startsWith("https://")
+					? handle
+					: `https://${handle}`,
+			)
+			handle = parsed.pathname.split("/").filter(Boolean)[0] ?? ""
+		} catch {
+			handle =
+				handle.match(/(?:x\.com|twitter\.com)\/([^/\s?#]+)/i)?.[1] ?? ""
+		}
+	}
+
+	return handle.replace(/^@+/, "").split(/[/?#]/)[0]?.toLowerCase() ?? ""
 }
 
 function finalPrompt(handle: string, userContext: string) {
@@ -46,6 +58,13 @@ export async function POST(req: Request) {
 		}
 
 		const handle = extractHandle(xUrl)
+
+		if (!/^[A-Za-z0-9_]{1,15}$/.test(handle)) {
+			return Response.json(
+				{ error: "Could not parse a valid X/Twitter handle from the input" },
+				{ status: 400 },
+			)
+		}
 
 		const contextParts: string[] = []
 		if (name) contextParts.push(`Name: ${name}`)

--- a/apps/web/app/api/onboarding/research/route.ts
+++ b/apps/web/app/api/onboarding/research/route.ts
@@ -7,14 +7,19 @@ interface ResearchRequest {
 	email?: string
 }
 
+const ALLOWED_X_HOSTS: ReadonlySet<string> = new Set([
+	"x.com",
+	"www.x.com",
+	"twitter.com",
+	"www.twitter.com",
+	"mobile.twitter.com",
+])
+
+const X_URL_FALLBACK_REGEX =
+	/^(?:https?:\/\/)?(?:x\.com|www\.x\.com|twitter\.com|www\.twitter\.com|mobile\.twitter\.com)\/([^/\s?#]+)/i
+
 function isXHost(hostname: string): boolean {
-	const host = hostname.toLowerCase()
-	return (
-		host === "x.com" ||
-		host === "twitter.com" ||
-		host.endsWith(".x.com") ||
-		host.endsWith(".twitter.com")
-	)
+	return ALLOWED_X_HOSTS.has(hostname.toLowerCase())
 }
 
 function extractHandle(input: string): string {
@@ -35,9 +40,7 @@ function extractHandle(input: string): string {
 				? (parsed.pathname.split("/").filter(Boolean)[0] ?? "")
 				: ""
 		} catch {
-			handle =
-				handle.match(/(?:^|[./])(?:x\.com|twitter\.com)\/([^/\s?#]+)/i)?.[1] ??
-				""
+			handle = handle.match(X_URL_FALLBACK_REGEX)?.[1] ?? ""
 		}
 	}
 

--- a/apps/web/app/api/onboarding/research/route.ts
+++ b/apps/web/app/api/onboarding/research/route.ts
@@ -7,6 +7,16 @@ interface ResearchRequest {
 	email?: string
 }
 
+function isXHost(hostname: string): boolean {
+	const host = hostname.toLowerCase()
+	return (
+		host === "x.com" ||
+		host === "twitter.com" ||
+		host.endsWith(".x.com") ||
+		host.endsWith(".twitter.com")
+	)
+}
+
 function extractHandle(input: string): string {
 	const trimmed = input.trim()
 	if (!trimmed) return ""
@@ -21,9 +31,13 @@ function extractHandle(input: string): string {
 					? handle
 					: `https://${handle}`,
 			)
-			handle = parsed.pathname.split("/").filter(Boolean)[0] ?? ""
+			handle = isXHost(parsed.hostname)
+				? (parsed.pathname.split("/").filter(Boolean)[0] ?? "")
+				: ""
 		} catch {
-			handle = handle.match(/(?:x\.com|twitter\.com)\/([^/\s?#]+)/i)?.[1] ?? ""
+			handle =
+				handle.match(/(?:^|[./])(?:x\.com|twitter\.com)\/([^/\s?#]+)/i)?.[1] ??
+				""
 		}
 	}
 

--- a/apps/web/app/api/onboarding/research/route.ts
+++ b/apps/web/app/api/onboarding/research/route.ts
@@ -23,8 +23,7 @@ function extractHandle(input: string): string {
 			)
 			handle = parsed.pathname.split("/").filter(Boolean)[0] ?? ""
 		} catch {
-			handle =
-				handle.match(/(?:x\.com|twitter\.com)\/([^/\s?#]+)/i)?.[1] ?? ""
+			handle = handle.match(/(?:x\.com|twitter\.com)\/([^/\s?#]+)/i)?.[1] ?? ""
 		}
 	}
 


### PR DESCRIPTION
The extractHandle helper in the onboarding research route relies on a few naive .replace() calls to strip protocol+domain prefixes, then splits on `/` and `?`. Anything other than the exact form `https://x.com/handle` or `https://twitter.com/handle` produces garbage. Confirmed locally:

- `https://www.x.com/vansh` returns `"https:"`
- `x.com/vansh` returns `"x.com"`
- `https://mobile.twitter.com/foo` returns `"https:"`

That junk handle then flows into the Grok call, so we burn an LLM request and the user gets back research about the wrong "handle".

This rewrites extractHandle using the URL constructor, mirroring the parseXAccount pattern that already exists in `apps/web/app/api/onboarding/account-status/route.ts`. A regex fallback handles inputs the URL constructor refuses. After extraction the handle is validated against the 1-15 char alphanumeric+underscore X handle rule, so anything still malformed returns a clean 400 instead of a wasted Grok call.

The parsing logic is now duplicated between this route and account-status. A shared helper would be nice but felt out of scope for this one.