### PR TITLE
fix(web): prevent multi-file upload queue rows from being clipped

### DIFF
--- a/apps/web/components/add-document/file.tsx
+++ b/apps/web/components/add-document/file.tsx
@@ -242,12 +242,12 @@ export function FileContent({
 			{hasItems ? (
 				<ul
 					id="file-upload-queue"
-					className="flex flex-col gap-2 max-h-[220px] overflow-y-auto scrollbar-thin pr-1"
+					className="flex flex-col gap-2 max-h-[360px] overflow-y-auto scrollbar-thin pr-1"
 				>
 					{data.items.map((item) => (
 						<li
 							key={item.id}
-							className="relative overflow-hidden rounded-[12px] bg-[#14161A] shadow-inside-out text-sm"
+							className="relative shrink-0 overflow-hidden rounded-[12px] bg-[#14161A] shadow-inside-out text-sm"
 						>
 							{item.status === "uploading" ? (
 								<div


### PR DESCRIPTION
Add shrink-0 to file queue rows so flexbox stops squishing them into
the max-height box (which clipped filenames via overflow-hidden), and
raise the list cap to 360px so the queue uses available modal space.