### PR TITLE
fix(tweet-preview): guard JSON.parse to avoid crashing the modal

### DIFF
--- a/apps/web/components/document-cards/tweet-preview.tsx
+++ b/apps/web/components/document-cards/tweet-preview.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { Suspense } from "react"
+import { Suspense, useMemo } from "react"
 import type { Tweet } from "react-tweet/api"
 import { TweetBody, enrichTweet, TweetSkeleton } from "react-tweet"
 import { cn } from "@lib/utils"
@@ -117,17 +117,41 @@ function CustomTweetMedia({
 	)
 }
 
+function isTweetLike(value: unknown): value is Tweet {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		!Array.isArray(value) &&
+		"user" in value
+	)
+}
+
 function parseTweetData(data: Tweet | string): Tweet | null {
 	if (!data) return null
-	if (typeof data !== "string") return data
+	if (typeof data !== "string") return isTweetLike(data) ? data : null
 	try {
-		const parsed = JSON.parse(data)
-		return parsed && typeof parsed === "object" && !Array.isArray(parsed)
-			? (parsed as Tweet)
-			: null
-	} catch {
+		const parsed: unknown = JSON.parse(data)
+		if (isTweetLike(parsed)) return parsed
+		console.warn("TweetPreview: parsed value did not match Tweet shape")
+		return null
+	} catch (error) {
+		console.warn("TweetPreview: failed to parse tweet data", error)
 		return null
 	}
+}
+
+function TweetPreviewFallback({ noBgColor }: { noBgColor?: boolean }) {
+	return (
+		<div
+			className={cn(
+				"w-full min-w-0 text-center text-[13px] text-[#737373]",
+				noBgColor ? "bg-transparent py-4" : "bg-black rounded-[18px] p-4",
+				dmSansClassName(),
+			)}
+		>
+			Tweet preview unavailable
+		</div>
+	)
 }
 
 export function TweetPreview({
@@ -137,8 +161,8 @@ export function TweetPreview({
 	data: Tweet | string
 	noBgColor?: boolean
 }) {
-	const parsedTweet = parseTweetData(data)
-	if (!parsedTweet) return null
+	const parsedTweet = useMemo(() => parseTweetData(data), [data])
+	if (!parsedTweet) return <TweetPreviewFallback noBgColor={noBgColor} />
 	const tweet = enrichTweet(parsedTweet)
 
 	return (

--- a/apps/web/components/document-cards/tweet-preview.tsx
+++ b/apps/web/components/document-cards/tweet-preview.tsx
@@ -122,7 +122,9 @@ function parseTweetData(data: Tweet | string): Tweet | null {
 	if (typeof data !== "string") return data
 	try {
 		const parsed = JSON.parse(data)
-		return parsed && typeof parsed === "object" ? (parsed as Tweet) : null
+		return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+			? (parsed as Tweet)
+			: null
 	} catch {
 		return null
 	}

--- a/apps/web/components/document-cards/tweet-preview.tsx
+++ b/apps/web/components/document-cards/tweet-preview.tsx
@@ -117,14 +117,26 @@ function CustomTweetMedia({
 	)
 }
 
+function parseTweetData(data: Tweet | string): Tweet | null {
+	if (!data) return null
+	if (typeof data !== "string") return data
+	try {
+		const parsed = JSON.parse(data)
+		return parsed && typeof parsed === "object" ? (parsed as Tweet) : null
+	} catch {
+		return null
+	}
+}
+
 export function TweetPreview({
 	data,
 	noBgColor,
 }: {
-	data: Tweet
+	data: Tweet | string
 	noBgColor?: boolean
 }) {
-	const parsedTweet = typeof data === "string" ? JSON.parse(data) : data
+	const parsedTweet = parseTweetData(data)
+	if (!parsedTweet) return null
 	const tweet = enrichTweet(parsedTweet)
 
 	return (

--- a/apps/web/components/document-cards/tweet-preview.tsx
+++ b/apps/web/components/document-cards/tweet-preview.tsx
@@ -144,18 +144,46 @@ function isTweetLike(value: unknown): value is Tweet {
 	return true
 }
 
+function ensureArray<T>(value: unknown): T[] {
+	return Array.isArray(value) ? (value as T[]) : []
+}
+
+// enrichTweet iterates entities.hashtags, .user_mentions, .urls and .symbols
+// with `for...of`, so any of them being absent throws "not iterable". A real
+// syndication payload always carries the four arrays (often empty), so default
+// them before the tweet reaches enrichTweet. `media` is intentionally left
+// untouched: enrichTweet only reads it when truthy and indexes media[0], so an
+// empty array would crash — the enrich-time guard below covers that case.
+function normalizeTweet(tweet: Tweet): Tweet {
+	const entities = tweet.entities as unknown as Record<string, unknown>
+	return {
+		...tweet,
+		entities: {
+			...tweet.entities,
+			hashtags: ensureArray(entities.hashtags),
+			user_mentions: ensureArray(entities.user_mentions),
+			urls: ensureArray(entities.urls),
+			symbols: ensureArray(entities.symbols),
+		},
+	}
+}
+
 function parseTweetData(data: Tweet | string): Tweet | null {
 	if (!data) return null
-	if (typeof data !== "string") return isTweetLike(data) ? data : null
-	try {
-		const parsed: unknown = JSON.parse(data)
-		if (isTweetLike(parsed)) return parsed
+	let value: unknown = data
+	if (typeof data === "string") {
+		try {
+			value = JSON.parse(data)
+		} catch (error) {
+			console.warn("TweetPreview: failed to parse tweet data", error)
+			return null
+		}
+	}
+	if (!isTweetLike(value)) {
 		console.warn("TweetPreview: parsed value did not match Tweet shape")
 		return null
-	} catch (error) {
-		console.warn("TweetPreview: failed to parse tweet data", error)
-		return null
 	}
+	return normalizeTweet(value)
 }
 
 function TweetPreviewFallback({ noBgColor }: { noBgColor?: boolean }) {
@@ -179,9 +207,21 @@ export function TweetPreview({
 	data: Tweet | string
 	noBgColor?: boolean
 }) {
-	const parsedTweet = useMemo(() => parseTweetData(data), [data])
-	if (!parsedTweet) return <TweetPreviewFallback noBgColor={noBgColor} />
-	const tweet = enrichTweet(parsedTweet)
+	const tweet = useMemo(() => {
+		const parsed = parseTweetData(data)
+		if (!parsed) return null
+		try {
+			return enrichTweet(parsed)
+		} catch (error) {
+			// enrichTweet still walks quoted tweets, media entities and per-entity
+			// indices, so a partially-malformed payload can throw here even after
+			// the shape check. Degrade to the fallback instead of crashing render.
+			console.warn("TweetPreview: failed to enrich tweet data", error)
+			return null
+		}
+	}, [data])
+
+	if (!tweet) return <TweetPreviewFallback noBgColor={noBgColor} />
 
 	return (
 		<div

--- a/apps/web/components/document-cards/tweet-preview.tsx
+++ b/apps/web/components/document-cards/tweet-preview.tsx
@@ -118,12 +118,30 @@ function CustomTweetMedia({
 }
 
 function isTweetLike(value: unknown): value is Tweet {
-	return (
-		typeof value === "object" &&
-		value !== null &&
-		!Array.isArray(value) &&
-		"user" in value
-	)
+	if (typeof value !== "object" || value === null || Array.isArray(value)) {
+		return false
+	}
+	const candidate = value as Record<string, unknown>
+	const user = candidate.user
+	if (
+		typeof user !== "object" ||
+		user === null ||
+		Array.isArray(user) ||
+		typeof (user as { screen_name?: unknown }).screen_name !== "string"
+	) {
+		return false
+	}
+	if (typeof candidate.text !== "string") return false
+	if (!Array.isArray(candidate.display_text_range)) return false
+	const entities = candidate.entities
+	if (
+		typeof entities !== "object" ||
+		entities === null ||
+		Array.isArray(entities)
+	) {
+		return false
+	}
+	return true
 }
 
 function parseTweetData(data: Tweet | string): Tweet | null {


### PR DESCRIPTION
TweetPreview runs `JSON.parse(data)` on the data prop with no try/catch. If a document's stored Twitter metadata is ever malformed (truncated JSON, corrupted serialization, exotic stringified values like `"null"` or `"123"`), the parse throws and the React tree rendering the document modal or memory card crashes.

This wraps the parse in a small `parseTweetData` helper that returns null when:

- The input is empty or null
- JSON.parse throws
- The parsed value isn't a plain object (covers arrays, which would otherwise slip past a `typeof === "object"` check and crash deeper in enrichTweet)

When parsing returns null the component renders nothing instead of crashing. Also widened the prop type from `Tweet` to `Tweet | string` to match what both call sites already pass via `as Tweet` / `as unknown as Tweet`.

One thing worth flagging for reviewers: in `apps/web/components/document-modal/content/tweet.tsx` the TweetPreview branch is entered whenever tweetMetadata is truthy, so malformed metadata now renders an empty container rather than the "Tweet preview unavailable" fallback further down that file. That is strictly better than crashing but not the friendliest UX. Happy to move the validation up into TweetContent in a follow-up if you would prefer the explicit fallback.