### PR TITLE
fix(openai-sdk): don't inject empty system prompt when no memories are found

### DIFF
--- a/packages/openai-sdk-python/src/supermemory_openai/middleware.py
+++ b/packages/openai-sdk-python/src/supermemory_openai/middleware.py
@@ -193,6 +193,9 @@ async def add_system_prompt(
             },
         )
 
+    if not memories:
+        return messages
+
     if system_prompt_exists:
         logger.debug("Added memories to existing system prompt")
         return [

--- a/packages/openai-sdk-python/tests/test_middleware.py
+++ b/packages/openai-sdk-python/tests/test_middleware.py
@@ -318,6 +318,65 @@ class TestMemoryInjection:
                 assert "User prefers Python" in system_message["content"]
 
 
+    @pytest.mark.asyncio
+    async def test_empty_memories_do_not_modify_messages(
+        self, mock_async_openai_client, mock_openai_response
+    ):
+        """No system prompt should be injected when the memory lookup returns nothing.
+
+        Previously, ``add_system_prompt`` would still modify messages even when
+        ``memories`` resolved to an empty string: it appended `` \\n `` (whitespace) to
+        any existing system prompt, or prepended a new ``{"role": "system", "content": ""}``
+        message when none existed.  Both outcomes pollute the conversation context with
+        meaningless tokens and can confuse the downstream model.
+        """
+        original_create = AsyncMock(return_value=mock_openai_response)
+        mock_async_openai_client.chat.completions.create = original_create
+
+        empty_response = {
+            "profile": {"static": [], "dynamic": []},
+            "searchResults": {"results": []},
+        }
+
+        with patch.dict(os.environ, {"SUPERMEMORY_API_KEY": "test-key"}):
+            with patch("supermemory_openai.middleware.supermemory_profile_search") as mock_search:
+                mock_search.return_value = Mock()
+                mock_search.return_value.profile = empty_response["profile"]
+                mock_search.return_value.search_results = empty_response["searchResults"]
+
+                wrapped_client = with_supermemory(
+                    mock_async_openai_client,
+                    OpenAIMiddlewareOptions(
+                        container_tag="user-123", custom_id="test-conv", mode="full"
+                    ),
+                )
+
+                # Case 1: no pre-existing system prompt — no system message should be prepended
+                user_only_messages = [{"role": "user", "content": "Hello"}]
+                await wrapped_client.chat.completions.create(
+                    model="gpt-4", messages=user_only_messages
+                )
+                sent_messages = original_create.call_args[1]["messages"]
+                assert sent_messages == user_only_messages, (
+                    "An empty-memory response must not prepend a blank system message"
+                )
+
+                original_create.reset_mock()
+
+                # Case 2: existing system prompt — it must not be modified
+                with_system = [
+                    {"role": "system", "content": "You are helpful."},
+                    {"role": "user", "content": "Hello"},
+                ]
+                await wrapped_client.chat.completions.create(
+                    model="gpt-4", messages=with_system
+                )
+                sent_messages = original_create.call_args[1]["messages"]
+                assert sent_messages[0]["content"] == "You are helpful.", (
+                    "An empty-memory response must not append whitespace to the existing system prompt"
+                )
+
+
 class TestMemoryStorage:
     """Test memory storage functionality."""
 


### PR DESCRIPTION
## Bug

In `packages/openai-sdk-python/src/supermemory_openai/middleware.py`, `add_system_prompt()` builds a `memories` string and then unconditionally modifies the message list — even when `memories` is empty (i.e. the profile and search results both returned nothing).

**What happens today when no memories are found:**

1. **Existing system prompt present** — the content becomes `"You are helpful. \n "` (trailing whitespace appended).
2. **No system prompt present** — a new `{"role": "system", "content": ""}` message is prepended to the list.

Both outcomes corrupt the conversation: the first wastes tokens with whitespace junk; the second injects a blank system turn that some models treat as an explicit instruction.

**Minimal reproduction:**
```python
# memories resolves to "" when profile/search return nothing
messages = [{"role": "user", "content": "Hello"}]
result = await add_system_prompt(messages, ...)
# Before fix: [{"role": "system", "content": ""}, {"role": "user", "content": "Hello"}]
# After fix:  [{"role": "user", "content": "Hello"}]   (unchanged)
```

## Fix

Add an early return before the modification block:

```python
if not memories:
    return messages
```

One line. No behaviour change when memories are present.

## Tests

Added `test_empty_memories_do_not_modify_messages` to `tests/test_middleware.py` covering both cases (messages with and without a pre-existing system prompt).