### PR TITLE
feat(web): rework nova onboarding into a 3-step wizard

### DIFF
--- a/apps/web/app/(app)/onboarding/page.tsx
+++ b/apps/web/app/(app)/onboarding/page.tsx
@@ -6,10 +6,8 @@ import {
 	useCallback,
 	useEffect,
 	useMemo,
-	type Dispatch,
 	type RefObject,
 	type ReactNode,
-	type SetStateAction,
 } from "react"
 import { useRouter } from "next/navigation"
 import { useAuth } from "@lib/auth-context"
@@ -20,32 +18,25 @@ import { dmSansClassName } from "@/lib/fonts"
 import { $fetch } from "@lib/api"
 import { authClient } from "@lib/auth"
 import NovaOrb from "@/components/nova/nova-orb"
-import Image from "next/image"
 import { IntegrationGridCard } from "@/components/integrations/integration-grid-card"
-import {
-	CHROME_EXTENSION_URL,
-	RAYCAST_EXTENSION_URL,
-	ADD_MEMORY_SHORTCUT_URL,
-} from "@repo/lib/constants"
-import {
-	ChromeIcon,
-	AppleShortcutsIcon,
-	RaycastIcon,
-} from "@/components/integration-icons"
+import { TeamInviteBeat } from "@/components/onboarding/team-invite-beat"
+import { CHROME_EXTENSION_URL } from "@repo/lib/constants"
+import { ChromeIcon } from "@/components/integration-icons"
 import { GoogleDrive, Notion, OneDrive } from "@ui/assets/icons"
 import {
-	Sparkles,
-	ChevronLeft,
-	ChevronRight,
 	AlertCircle,
 	CheckCircle2,
 	Loader2,
+	Check,
+	ChevronLeft,
 } from "lucide-react"
 import { analytics } from "@/lib/analytics"
 import { consumePendingConnectUrl } from "@/lib/constants"
 
 type DetectedSource = "x" | "linkedin" | "resume" | null
-type Status = "idle" | "processing" | "done" | "error"
+type SubmittedSource = "x" | "linkedin" | "resume"
+type Step = 1 | 2 | 3
+type DocState = "idle" | "processing" | "done" | "failed"
 type AccountLookupStatus = "checking" | "found" | "not_found" | "error"
 type AccountLookup = {
 	source: "x" | "linkedin"
@@ -61,6 +52,8 @@ type DocStatus =
 	| "indexing"
 	| "done"
 	| "failed"
+
+const TOTAL_STEPS = 3
 
 function XIcon({ className }: { className?: string }) {
 	return (
@@ -147,39 +140,15 @@ const SOURCE_NAME: Record<"x" | "linkedin", string> = {
 	linkedin: "LinkedIn",
 }
 
-type SpotlightItem = {
-	id: string
+type SmartStep = {
 	title: string
 	description: string
 	icon: ReactNode
-	pro?: boolean
+	isExternal?: boolean
 	onOpen: () => void
 }
 
-type SpotlightCategoryId = "coding" | "productivity" | "agents"
-
-const SPOTLIGHT_CATEGORY_TABS: { id: SpotlightCategoryId; label: string }[] = [
-	{ id: "coding", label: "Coding" },
-	{ id: "productivity", label: "Productivity" },
-	{ id: "agents", label: "Agents" },
-]
-
-const SPOTLIGHT_CATEGORY_ORDER: SpotlightCategoryId[] =
-	SPOTLIGHT_CATEGORY_TABS.map((t) => t.id)
-
-function spotlightPluginCornerIcon(src: string, alt: string) {
-	return (
-		<Image
-			src={src}
-			alt={alt}
-			width={40}
-			height={40}
-			className="size-10 rounded"
-		/>
-	)
-}
-
-const spotlightConnectionsIcon = (
+const connectionsIcon = (
 	<div className="flex items-center -space-x-1">
 		<GoogleDrive className="size-5" />
 		<Notion className="size-5" />
@@ -187,217 +156,66 @@ const spotlightConnectionsIcon = (
 	</div>
 )
 
-function buildSpotlightCatalog(
+/** Capability cards shown on step 2, led by the highest-leverage one for the source. */
+function buildNextSteps(
+	source: SubmittedSource,
 	router: ReturnType<typeof useRouter>,
-): Record<SpotlightCategoryId, SpotlightItem[]> {
+): SmartStep[] {
 	const track = (integration: string) =>
 		analytics.onboardingIntegrationClicked({ integration })
 
-	const openPluginsPanel = () => {
-		void router.push("/?view=plugins")
+	const importBookmarks: SmartStep = {
+		title: "Import your bookmarks",
+		description: "Bring in your X bookmarks and turn them into memories",
+		icon: <img src="/onboarding/x.png" alt="X" className="size-10" />,
+		onOpen: () => {
+			track("import_x")
+			void router.push("/?view=import")
+		},
+	}
+	const chromeExt: SmartStep = {
+		title: "Chrome extension",
+		description: "Save any webpage and sync ChatGPT memories",
+		icon: <ChromeIcon className="size-14" />,
+		isExternal: true,
+		onOpen: () => {
+			track("chrome")
+			window.open(CHROME_EXTENSION_URL, "_blank", "noopener,noreferrer")
+		},
+	}
+	const connectTools: SmartStep = {
+		title: "Connect your tools",
+		description: "Link Notion, Google Drive, or OneDrive to import docs",
+		icon: connectionsIcon,
+		onOpen: () => {
+			track("connections")
+			void router.push("/?add=connect")
+		},
+	}
+	const connectAI: SmartStep = {
+		title: "Connect to AI",
+		description: "Use your memory in Cursor, Claude, and more via MCP",
+		icon: (
+			<img src="/onboarding/mcp.png" alt="MCP" className="size-14 h-auto" />
+		),
+		onOpen: () => {
+			track("mcp")
+			void router.push("/?view=integrations")
+		},
 	}
 
-	return {
-		coding: [
-			{
-				id: "mcp",
-				title: "Connect to AI",
-				description:
-					"Set up MCP to use your memory in Cursor, Claude, and more",
-				icon: (
-					<img src="/onboarding/mcp.png" alt="MCP" className="size-20 h-auto" />
-				),
-				onOpen: () => {
-					track("mcp")
-					void router.push("/?view=integrations")
-				},
-			},
-			{
-				id: "coding-claude-supermemory",
-				title: "Claude Supermemory",
-				description:
-					"Persistent memory for Claude Code — context and decisions across sessions.",
-				icon: spotlightPluginCornerIcon(
-					"/images/plugins/claude-code.svg",
-					"Claude Supermemory",
-				),
-				pro: true,
-				onOpen: () => {
-					track("plugin_claude_supermemory")
-					openPluginsPanel()
-				},
-			},
-			{
-				id: "coding-opencode",
-				title: "OpenCode",
-				description:
-					"Memory layer for OpenCode — search past sessions and inject context.",
-				icon: spotlightPluginCornerIcon(
-					"/images/plugins/opencode.svg",
-					"OpenCode",
-				),
-				pro: true,
-				onOpen: () => {
-					track("plugin_opencode")
-					openPluginsPanel()
-				},
-			},
-			{
-				id: "connections",
-				title: "Connections",
-				description:
-					"Link Notion, Google Drive, or OneDrive to import your docs",
-				icon: spotlightConnectionsIcon,
-				pro: true,
-				onOpen: () => {
-					track("connections")
-					void router.push("/?add=connect")
-				},
-			},
-		],
-		productivity: [
-			{
-				id: "chrome",
-				title: "Chrome Extension",
-				description:
-					"Save any webpage, import bookmarks, sync ChatGPT memories",
-				icon: <ChromeIcon className="size-14" />,
-				onOpen: () => {
-					window.open(CHROME_EXTENSION_URL, "_blank", "noopener,noreferrer")
-					analytics.onboardingChromeExtensionClicked({ source: "onboarding" })
-				},
-			},
-			{
-				id: "raycast",
-				title: "Raycast",
-				description: "Add and search memories from Raycast on Mac",
-				icon: <RaycastIcon className="size-10" />,
-				onOpen: () => {
-					track("raycast")
-					window.open(RAYCAST_EXTENSION_URL, "_blank", "noopener,noreferrer")
-				},
-			},
-			{
-				id: "shortcuts",
-				title: "Apple Shortcuts",
-				description: "Add memories directly from iPhone, iPad or Mac",
-				icon: <AppleShortcutsIcon />,
-				onOpen: () => {
-					track("shortcuts")
-					window.open(ADD_MEMORY_SHORTCUT_URL, "_blank", "noopener,noreferrer")
-				},
-			},
-			{
-				id: "import",
-				title: "Import Bookmarks",
-				description: "Bring in X/Twitter bookmarks and turn them into memories",
-				icon: <img src="/onboarding/x.png" alt="X" className="size-10" />,
-				onOpen: () => {
-					track("import_x")
-					void router.push("/?view=import")
-				},
-			},
-		],
-		agents: [
-			{
-				id: "agents-openclaw",
-				title: "OpenClaw",
-				description:
-					"Multi-platform memory for OpenClaw — Telegram, WhatsApp, Discord, Slack, and more.",
-				icon: spotlightPluginCornerIcon(
-					"/images/plugins/openclaw.svg",
-					"OpenClaw",
-				),
-				pro: true,
-				onOpen: () => {
-					track("plugin_openclaw")
-					openPluginsPanel()
-				},
-			},
-			{
-				id: "agents-hermes",
-				title: "Hermes",
-				description:
-					"Memory layer for the Hermes agent — recall, capture, and user profile.",
-				icon: spotlightPluginCornerIcon("/images/plugins/hermes.svg", "Hermes"),
-				onOpen: () => {
-					track("plugin_hermes")
-					openPluginsPanel()
-				},
-			},
-			{
-				id: "agents-claude-supermemory",
-				title: "Claude Supermemory",
-				description:
-					"Persistent memory for Claude Code — context and decisions across sessions.",
-				icon: spotlightPluginCornerIcon(
-					"/images/plugins/claude-code.svg",
-					"Claude Supermemory",
-				),
-				pro: true,
-				onOpen: () => {
-					track("plugin_claude_supermemory")
-					openPluginsPanel()
-				},
-			},
-			{
-				id: "agents-opencode",
-				title: "OpenCode",
-				description:
-					"Memory layer for OpenCode — search past sessions and inject context.",
-				icon: spotlightPluginCornerIcon(
-					"/images/plugins/opencode.svg",
-					"OpenCode",
-				),
-				pro: true,
-				onOpen: () => {
-					track("plugin_opencode")
-					openPluginsPanel()
-				},
-			},
-			{
-				id: "console-api",
-				title: "Console & API",
-				description:
-					"API keys, orgs, and the hosted API for production agent workloads",
-				icon: <Sparkles className="size-10" />,
-				onOpen: () => {
-					track("console_api")
-					window.open(
-						"https://console.supermemory.ai",
-						"_blank",
-						"noopener,noreferrer",
-					)
-				},
-			},
-		],
+	switch (source) {
+		case "x":
+			return [importBookmarks, chromeExt, connectAI]
+		case "linkedin":
+			return [chromeExt, connectTools, connectAI]
+		case "resume":
+			return [connectTools, chromeExt, connectAI]
 	}
 }
 
 function isAccountSource(source: DetectedSource): source is "x" | "linkedin" {
 	return source === "x" || source === "linkedin"
-}
-
-function useSpotlightAutoRotation(
-	status: Status,
-	pauseSpotlight: boolean,
-	setSpotlightCategory: Dispatch<SetStateAction<SpotlightCategoryId>>,
-) {
-	useEffect(() => {
-		if (status !== "processing") return
-		if (pauseSpotlight) return
-		const n = SPOTLIGHT_CATEGORY_ORDER.length
-		if (n <= 1) return
-		const t = setInterval(() => {
-			setSpotlightCategory((cur) => {
-				const i = SPOTLIGHT_CATEGORY_ORDER.indexOf(cur)
-				const from = i >= 0 ? i : 0
-				const next = (from + 1) % n
-				return SPOTLIGHT_CATEGORY_ORDER[next] ?? cur
-			})
-		}, 8000)
-		return () => clearInterval(t)
-	}, [status, pauseSpotlight, setSpotlightCategory])
 }
 
 function useInitialInputFocus(inputRef: RefObject<HTMLInputElement | null>) {
@@ -409,17 +227,17 @@ function useInitialInputFocus(inputRef: RefObject<HTMLInputElement | null>) {
 
 function useAccountLookup({
 	detected,
-	status,
+	active,
 	value,
 }: {
 	detected: DetectedSource
-	status: Status
+	active: boolean
 	value: string
 }) {
 	const [accountLookup, setAccountLookup] = useState<AccountLookup | null>(null)
 
 	useEffect(() => {
-		if (status !== "idle") return
+		if (!active) return
 
 		const source = isAccountSource(detected) ? detected : null
 		const trimmedValue = value.trim()
@@ -498,7 +316,7 @@ function useAccountLookup({
 			clearTimeout(timeout)
 			controller.abort()
 		}
-	}, [detected, status, value])
+	}, [detected, active, value])
 
 	return accountLookup
 }
@@ -513,82 +331,104 @@ function usePollingCleanup(
 	}, [pollingRef])
 }
 
-function useDoneAnimation(
-	status: Status,
-	setStampLanded: Dispatch<SetStateAction<boolean>>,
-	setVisibleSnippets: Dispatch<SetStateAction<number>>,
-) {
-	useEffect(() => {
-		if (status !== "done") return
-		setStampLanded(false)
-		setVisibleSnippets(0)
-		const t1 = setTimeout(() => setStampLanded(true), 400)
-		const t2 = setTimeout(() => setVisibleSnippets(1), 900)
-		const t3 = setTimeout(() => setVisibleSnippets(2), 1200)
-		const t4 = setTimeout(() => setVisibleSnippets(3), 1500)
-		return () => {
-			clearTimeout(t1)
-			clearTimeout(t2)
-			clearTimeout(t3)
-			clearTimeout(t4)
-		}
-	}, [status, setStampLanded, setVisibleSnippets])
+/** Animated pill, top-right, once the background save lands. Click to jump to the doc. */
+function SavedToast({
+	docState,
+	memoriesCount,
+	onSeeMemories,
+	onRetry,
+}: {
+	docState: DocState
+	memoriesCount: number
+	onSeeMemories: () => void
+	onRetry: () => void
+}) {
+	return (
+		<AnimatePresence>
+			{docState === "done" && (
+				<motion.button
+					key="saved"
+					type="button"
+					initial={{ opacity: 0, y: -8, scale: 0.96 }}
+					animate={{ opacity: 1, y: 0, scale: 1 }}
+					exit={{ opacity: 0, y: -8 }}
+					transition={{ type: "spring", stiffness: 360, damping: 24 }}
+					onClick={onSeeMemories}
+					className="fixed right-6 top-16 z-50 flex items-center gap-3 rounded-2xl border border-[#2261CA]/40 bg-[#080E18]/95 px-4 py-3 text-left backdrop-blur cursor-pointer hover:border-[#2261CA]/70 transition-colors"
+				>
+					<span className="flex size-7 shrink-0 items-center justify-center rounded-full bg-[#4BA0FA]/15">
+						<Check className="size-4 text-[#4BA0FA]" />
+					</span>
+					<span className="flex flex-col">
+						<span className="text-sm font-medium text-white">
+							Your memory is saved
+						</span>
+						<span className="text-xs text-[#6BB0FF]">
+							{memoriesCount > 0
+								? `${memoriesCount} memories · See it →`
+								: "Click to see it →"}
+						</span>
+					</span>
+				</motion.button>
+			)}
+			{docState === "failed" && (
+				<motion.button
+					key="failed"
+					type="button"
+					initial={{ opacity: 0, y: -8 }}
+					animate={{ opacity: 1, y: 0 }}
+					exit={{ opacity: 0, y: -8 }}
+					onClick={onRetry}
+					className="fixed right-6 top-16 z-50 flex items-center gap-2 rounded-2xl border border-[#FF8A8A]/30 bg-[#080E18]/95 px-4 py-3 text-sm text-[#FF8A8A] backdrop-blur cursor-pointer hover:border-[#FF8A8A]/60 transition-colors"
+				>
+					<AlertCircle className="size-4" />
+					Couldn&apos;t save — tap to retry
+				</motion.button>
+			)}
+		</AnimatePresence>
+	)
 }
 
 export default function OnboardingPage() {
 	const router = useRouter()
 	const { user, organizations, refetchOrganizations, setActiveOrg } = useAuth()
 
+	const [step, setStep] = useState<Step>(1)
 	const [value, setValue] = useState("")
 	const [detected, setDetected] = useState<DetectedSource>(null)
 	const [resumeFile, setResumeFile] = useState<File | null>(null)
 	const [isDragging, setIsDragging] = useState(false)
-	const [status, setStatus] = useState<Status>("idle")
+	const [submittedSource, setSubmittedSource] =
+		useState<SubmittedSource | null>(null)
+	const [docState, setDocState] = useState<DocState>("idle")
 	const [_docStatus, setDocStatus] = useState<DocStatus>("queued")
 	const [memoriesCount, setMemoriesCount] = useState(0)
-	const [memorySnippets, setMemorySnippets] = useState<string[]>([])
-	const [docTitle, setDocTitle] = useState("")
-	const [errorMsg, setErrorMsg] = useState("")
-	const [stampLanded, setStampLanded] = useState(false)
-	const [visibleSnippets, setVisibleSnippets] = useState(0)
 	const inputRef = useRef<HTMLInputElement>(null)
 	const fileRef = useRef<HTMLInputElement>(null)
 	const pollingRef = useRef<ReturnType<typeof setInterval> | null>(null)
 	const skippingRef = useRef(false)
-	const [spotlightCategory, setSpotlightCategory] =
-		useState<SpotlightCategoryId>("productivity")
 
-	/** Navigate home, or back to the plugin connect page if one is pending. */
+	const goToMemories = useCallback(() => {
+		router.push("/?view=list")
+	}, [router])
+
 	const goHomeOrPendingConnect = useCallback(() => {
 		const pendingPath = consumePendingConnectUrl()
 		router.push(pendingPath ?? "/")
 	}, [router])
-	const [pauseSpotlight, setPauseSpotlight] = useState(false)
 
-	const spotlightCatalog = useMemo(
-		() => buildSpotlightCatalog(router),
-		[router],
-	)
-	const categoryCards = spotlightCatalog[spotlightCategory] ?? []
-
-	const bumpSpotlightCategory = useCallback(
-		(delta: number) => {
-			const n = SPOTLIGHT_CATEGORY_ORDER.length
-			if (n === 0) return
-			const i = SPOTLIGHT_CATEGORY_ORDER.indexOf(spotlightCategory)
-			const from = i >= 0 ? i : 0
-			const next = (from + delta + n) % n
-			const id = SPOTLIGHT_CATEGORY_ORDER[next]
-			if (id) setSpotlightCategory(id)
-		},
-		[spotlightCategory],
+	const nextSteps = useMemo(
+		() => (submittedSource ? buildNextSteps(submittedSource, router) : []),
+		[submittedSource, router],
 	)
 
-	useSpotlightAutoRotation(status, pauseSpotlight, setSpotlightCategory)
 	useInitialInputFocus(inputRef)
-	const accountLookup = useAccountLookup({ detected, status, value })
+	const accountLookup = useAccountLookup({
+		detected,
+		active: step === 1,
+		value,
+	})
 	usePollingCleanup(pollingRef)
-	useDoneAnimation(status, setStampLanded, setVisibleSnippets)
 
 	const handleChange = (v: string) => {
 		setValue(v)
@@ -635,8 +475,7 @@ export default function OnboardingPage() {
 			attempt++
 			if (attempt > maxAttempts) {
 				if (pollingRef.current) clearInterval(pollingRef.current)
-				setErrorMsg("Processing is taking too long. Try again later.")
-				setStatus("error")
+				setDocState("failed")
 				return
 			}
 
@@ -656,26 +495,14 @@ export default function OnboardingPage() {
 
 				const s = doc.status ?? "queued"
 				setDocStatus(s)
-
-				if (doc.memories) {
-					setMemoriesCount(doc.memories.length)
-					setMemorySnippets(
-						doc.memories
-							.slice(0, 3)
-							.map((m: { memory: string; title?: string }) => m.memory)
-							.filter(Boolean),
-					)
-				}
-				if (doc.title) setDocTitle(doc.title)
+				if (doc.memories) setMemoriesCount(doc.memories.length)
 
 				if (s === "done") {
 					if (pollingRef.current) clearInterval(pollingRef.current)
-					await new Promise((r) => setTimeout(r, 600))
-					setStatus("done")
+					setDocState("done")
 				} else if (s === "failed") {
 					if (pollingRef.current) clearInterval(pollingRef.current)
-					setErrorMsg("Processing failed. You can skip and try later.")
-					setStatus("error")
+					setDocState("failed")
 				}
 			} catch {
 				// keep polling on transient errors
@@ -683,14 +510,14 @@ export default function OnboardingPage() {
 		}, 1500)
 	}, [])
 
-	const handleSubmit = useCallback(
-		async (source: "x" | "linkedin" | "resume", resumeFileOverride?: File) => {
-			setStatus("processing")
-			setSpotlightCategory("productivity")
-			setPauseSpotlight(false)
+	/** Kick off the save in the background and move the user into the wizard. */
+	const startProcessing = useCallback(
+		async (source: SubmittedSource, resumeFileOverride?: File) => {
+			setSubmittedSource(source)
+			setDocState("processing")
 			setDocStatus("queued")
 			setMemoriesCount(0)
-			setDocTitle("")
+			setStep(2)
 
 			try {
 				await ensureOrg()
@@ -728,17 +555,21 @@ export default function OnboardingPage() {
 				if (docId) {
 					pollDocument(docId)
 				} else {
-					await new Promise((r) => setTimeout(r, 2000))
-					setStatus("done")
+					setDocState("done")
 				}
 			} catch (err) {
 				console.error(err)
-				setErrorMsg("Something went wrong. You can skip and try later.")
-				setStatus("error")
+				setDocState("failed")
 			}
 		},
 		[value, resumeFile, ensureOrg, pollDocument],
 	)
+
+	const retryProcessing = useCallback(() => {
+		if (pollingRef.current) clearInterval(pollingRef.current)
+		setDocState("idle")
+		setStep(1)
+	}, [])
 
 	const handleDrop = (e: React.DragEvent) => {
 		e.preventDefault()
@@ -746,7 +577,7 @@ export default function OnboardingPage() {
 		const f = e.dataTransfer.files[0]
 		if (f?.type === "application/pdf") {
 			setResumeFile(f)
-			handleSubmit("resume", f)
+			startProcessing("resume", f)
 		}
 	}
 
@@ -767,8 +598,7 @@ export default function OnboardingPage() {
 		// biome-ignore lint/a11y/noStaticElementInteractions: full-surface drag-and-drop for resume PDF
 		<div
 			className={cn(
-				"relative min-h-screen bg-black flex flex-col overflow-x-hidden",
-				status === "processing" ? "overflow-y-auto" : "overflow-hidden",
+				"relative min-h-screen bg-black flex flex-col overflow-x-hidden overflow-y-auto",
 				dmSansClassName(),
 			)}
 			onDragOver={(e) => {
@@ -793,6 +623,13 @@ export default function OnboardingPage() {
 				)}
 			</AnimatePresence>
 
+			<SavedToast
+				docState={docState}
+				memoriesCount={memoriesCount}
+				onSeeMemories={goToMemories}
+				onRetry={retryProcessing}
+			/>
+
 			<div className="flex items-center justify-between px-6 py-5 shrink-0 z-10">
 				<Logo className="h-7" />
 				<button
@@ -804,19 +641,12 @@ export default function OnboardingPage() {
 				</button>
 			</div>
 
-			<div
-				className={cn(
-					"flex flex-1 flex-col pb-16 min-h-0 w-full",
-					status === "processing"
-						? "items-stretch justify-start pt-2"
-						: "items-center justify-center",
-				)}
-			>
+			<div className="flex flex-1 flex-col items-center justify-center gap-10 pb-16 min-h-0 w-full">
 				<AnimatePresence mode="wait">
-					{/* ── IDLE ── */}
-					{status === "idle" && (
+					{/* ── STEP 1 · INPUT ── */}
+					{step === 1 && (
 						<motion.div
-							key="idle"
+							key="step-1"
 							initial={{ opacity: 0 }}
 							animate={{ opacity: 1 }}
 							exit={{ opacity: 0, transition: { duration: 0.2 } }}
@@ -855,7 +685,7 @@ export default function OnboardingPage() {
 										onChange={(e) => handleChange(e.target.value)}
 										onKeyDown={(e) => {
 											if (e.key === "Enter" && canSubmit)
-												handleSubmit(detected as "x" | "linkedin")
+												startProcessing(detected as "x" | "linkedin")
 										}}
 										placeholder="Paste an X handle, LinkedIn URL, or drop a PDF"
 										className={cn(
@@ -888,7 +718,9 @@ export default function OnboardingPage() {
 											type="button"
 											initial={{ opacity: 0, scale: 0.8 }}
 											animate={{ opacity: 1, scale: 1 }}
-											onClick={() => handleSubmit(detected as "x" | "linkedin")}
+											onClick={() =>
+												startProcessing(detected as "x" | "linkedin")
+											}
 											className="absolute right-1 rounded-xl size-8 flex items-center justify-center border-[0.5px] border-[#161F2C] hover:scale-[0.95] active:scale-[0.95] transition-transform cursor-pointer"
 											style={{
 												background:
@@ -989,343 +821,108 @@ export default function OnboardingPage() {
 									const f = e.target.files?.[0]
 									if (f) {
 										setResumeFile(f)
-										handleSubmit("resume", f)
+										startProcessing("resume", f)
 									}
 								}}
 							/>
 						</motion.div>
 					)}
 
-					{/* ── PROCESSING ── */}
-					{status === "processing" && (
+					{/* ── STEP 2 · CAPABILITIES ── */}
+					{step === 2 && (
 						<motion.div
-							key="processing"
-							initial={{ opacity: 0 }}
-							animate={{ opacity: 1 }}
-							exit={{ opacity: 0 }}
-							transition={{ duration: 0.35 }}
-							className="flex flex-col items-center w-full max-w-xl mx-auto px-6 pb-20 gap-10"
+							key="step-2"
+							initial={{ opacity: 0, y: 8 }}
+							animate={{ opacity: 1, y: 0 }}
+							exit={{ opacity: 0, y: -8, transition: { duration: 0.2 } }}
+							transition={{ duration: 0.4 }}
+							className="flex flex-col items-center gap-8 w-full max-w-2xl px-6"
 						>
-							<NovaOrb size={88} className="blur-[3px]" />
+							<NovaOrb size={96} className="blur-[2px]" />
 
-							<div className="text-center space-y-2 max-w-sm">
+							<div className="text-center space-y-2">
 								<p className="text-white text-2xl font-medium leading-tight tracking-tight">
-									Finishing your first save
+									Here&apos;s what you can do with Nova
 								</p>
 								<p className="text-sm text-[#6b7c91] leading-relaxed">
-									Most finish in under a minute. Below is optional: ways to add
-									more later.
+									We&apos;re saving your first memory in the background. Explore
+									while it finishes.
 								</p>
 							</div>
 
-							<div className="w-full flex flex-col gap-5">
-								{/* biome-ignore lint/a11y/noStaticElementInteractions: pause category rotation on hover/focus within */}
-								<div
-									className="flex flex-col gap-4 outline-none"
-									onMouseEnter={() => setPauseSpotlight(true)}
-									onMouseLeave={() => setPauseSpotlight(false)}
-									onFocus={() => setPauseSpotlight(true)}
-									onBlur={(e) => {
-										if (
-											!e.currentTarget.contains(e.relatedTarget as Node | null)
-										) {
-											setPauseSpotlight(false)
-										}
-									}}
-								>
-									<div className="flex items-center justify-center gap-1 sm:gap-2">
-										<button
-											type="button"
-											id="onboarding-spotlight-category-prev"
-											aria-label="Previous category"
-											onClick={() => bumpSpotlightCategory(-1)}
-											className="rounded-full p-2 text-[#5c6d82] hover:text-white hover:bg-white/5 cursor-pointer transition-colors shrink-0"
-										>
-											<ChevronLeft className="size-5" />
-										</button>
-										<div
-											className="flex flex-wrap justify-center gap-2 flex-1 min-w-0"
-											role="tablist"
-											aria-label="Integration categories"
-										>
-											{SPOTLIGHT_CATEGORY_TABS.map((tab) => (
-												<button
-													key={tab.id}
-													type="button"
-													role="tab"
-													aria-selected={spotlightCategory === tab.id}
-													onClick={() => setSpotlightCategory(tab.id)}
-													className={cn(
-														"rounded-full px-4 py-1.5 text-sm font-medium transition-colors cursor-pointer",
-														spotlightCategory === tab.id
-															? "bg-white/12 text-white"
-															: "text-[#6b7c91] hover:text-[#9aadbf]",
-													)}
-												>
-													{tab.label}
-												</button>
-											))}
-										</div>
-										<button
-											type="button"
-											id="onboarding-spotlight-category-next"
-											aria-label="Next category"
-											onClick={() => bumpSpotlightCategory(1)}
-											className="rounded-full p-2 text-[#5c6d82] hover:text-white hover:bg-white/5 cursor-pointer transition-colors shrink-0"
-										>
-											<ChevronRight className="size-5" />
-										</button>
-									</div>
-
-									<div
-										className="flex justify-center gap-2"
-										id="onboarding-spotlight-category-dots"
-									>
-										{SPOTLIGHT_CATEGORY_TABS.map((tab) => (
-											<button
-												key={tab.id}
-												type="button"
-												aria-label={`Show ${tab.label}`}
-												onClick={() => setSpotlightCategory(tab.id)}
-												className={cn(
-													"h-1.5 rounded-full transition-all duration-300",
-													spotlightCategory === tab.id
-														? "w-6 bg-[#4BA0FA]"
-														: "w-1.5 bg-white/15 hover:bg-white/30",
-												)}
-											/>
-										))}
-									</div>
-
-									<AnimatePresence mode="wait">
-										<motion.div
-											key={spotlightCategory}
-											initial={{ opacity: 0, y: 8 }}
-											animate={{ opacity: 1, y: 0 }}
-											exit={{ opacity: 0, y: -8 }}
-											transition={{ duration: 0.2 }}
-											className="grid gap-3 w-full max-w-3xl mx-auto sm:grid-cols-2"
-										>
-											{categoryCards.map((card) => (
-												<IntegrationGridCard
-													key={card.id}
-													title={card.title}
-													description={card.description}
-													icon={card.icon}
-													pro={card.pro}
-													onClick={card.onOpen}
-												/>
-											))}
-										</motion.div>
-									</AnimatePresence>
-								</div>
-
-								<button
-									type="button"
-									id="onboarding-all-integrations"
-									onClick={() => {
-										analytics.onboardingIntegrationClicked({
-											integration: "all_from_processing",
-										})
-										void router.push("/?view=integrations")
-									}}
-									className="text-center text-xs text-[#4d5d72] hover:text-[#8B9DB5] transition-colors cursor-pointer"
-								>
-									All integrations
-								</button>
-							</div>
-						</motion.div>
-					)}
-
-					{/* ── DONE ── */}
-					{status === "done" && (
-						<motion.div
-							key="done"
-							initial={{ opacity: 0 }}
-							animate={{ opacity: 1 }}
-							transition={{ duration: 0.4 }}
-							className="flex flex-col items-center gap-6 text-center w-full max-w-[440px] px-6"
-						>
-							<div className="space-y-2">
-								<p className="text-white text-2xl font-medium leading-tight">
-									It&apos;s in your memory
-								</p>
-								<p className="text-sm text-[#8B9DB5] leading-relaxed">
-									Your first save is ready. When you want more, use Integrations
-									for browser, phone, editor, and AI tools, all in one place.
-								</p>
-							</div>
-
-							{/* Document card with stamp */}
-							<div className="relative w-full">
-								{/* Clickable document card */}
-								<motion.button
-									type="button"
-									initial={{ opacity: 0, y: 12 }}
-									animate={{ opacity: 1, y: 0 }}
-									transition={{ duration: 0.4 }}
-									onClick={() => router.push("/?view=list")}
-									className="group w-full text-left bg-[#080E18] border border-[rgba(255,255,255,0.07)] rounded-2xl p-4 cursor-pointer hover:border-[rgba(255,255,255,0.14)] transition-colors"
-								>
-									{/* Faux document lines */}
-									<div className="space-y-2.5 mb-4">
-										<div className="h-2 w-3/5 rounded-full bg-[#1A2438]" />
-										<div className="h-1.5 w-full rounded-full bg-[#131B2A]" />
-										<div className="h-1.5 w-[90%] rounded-full bg-[#131B2A]" />
-										<div className="h-1.5 w-4/5 rounded-full bg-[#131B2A]" />
-										<div className="h-1.5 w-[92%] rounded-full bg-[#131B2A]" />
-										<div className="h-1.5 w-3/5 rounded-full bg-[#131B2A]" />
-									</div>
-									<div className="flex items-center justify-between">
-										<p className="text-[11px] text-[#3A4A5E] truncate pr-2">
-											{docTitle || "Your document"}
-										</p>
-										<span className="shrink-0 text-[10px] font-medium text-[#4BA0FA] bg-[#4BA0FA]/10 rounded-full px-2 py-0.5">
-											{memoriesCount} memories
-										</span>
-									</div>
-									<p className="mt-2 text-[11px] text-[#2A3A50] group-hover:text-[#4A6A80] transition-colors">
-										View in memories →
-									</p>
-								</motion.button>
-
-								{/* Stamp */}
-								<motion.div
-									initial={{ y: -60, rotate: -18, scale: 1.1, opacity: 0 }}
-									animate={
-										stampLanded
-											? { y: -28, rotate: -12, scale: 1, opacity: 1 }
-											: { y: -60, rotate: -18, scale: 1.1, opacity: 0 }
-									}
-									transition={{ type: "spring", stiffness: 400, damping: 18 }}
-									className="absolute -top-2 right-4 pointer-events-none"
-								>
-									<div className="relative flex items-center justify-center size-[72px]">
-										{/* Ink ring ripple */}
-										{stampLanded && (
-											<motion.div
-												initial={{ scale: 0.6, opacity: 0.5 }}
-												animate={{ scale: 1.5, opacity: 0 }}
-												transition={{ duration: 0.5, ease: "easeOut" }}
-												className="absolute inset-0 rounded-full border border-[#4BA0FA]/40"
-											/>
-										)}
-										<div
-											className="size-[72px] rounded-full border-[2.5px] border-[#4BA0FA] bg-[#040810] flex flex-col items-center justify-center gap-0.5"
-											style={{
-												boxShadow: stampLanded
-													? "0 0 16px rgba(75,160,250,0.25)"
-													: "none",
-											}}
-										>
-											<Logo className="size-4 text-[#4BA0FA]" />
-											<span className="text-[7px] font-bold tracking-[0.18em] text-[#4BA0FA] uppercase">
-												Memorized
-											</span>
-										</div>
-									</div>
-								</motion.div>
-							</div>
-
-							<button
-								type="button"
-								id="onboarding-done-integrations"
-								onClick={() => {
-									analytics.onboardingIntegrationClicked({
-										integration: "all_from_done",
-									})
-									void router.push("/?view=integrations")
-								}}
-								className="w-full rounded-xl border border-white/[0.1] bg-[#080E18] px-4 py-2.5 text-sm font-medium text-[#8B9DB5] hover:text-white hover:border-[#2261CA]/30 cursor-pointer transition-colors"
-							>
-								Browse Integrations
-							</button>
-
-							{/* Memory snippets */}
-							<div className="w-full space-y-2">
-								<p className="text-[11px] text-[#3A4A5E] uppercase tracking-widest mb-3">
-									Nova learned
-								</p>
-								{memorySnippets.slice(0, 3).map((snippet, i) => (
-									<motion.div
-										key={i}
-										initial={{ opacity: 0, x: -8 }}
-										animate={
-											visibleSnippets > i
-												? { opacity: 1, x: 0 }
-												: { opacity: 0, x: -8 }
-										}
-										transition={{ duration: 0.35, ease: "easeOut" }}
-										className="flex items-start gap-2 text-left"
-									>
-										<span className="mt-0.5 size-1.5 rounded-full bg-[#4BA0FA] shrink-0" />
-										<p className="text-[13px] text-[#8B9DB5] leading-snug line-clamp-2">
-											{snippet}
-										</p>
-									</motion.div>
+							<div className="grid w-full gap-3 sm:grid-cols-3">
+								{nextSteps.map((card) => (
+									<IntegrationGridCard
+										key={card.title}
+										title={card.title}
+										description={card.description}
+										icon={card.icon}
+										isExternal={card.isExternal}
+										onClick={card.onOpen}
+									/>
 								))}
 							</div>
-
-							{/* CTAs */}
-							<div className="flex flex-col items-center gap-3 w-full">
-								<button
-									type="button"
-									onClick={() => router.push("/?view=list")}
-									className="w-full rounded-xl px-5 py-2.5 text-sm font-medium text-white cursor-pointer hover:scale-[0.98] active:scale-[0.96] transition-transform border-[0.5px] border-[#2261CA]/40"
-									style={{
-										background:
-											"linear-gradient(180deg, #0D1E3A -26.14%, #060C18 100%)",
-									}}
-								>
-									See your memories →
-								</button>
-								<button
-									type="button"
-									onClick={goHomeOrPendingConnect}
-									className="text-sm text-[#3A4A5E] hover:text-[#6B7A8D] transition-colors cursor-pointer"
-								>
-									Go to home
-								</button>
-							</div>
 						</motion.div>
 					)}
 
-					{/* ── ERROR ── */}
-					{status === "error" && (
+					{/* ── STEP 3 · TEAM ── */}
+					{step === 3 && (
 						<motion.div
-							key="error"
-							initial={{ opacity: 0 }}
-							animate={{ opacity: 1 }}
-							className="flex flex-col items-center gap-6 text-center max-w-sm px-6"
+							key="step-3"
+							initial={{ opacity: 0, y: 8 }}
+							animate={{ opacity: 1, y: 0 }}
+							exit={{ opacity: 0, y: -8, transition: { duration: 0.2 } }}
+							transition={{ duration: 0.4 }}
+							className="flex flex-col items-center gap-6 w-full max-w-[460px] px-6"
 						>
-							<p className="text-[#8B9DB5] text-sm">{errorMsg}</p>
-							<div className="flex gap-3">
-								<button
-									type="button"
-									onClick={() => {
-										setStatus("idle")
-										setDocStatus("queued")
-										setErrorMsg("")
-									}}
-									className="rounded-xl border border-[#1E2530] px-4 py-2.5 text-sm text-white hover:border-[#4A4A4A] transition-colors cursor-pointer"
-								>
-									Try again
-								</button>
-								<button
-									type="button"
-									onClick={handleSkip}
-									className="rounded-xl px-4 py-2.5 text-sm font-medium text-white cursor-pointer border-[0.5px] border-[#161F2C]"
-									style={{
-										background:
-											"linear-gradient(180deg, #0D121A -26.14%, #000 100%)",
-									}}
-								>
-									Skip for now
-								</button>
-							</div>
+							<TeamInviteBeat />
 						</motion.div>
 					)}
 				</AnimatePresence>
+
+				{/* ── WIZARD NAV (steps 2 & 3) ── */}
+				{step > 1 && (
+					<div className="flex flex-col items-center gap-5 w-full max-w-2xl px-6">
+						<div className="flex items-center gap-2">
+							{Array.from({ length: TOTAL_STEPS }, (_, i) => i + 1).map((d) => (
+								<span
+									key={d}
+									className={cn(
+										"h-1.5 rounded-full transition-all duration-300",
+										d === step ? "w-6 bg-[#4BA0FA]" : "w-1.5 bg-white/15",
+									)}
+								/>
+							))}
+						</div>
+
+						<div className="relative flex items-center justify-center w-full">
+							{step === 3 && (
+								<button
+									type="button"
+									onClick={() => setStep(2)}
+									className="absolute left-0 flex items-center gap-1 text-sm text-[#6b7c91] hover:text-white transition-colors cursor-pointer"
+								>
+									<ChevronLeft className="size-4" />
+									Back
+								</button>
+							)}
+
+							<button
+								type="button"
+								onClick={() =>
+									step === 2 ? setStep(3) : goHomeOrPendingConnect()
+								}
+								className="rounded-xl px-6 py-2.5 text-sm font-medium text-white cursor-pointer hover:scale-[0.98] active:scale-[0.96] transition-transform border-[0.5px] border-[#2261CA]/40"
+								style={{
+									background:
+										"linear-gradient(180deg, #0D1E3A -26.14%, #060C18 100%)",
+								}}
+							>
+								{step === 2 ? "Next →" : "Finish →"}
+							</button>
+						</div>
+					</div>
+				)}
 			</div>
 		</div>
 	)

--- a/apps/web/components/onboarding/team-invite-beat.tsx
+++ b/apps/web/components/onboarding/team-invite-beat.tsx
@@ -1,0 +1,196 @@
+"use client"
+
+import { useState, useCallback } from "react"
+import { motion, AnimatePresence } from "motion/react"
+import NovaOrb from "@/components/nova/nova-orb"
+import { authClient } from "@lib/auth"
+import { useAuth } from "@lib/auth-context"
+import { cn } from "@lib/utils"
+import { dmSansClassName } from "@/lib/fonts"
+import { Plus, Check, Loader2 } from "lucide-react"
+
+const EMAIL_RE = /^[^\s@]+@[^\s@]+\.[^\s@]+$/
+
+const W = 300
+const H = 200
+const CX = W / 2
+const CY = H / 2
+const R = 74
+
+function orbPoint(index: number, total: number) {
+	const angle = (-90 + (360 / Math.max(total, 1)) * index) * (Math.PI / 180)
+	return { x: CX + R * Math.cos(angle), y: CY + R * Math.sin(angle) }
+}
+
+export function TeamInviteBeat() {
+	const { org } = useAuth()
+	const [emails, setEmails] = useState<string[]>([])
+	const [draft, setDraft] = useState("")
+	const [status, setStatus] = useState<"idle" | "sending" | "sent">("idle")
+	const [error, setError] = useState("")
+
+	const addEmail = useCallback(() => {
+		const e = draft.trim().toLowerCase()
+		if (!EMAIL_RE.test(e)) {
+			setError("Enter a valid email")
+			return
+		}
+		if (emails.includes(e)) {
+			setDraft("")
+			return
+		}
+		setEmails((prev) => [...prev, e])
+		setDraft("")
+		setError("")
+	}, [draft, emails])
+
+	const sendInvites = useCallback(async () => {
+		if (emails.length === 0 || !org?.id) return
+		setStatus("sending")
+		setError("")
+		const results = await Promise.allSettled(
+			emails.map((email) =>
+				authClient.organization.inviteMember({
+					email,
+					role: "member",
+					organizationId: org.id,
+					resend: true,
+				}),
+			),
+		)
+		const failed = results.filter((r) => r.status === "rejected").length
+		if (failed === emails.length) {
+			setError("Could not send invites. Try again later.")
+			setStatus("idle")
+			return
+		}
+		setStatus("sent")
+	}, [emails, org?.id])
+
+	return (
+		<div className="w-full rounded-2xl border border-[#0D121A] bg-[#080B0F] p-5">
+			<div className="text-center space-y-1">
+				<p className="text-white text-base font-medium">
+					Make Nova a team brain
+				</p>
+				<p className={cn("text-xs text-[#6b7c91]", dmSansClassName())}>
+					One memory for your whole team. Add a few people to share it.
+				</p>
+			</div>
+
+			<div className="relative mx-auto mt-4" style={{ width: W, height: H }}>
+				<svg
+					className="absolute inset-0"
+					width={W}
+					height={H}
+					viewBox={`0 0 ${W} ${H}`}
+					aria-hidden="true"
+				>
+					<title>Team constellation</title>
+					<AnimatePresence>
+						{emails.map((email, i) => {
+							const p = orbPoint(i, emails.length)
+							return (
+								<motion.line
+									key={email}
+									x1={CX}
+									y1={CY}
+									x2={p.x}
+									y2={p.y}
+									stroke="#2261CA"
+									strokeWidth={1}
+									initial={{ opacity: 0 }}
+									animate={{ opacity: 0.5 }}
+									exit={{ opacity: 0 }}
+									transition={{ duration: 0.3 }}
+								/>
+							)
+						})}
+					</AnimatePresence>
+				</svg>
+
+				<div className="absolute" style={{ left: CX - 44, top: CY - 44 }}>
+					<NovaOrb size={88} />
+				</div>
+
+				<AnimatePresence>
+					{emails.map((email, i) => {
+						const p = orbPoint(i, emails.length)
+						return (
+							<motion.div
+								key={email}
+								layout
+								initial={{ scale: 0, opacity: 0 }}
+								animate={{ scale: 1, opacity: 1 }}
+								exit={{ scale: 0, opacity: 0 }}
+								transition={{ type: "spring", stiffness: 380, damping: 22 }}
+								className="absolute flex items-center justify-center"
+								style={{ left: p.x - 16, top: p.y - 16, width: 32, height: 32 }}
+							>
+								<NovaOrb size={32} />
+								<span className="absolute text-[11px] font-semibold text-white uppercase">
+									{email[0]}
+								</span>
+							</motion.div>
+						)
+					})}
+				</AnimatePresence>
+			</div>
+
+			{status === "sent" ? (
+				<div className="mt-2 flex items-center justify-center gap-2 text-sm text-[#65D08C]">
+					<Check className="size-4" />
+					<span>
+						Invited {emails.length} {emails.length === 1 ? "person" : "people"}
+					</span>
+				</div>
+			) : (
+				<div className="mt-2 space-y-2">
+					<div className="flex items-center gap-2">
+						<input
+							type="email"
+							value={draft}
+							onChange={(e) => setDraft(e.target.value)}
+							onKeyDown={(e) => {
+								if (e.key === "Enter") {
+									e.preventDefault()
+									addEmail()
+								}
+							}}
+							placeholder="teammate@company.com"
+							className="flex-1 rounded-xl border border-[#52596633] bg-[#070E1B] px-3 py-2.5 text-sm text-white placeholder:text-[#525966] focus:border-[#2261CA] focus:outline-none"
+						/>
+						<button
+							type="button"
+							onClick={addEmail}
+							aria-label="Add teammate"
+							className="flex size-10 shrink-0 items-center justify-center rounded-xl border border-[#52596633] text-[#8B9DB5] hover:border-[#2261CA]/50 hover:text-white transition-colors cursor-pointer"
+						>
+							<Plus className="size-4" />
+						</button>
+					</div>
+
+					{error && <p className="text-xs text-[#FF8A8A] pl-1">{error}</p>}
+
+					{emails.length > 0 && (
+						<button
+							type="button"
+							onClick={sendInvites}
+							disabled={status === "sending"}
+							className="flex w-full items-center justify-center gap-2 rounded-xl px-5 py-2.5 text-sm font-medium text-white cursor-pointer hover:scale-[0.98] active:scale-[0.96] transition-transform border-[0.5px] border-[#2261CA]/40 disabled:opacity-60 disabled:hover:scale-100"
+							style={{
+								background:
+									"linear-gradient(180deg, #0D1E3A -26.14%, #060C18 100%)",
+							}}
+						>
+							{status === "sending" && (
+								<Loader2 className="size-4 animate-spin" />
+							)}
+							Send {emails.length} {emails.length === 1 ? "invite" : "invites"}
+						</button>
+					)}
+				</div>
+			)}
+		</div>
+	)
+}


### PR DESCRIPTION
- Step 1 input kicks off the first save in the background instead of a
  blocking processing screen, then advances through the wizard.
- Step 2 shows source-aware capability cards (reusing IntegrationGridCard).
- Step 3 promotes the team brain via a new TeamInviteBeat (orb constellation
  + real org invites).
- Background completion surfaces as a clickable top-right toast linking to
  the saved memory.