### PR TITLE
feat: default auto space in chat input space selector

### DIFF
--- a/apps/web/components/chat/home-chat-composer.tsx
+++ b/apps/web/components/chat/home-chat-composer.tsx
@@ -7,6 +7,7 @@ import { useProject } from "@/stores"
 import { cn } from "@lib/utils"
 import type { ModelId } from "@/lib/models"
 import { SpaceSelector } from "@/components/space-selector"
+import { AUTO_CHAT_SPACE_ID } from "@/lib/chat-auto-space"
 
 export function HomeChatComposer({
 	onStartChat,
@@ -19,7 +20,7 @@ export function HomeChatComposer({
 	const [selectedModel, setSelectedModel] = useState<ModelId>("gemini-2.5-pro")
 	const { selectedProject } = useProject()
 	const [chatSpaceProjects, setChatSpaceProjects] = useState<string[]>([
-		selectedProject,
+		AUTO_CHAT_SPACE_ID,
 	])
 
 	const send = useCallback(() => {

--- a/apps/web/components/chat/index.tsx
+++ b/apps/web/components/chat/index.tsx
@@ -153,7 +153,7 @@ export function ChatSidebar({
 	const targetHighlightChatIdRef = useRef<string | null>(null)
 	const { selectedProject } = useProject()
 	const [chatSpaceProjects, setChatSpaceProjects] = useState<string[]>([
-		initialChatProject ?? selectedProject,
+		initialChatProject ?? AUTO_CHAT_SPACE_ID,
 	])
 	const chatProject = chatSpaceProjects[0] ?? selectedProject
 	const { allProjects } = useContainerTags()


### PR DESCRIPTION
## Summary

The space selector in the chat input now defaults to **Auto** instead of the currently selected space. This applies to both the home page chat composer and the active chat view.

## Changes

- `apps/web/components/chat/home-chat-composer.tsx`: Initialize `chatSpaceProjects` state with `AUTO_CHAT_SPACE_ID` instead of `selectedProject`
- `apps/web/components/chat/index.tsx`: Fall back to `AUTO_CHAT_SPACE_ID` instead of `selectedProject` when no `initialChatProject` is provided

## Testing

### Manual Verification
- Opened the chat input on the home page — space selector shows "Auto" by default
- Started a new chat from the home composer — chat opens with Auto space active
- Existing behavior preserved: if a chat is initiated with an explicit `initialChatProject` (e.g. from a highlight), it still uses that project


---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/8152ddda-8179-47e0-95de-09d0f5466c1b)
- Requested by: Mahesh Sanikommu (mahesh@supermemory.com)
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
