### PR TITLE
fix(onboarding): fail fast when EXA_API_KEY is missing

### DIFF
--- a/apps/web/app/api/onboarding/extract-content/route.ts
+++ b/apps/web/app/api/onboarding/extract-content/route.ts
@@ -9,14 +9,19 @@ interface ExaApiResponse {
 	results: ExaContentResult[]
 }
 
+const exaApiKey = process.env.EXA_API_KEY
+if (!exaApiKey) {
+	console.error(
+		"EXA_API_KEY is not configured; /api/onboarding/extract-content will return 503",
+	)
+}
+
 export async function POST(request: Request) {
 	try {
-		const exaApiKey = process.env.EXA_API_KEY
 		if (!exaApiKey) {
-			console.error("EXA_API_KEY is not configured")
 			return Response.json(
-				{ error: "Content extraction service is not configured" },
-				{ status: 500 },
+				{ error: "Content extraction is unavailable" },
+				{ status: 503 },
 			)
 		}
 

--- a/apps/web/app/api/onboarding/extract-content/route.ts
+++ b/apps/web/app/api/onboarding/extract-content/route.ts
@@ -11,6 +11,15 @@ interface ExaApiResponse {
 
 export async function POST(request: Request) {
 	try {
+		const exaApiKey = process.env.EXA_API_KEY
+		if (!exaApiKey) {
+			console.error("EXA_API_KEY is not configured")
+			return Response.json(
+				{ error: "Content extraction service is not configured" },
+				{ status: 500 },
+			)
+		}
+
 		const { urls } = await request.json()
 
 		if (!Array.isArray(urls) || urls.length === 0) {
@@ -30,7 +39,7 @@ export async function POST(request: Request) {
 		const response = await fetch("https://api.exa.ai/contents", {
 			method: "POST",
 			headers: {
-				"x-api-key": process.env.EXA_API_KEY ?? "",
+				"x-api-key": exaApiKey,
 				"Content-Type": "application/json",
 			},
 			body: JSON.stringify({


### PR DESCRIPTION
The extract-content route currently uses `process.env.EXA_API_KEY ?? ""` as the auth header. Deploying without EXA_API_KEY set sends a request to Exa with an empty key, Exa returns an auth failure, and the client gets back a generic 500 "Failed to fetch content from Exa API". From the outside that looks identical to any upstream error, which makes self-hosted setups frustrating to debug.

This reads EXA_API_KEY once at the top of the handler. If it's missing we log a specific message and return a 500 with "Content extraction service is not configured" so the cause is obviously a config issue rather than an upstream hiccup. The downstream fetch then uses the validated key with no fallback.

Kept the status as 500 to stay consistent with the file's existing 500 for upstream errors. 503 could be argued for a misconfig but introducing a new status code felt like scope creep here.