### PR TITLE
fix(extension): resolve sign-in loop and stale spaces

### DIFF
--- a/apps/browser-extension/entrypoints/popup/App.tsx
+++ b/apps/browser-extension/entrypoints/popup/App.tsx
@@ -175,10 +175,21 @@ function App() {
 		setShowProjectSelector(true)
 	}
 
+	// Reconcile stored default against live list: reset if deleted, refresh if renamed.
 	useEffect(() => {
-		if (!defaultProject && projects.length > 0) {
-			const firstProject = projects[0]
-			setDefaultProjectMutation.mutate(firstProject)
+		if (projects.length === 0) return
+		if (!defaultProject) {
+			setDefaultProjectMutation.mutate(projects[0])
+			return
+		}
+		const live = projects.find((p) => p.id === defaultProject.id)
+		if (!live) {
+			setDefaultProjectMutation.mutate(projects[0])
+		} else if (
+			live.name !== defaultProject.name ||
+			live.containerTag !== defaultProject.containerTag
+		) {
+			setDefaultProjectMutation.mutate(live)
 		}
 	}, [defaultProject, projects, setDefaultProjectMutation])
 

--- a/apps/browser-extension/wxt.config.ts
+++ b/apps/browser-extension/wxt.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
 	manifest: {
 		name: "supermemory",
 		homepage_url: "https://supermemory.ai",
-		version: "6.1.3",
+		version: "6.1.4",
 		permissions: ["storage", "activeTab", "webRequest", "tabs"],
 		host_permissions: [
 			"*://x.com/*",

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -140,14 +140,11 @@ export default function LoginPage() {
 			)
 			return
 		}
-		router.replace("/")
-	}, [
-		sessionPending,
-		sessionData?.session,
-		oauthQueryForResume,
-		params,
-		router,
-	])
+		// Carry the flag so the dashboard posts the session token to the extension (else: sign-in loop).
+		const dest = new URL("/", window.location.origin)
+		dest.searchParams.set("extension-auth-success", "true")
+		window.location.assign(dest.toString())
+	}, [sessionPending, sessionData?.session, oauthQueryForResume, params])
 
 	// Get redirect URL from query params
 	const redirectUrl = params.get("redirect")


### PR DESCRIPTION
## What

Fixes two bugs reported by a customer (Plain T-1289) using the Supermemory browser extension.

### Bug 1 — extension sign-in loop

When a user logs out of the _extension_ but is still authenticated in the _web app_, the extension's Sign-in button opens `/login`, which short-circuited via a bare `router.replace("/")`. That path never carried the `extension-auth-success` flag the dashboard waits on before `postMessage`\-ing the session token to the extension content script — so the extension never received a token and stayed stuck on "Sign in" indefinitely.

Now the already-authenticated redirect carries `?extension-auth-success=true`, matching the existing fresh-login callback behavior (no new token exposure).

### Bug 2 — stale / deleted spaces

The extension's stored default space (`local:sm-default-project`) was only set when none existed, never reconciled. After renaming/deleting spaces in the web app, the popup kept showing save buttons pointing at dead spaces. Now the popup reconciles the stored default against the freshly-fetched live list: resets to the first space if the stored one was deleted, and refreshes the cached copy (label/containerTag) if it was renamed.