### PR TITLE
add web upgrade plans UI

### DIFF
--- a/apps/web/components/header.tsx
+++ b/apps/web/components/header.tsx
@@ -437,11 +437,10 @@ export function Header({ onAddMemory, onOpenSearch }: HeaderProps) {
 							<TooltipTrigger asChild>
 								<Button
 									asChild
-									variant="headers"
 									className={cn(
-										"rounded-full! h-9! min-h-9 shrink-0",
+										"rounded-full! h-9! min-h-9 shrink-0 border border-[#0B65C9]/70 bg-[#0054AD] !text-[#FAFAFA] hover:bg-[#0B65C9]",
 										"max-lg:w-9 max-lg:min-w-9 max-lg:justify-center max-lg:gap-0 max-lg:px-0",
-										"lg:min-w-0 lg:gap-1.5 lg:px-3 lg:font-medium",
+										"lg:min-w-0 lg:gap-1.5 lg:px-3 lg:font-semibold",
 										dmSansClassName(),
 									)}
 								>

--- a/apps/web/components/header.tsx
+++ b/apps/web/components/header.tsx
@@ -15,7 +15,6 @@ import {
 	LifeBuoy,
 	LayoutGrid,
 	ChevronRight,
-	Zap,
 } from "lucide-react"
 import { Button } from "@ui/components/button"
 import { cn } from "@lib/utils"
@@ -360,7 +359,7 @@ export function Header({ onAddMemory, onOpenSearch }: HeaderProps) {
 									className="gap-2.5 rounded-lg px-2.5 py-2 text-sm font-medium text-white/85 hover:bg-white/[0.06] focus:bg-white/[0.06] focus:text-white cursor-pointer"
 								>
 									<a href={billingSettingsUrl}>
-										<Zap className="size-4 text-[#4BA0FA]" />
+										<Logo className="h-4 w-5 shrink-0" />
 										Upgrade
 									</a>
 								</DropdownMenuItem>
@@ -445,7 +444,7 @@ export function Header({ onAddMemory, onOpenSearch }: HeaderProps) {
 									)}
 								>
 									<a href={billingSettingsUrl} aria-label="Upgrade">
-										<Zap className="size-3.5 shrink-0 lg:size-4" />
+										<Logo className="h-3.5 w-[17px] shrink-0 lg:h-4 lg:w-5" />
 										<span className="max-lg:sr-only">Upgrade</span>
 									</a>
 								</Button>

--- a/apps/web/components/header.tsx
+++ b/apps/web/components/header.tsx
@@ -15,6 +15,7 @@ import {
 	LifeBuoy,
 	LayoutGrid,
 	ChevronRight,
+	Zap,
 } from "lucide-react"
 import { Button } from "@ui/components/button"
 import { cn } from "@lib/utils"
@@ -353,6 +354,15 @@ export function Header({ onAddMemory, onOpenSearch }: HeaderProps) {
 								}}
 							>
 								<DropdownMenuItem
+									asChild
+									className="gap-2.5 rounded-lg px-2.5 py-2 text-sm font-medium text-white/85 hover:bg-white/[0.06] focus:bg-white/[0.06] focus:text-white cursor-pointer"
+								>
+									<a href="https://app.supermemory.ai/settings#billing">
+										<Zap className="size-4 text-[#4BA0FA]" />
+										Upgrade
+									</a>
+								</DropdownMenuItem>
+								<DropdownMenuItem
 									onClick={onAddMemory}
 									className="gap-2.5 rounded-lg px-2.5 py-2 text-sm font-medium text-white/85 hover:bg-white/[0.06] focus:bg-white/[0.06] focus:text-white cursor-pointer"
 								>
@@ -421,6 +431,30 @@ export function Header({ onAddMemory, onOpenSearch }: HeaderProps) {
 					</>
 				) : (
 					<>
+						<Tooltip>
+							<TooltipTrigger asChild>
+								<Button
+									asChild
+									className={cn(
+										"rounded-full! h-9! min-h-9 shrink-0 border-transparent bg-[#4BA0FA] text-[#00171A] hover:bg-[#4BA0FA]/90",
+										"max-lg:w-9 max-lg:min-w-9 max-lg:justify-center max-lg:gap-0 max-lg:px-0",
+										"lg:min-w-0 lg:gap-1.5 lg:px-3 lg:font-semibold",
+										dmSansClassName(),
+									)}
+								>
+									<a
+										href="https://app.supermemory.ai/settings#billing"
+										aria-label="Upgrade"
+									>
+										<Zap className="size-3.5 shrink-0 lg:size-4" />
+										<span className="max-lg:sr-only">Upgrade</span>
+									</a>
+								</Button>
+							</TooltipTrigger>
+							<TooltipContent side="bottom" className={dmSansClassName()}>
+								Upgrade
+							</TooltipContent>
+						</Tooltip>
 						<Tooltip>
 							<TooltipTrigger asChild>
 								<Button

--- a/apps/web/components/header.tsx
+++ b/apps/web/components/header.tsx
@@ -20,6 +20,7 @@ import {
 import { Button } from "@ui/components/button"
 import { cn } from "@lib/utils"
 import { dmSansClassName } from "@/lib/fonts"
+import { getBillingSettingsUrl } from "@/lib/url-helpers"
 import { GraphIcon, IntegrationsIcon } from "@/components/integration-icons"
 import {
 	DropdownMenu,
@@ -81,6 +82,7 @@ export function Header({ onAddMemory, onOpenSearch }: HeaderProps) {
 		feedbackParam,
 	)
 	const { viewMode, setViewMode } = useViewMode()
+	const billingSettingsUrl = getBillingSettingsUrl()
 
 	const handleFeedback = () => setFeedbackOpen(true)
 
@@ -357,7 +359,7 @@ export function Header({ onAddMemory, onOpenSearch }: HeaderProps) {
 									asChild
 									className="gap-2.5 rounded-lg px-2.5 py-2 text-sm font-medium text-white/85 hover:bg-white/[0.06] focus:bg-white/[0.06] focus:text-white cursor-pointer"
 								>
-									<a href="https://app.supermemory.ai/settings#billing">
+									<a href={billingSettingsUrl}>
 										<Zap className="size-4 text-[#4BA0FA]" />
 										Upgrade
 									</a>
@@ -443,10 +445,7 @@ export function Header({ onAddMemory, onOpenSearch }: HeaderProps) {
 										dmSansClassName(),
 									)}
 								>
-									<a
-										href="https://app.supermemory.ai/settings#billing"
-										aria-label="Upgrade"
-									>
+									<a href={billingSettingsUrl} aria-label="Upgrade">
 										<Zap className="size-3.5 shrink-0 lg:size-4" />
 										<span className="max-lg:sr-only">Upgrade</span>
 									</a>

--- a/apps/web/components/header.tsx
+++ b/apps/web/components/header.tsx
@@ -437,7 +437,7 @@ export function Header({ onAddMemory, onOpenSearch }: HeaderProps) {
 								<Button
 									asChild
 									className={cn(
-										"rounded-full! h-9! min-h-9 shrink-0 border border-[#0B65C9]/70 bg-[#0054AD] !text-[#FAFAFA] hover:bg-[#0B65C9]",
+										"rounded-full! h-9! min-h-9 shrink-0 border border-[#2261CA33] bg-[#00173C] !text-white hover:bg-[#001F50]",
 										"max-lg:w-9 max-lg:min-w-9 max-lg:justify-center max-lg:gap-0 max-lg:px-0",
 										"lg:min-w-0 lg:gap-1.5 lg:px-3 lg:font-semibold",
 										dmSansClassName(),

--- a/apps/web/components/header.tsx
+++ b/apps/web/components/header.tsx
@@ -435,10 +435,11 @@ export function Header({ onAddMemory, onOpenSearch }: HeaderProps) {
 							<TooltipTrigger asChild>
 								<Button
 									asChild
+									variant="headers"
 									className={cn(
-										"rounded-full! h-9! min-h-9 shrink-0 border-transparent bg-[#4BA0FA] text-[#00171A] hover:bg-[#4BA0FA]/90",
+										"rounded-full! h-9! min-h-9 shrink-0",
 										"max-lg:w-9 max-lg:min-w-9 max-lg:justify-center max-lg:gap-0 max-lg:px-0",
-										"lg:min-w-0 lg:gap-1.5 lg:px-3 lg:font-semibold",
+										"lg:min-w-0 lg:gap-1.5 lg:px-3 lg:font-medium",
 										dmSansClassName(),
 									)}
 								>

--- a/apps/web/components/settings/billing.tsx
+++ b/apps/web/components/settings/billing.tsx
@@ -147,11 +147,9 @@ function SettingsCard({
 
 function PlanCard({
 	action,
-	isCurrent,
 	plan,
 }: {
 	action: React.ReactNode
-	isCurrent: boolean
 	plan: PlanCardDefinition
 }) {
 	return (
@@ -159,9 +157,7 @@ function PlanCard({
 			className={cn(
 				"relative flex min-h-[416px] flex-col overflow-hidden rounded-[14px] border p-5",
 				"shadow-[inset_2.42px_2.42px_4.263px_rgba(11,15,21,0.7)]",
-				isCurrent
-					? "border-[#2261CA33] bg-[#17202B]"
-					: "border-white/[0.08] bg-[#14161A]",
+				"border-white/[0.08] bg-[#14161A]",
 			)}
 		>
 			<p className="font-mono text-[10px] font-medium uppercase tracking-[0.18em] text-[#737373]">
@@ -896,7 +892,6 @@ export default function Billing() {
 					{PLAN_CARDS.map((plan) => (
 						<PlanCard
 							action={getPlanCardAction(plan)}
-							isCurrent={currentPlan === plan.id}
 							key={plan.id}
 							plan={plan}
 						/>

--- a/apps/web/components/settings/billing.tsx
+++ b/apps/web/components/settings/billing.tsx
@@ -876,9 +876,7 @@ export default function Billing() {
 			</section>
 
 			<section id="billing-plans" className="flex flex-col gap-4">
-				<div className="px-2">
-					<SectionTitle>Plans</SectionTitle>
-				</div>
+				<SectionTitle>Plans</SectionTitle>
 				<div className="grid gap-4 md:grid-cols-2">
 					{PLAN_CARDS.map((plan) => (
 						<PlanCard

--- a/apps/web/components/settings/billing.tsx
+++ b/apps/web/components/settings/billing.tsx
@@ -13,6 +13,7 @@ import {
 import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useCustomer } from "autumn-js/react"
 import {
+	Check,
 	Coins,
 	ExternalLink,
 	LoaderIcon,
@@ -30,6 +31,8 @@ const API_BASE =
 const CREDIT_FEATURE_ID = "usd_credits"
 const TOP_UP_PLAN_ID = "credits_topup"
 const TOP_UP_AMOUNTS = [10, 25, 50, 100] as const
+const PLAN_CARD_ACTION_CLASS =
+	"inline-flex h-10 w-full items-center justify-center gap-2 rounded-[10px] text-[14px] font-semibold transition-colors disabled:cursor-not-allowed disabled:opacity-60"
 
 type BillingInvoice = {
 	planIds?: string[]
@@ -60,6 +63,45 @@ type AutoTopupsResponse =
 			autoTopup: AutoTopupConfig | null
 	  }
 	| { ok: false; reason: string; message?: string }
+
+type PlanCardDefinition = {
+	id: "free" | "pro"
+	name: string
+	price: string
+	period: string
+	credits: string
+	description: string
+	features: string[]
+}
+
+const PLAN_CARDS: PlanCardDefinition[] = [
+	{
+		id: "free",
+		name: "Free",
+		price: "$0",
+		period: "",
+		credits: "$5",
+		description: "Try supermemory with no commitment",
+		features: [
+			"Pay-as-you-go after $5 runs out",
+			"Full search and memory access",
+			"Email support",
+		],
+	},
+	{
+		id: "pro",
+		name: "Pro",
+		price: "$19",
+		period: "/mo",
+		credits: "$20",
+		description: "For people building with AI memory",
+		features: [
+			"Auto top-up when balance runs low",
+			"All plugins (Claude Code, Cursor, Hermes...)",
+			"Priority support",
+		],
+	},
+]
 
 function SectionTitle({
 	children,
@@ -99,6 +141,81 @@ function SettingsCard({
 			)}
 		>
 			{children}
+		</div>
+	)
+}
+
+function PlanCard({
+	action,
+	isCurrent,
+	plan,
+}: {
+	action: React.ReactNode
+	isCurrent: boolean
+	plan: PlanCardDefinition
+}) {
+	return (
+		<div
+			className={cn(
+				"relative flex min-h-[416px] flex-col overflow-hidden rounded-[14px] border p-5",
+				"shadow-[inset_2.42px_2.42px_4.263px_rgba(11,15,21,0.7)]",
+				isCurrent
+					? "border-[#2261CA33] bg-[#17202B]"
+					: "border-white/[0.08] bg-[#14161A]",
+			)}
+		>
+			<p className="font-mono text-[10px] font-medium uppercase tracking-[0.18em] text-[#737373]">
+				{plan.name}
+			</p>
+
+			<div className="mt-3 flex items-baseline gap-1">
+				<span
+					className={cn(
+						dmSans125ClassName(),
+						"text-[34px] font-bold leading-none tracking-[-0.34px] text-[#FAFAFA] tabular-nums",
+					)}
+				>
+					{plan.price}
+				</span>
+				{plan.period ? (
+					<span className="text-[13px] text-[#737373]">{plan.period}</span>
+				) : null}
+			</div>
+
+			<p
+				className={cn(
+					dmSans125ClassName(),
+					"mt-2 text-[13px] leading-snug text-[#A3A3A3]",
+				)}
+			>
+				{plan.description}
+			</p>
+
+			<div className="mt-5 flex items-center gap-2 rounded-[8px] bg-white/[0.04] px-3 py-2.5 text-[#A3A3A3]">
+				<Coins className="size-3.5 shrink-0 text-[#737373]" />
+				<div className="min-w-0">
+					<p className="text-[12px] font-semibold leading-none text-[#C8D0DA] tabular-nums">
+						{plan.credits}
+					</p>
+					<p className="mt-0.5 text-[10px] leading-none text-[#737373]">
+						of usage included
+					</p>
+				</div>
+			</div>
+
+			<ul className="mt-5 mb-6 flex flex-1 flex-col gap-3">
+				{plan.features.map((feature) => (
+					<li
+						className="flex items-start gap-2 text-[13px] leading-snug text-[#C8D0DA]"
+						key={feature}
+					>
+						<Check className="mt-0.5 size-3.5 shrink-0 text-[#737373]" />
+						<span>{feature}</span>
+					</li>
+				))}
+			</ul>
+
+			{action}
 		</div>
 	)
 }
@@ -490,6 +607,74 @@ export default function Billing() {
 		})
 	}
 
+	const getPlanCardAction = (plan: PlanCardDefinition) => {
+		if (plan.id === "free") {
+			return (
+				<button
+					type="button"
+					disabled
+					className={cn(
+						dmSans125ClassName(),
+						PLAN_CARD_ACTION_CLASS,
+						"border border-white/[0.04] bg-white/[0.02] text-[#737373]",
+					)}
+				>
+					{hasPaidPlan ? "Included with current plan" : "Your current plan"}
+				</button>
+			)
+		}
+
+		if (currentPlan === "pro") {
+			return (
+				<button
+					type="button"
+					disabled
+					className={cn(
+						dmSans125ClassName(),
+						PLAN_CARD_ACTION_CLASS,
+						"border border-white/[0.04] bg-white/[0.02] text-[#737373]",
+					)}
+				>
+					Your current plan
+				</button>
+			)
+		}
+
+		if (currentPlan === "scale" || currentPlan === "enterprise") {
+			return (
+				<button
+					type="button"
+					disabled
+					className={cn(
+						dmSans125ClassName(),
+						PLAN_CARD_ACTION_CLASS,
+						"border border-white/[0.04] bg-white/[0.02] text-[#737373]",
+					)}
+				>
+					Included with {planDisplayNames[currentPlan]}
+				</button>
+			)
+		}
+
+		return (
+			<button
+				type="button"
+				onClick={handleUpgrade}
+				disabled={isUpgrading || isCheckingStatus || autumn.isLoading}
+				className={cn(
+					dmSans125ClassName(),
+					PLAN_CARD_ACTION_CLASS,
+					"bg-[#0054AD] text-[#FAFAFA] hover:bg-[#0B65C9]",
+				)}
+			>
+				{isUpgrading || isCheckingStatus || autumn.isLoading ? (
+					<LoaderIcon className="size-4 animate-spin" />
+				) : null}
+				Upgrade to Pro
+			</button>
+		)
+	}
+
 	return (
 		<div className="flex w-full flex-col gap-7">
 			<section id="billing-subscription" className="flex flex-col gap-4">
@@ -692,6 +877,31 @@ export default function Billing() {
 						) : null}
 					</div>
 				</SettingsCard>
+			</section>
+
+			<section id="billing-plans" className="flex flex-col gap-4">
+				<div className="flex flex-col gap-1 px-2">
+					<SectionTitle>Plans</SectionTitle>
+					<p
+						className={cn(
+							dmSans125ClassName(),
+							"text-[13px] leading-relaxed text-[#A3A3A3]",
+						)}
+					>
+						All plans include usage-metered access. Top-ups roll over with paid
+						plans.
+					</p>
+				</div>
+				<div className="grid gap-4 md:grid-cols-2">
+					{PLAN_CARDS.map((plan) => (
+						<PlanCard
+							action={getPlanCardAction(plan)}
+							isCurrent={currentPlan === plan.id}
+							key={plan.id}
+							plan={plan}
+						/>
+					))}
+				</div>
 			</section>
 
 			<section className="flex flex-col gap-4">

--- a/apps/web/components/settings/billing.tsx
+++ b/apps/web/components/settings/billing.tsx
@@ -15,6 +15,7 @@ import { useCustomer } from "autumn-js/react"
 import {
 	Check,
 	Coins,
+	ArrowRight,
 	ExternalLink,
 	LoaderIcon,
 	Plus,
@@ -65,13 +66,17 @@ type AutoTopupsResponse =
 	| { ok: false; reason: string; message?: string }
 
 type PlanCardDefinition = {
-	id: "free" | "pro"
+	id: "free" | "pro" | "scale" | "enterprise"
 	name: string
 	price: string
 	period: string
 	credits: string
+	productId: "api_free" | "api_pro" | "api_scale" | "api_enterprise"
 	description: string
+	includesFrom?: string
 	features: string[]
+	highlight?: boolean
+	isContactSales?: boolean
 }
 
 const PLAN_CARDS: PlanCardDefinition[] = [
@@ -81,6 +86,7 @@ const PLAN_CARDS: PlanCardDefinition[] = [
 		price: "$0",
 		period: "",
 		credits: "$5",
+		productId: "api_free",
 		description: "Try supermemory with no commitment",
 		features: [
 			"Pay-as-you-go after $5 runs out",
@@ -94,6 +100,7 @@ const PLAN_CARDS: PlanCardDefinition[] = [
 		price: "$19",
 		period: "/mo",
 		credits: "$20",
+		productId: "api_pro",
 		description: "For people building with AI memory",
 		features: [
 			"Auto top-up when balance runs low",
@@ -102,6 +109,48 @@ const PLAN_CARDS: PlanCardDefinition[] = [
 		],
 	},
 ]
+
+const ADVANCED_PLAN_CARDS: PlanCardDefinition[] = [
+	{
+		id: "scale",
+		name: "Scale",
+		price: "$399",
+		period: "/mo",
+		credits: "$600",
+		productId: "api_scale",
+		description: "For teams and production workloads",
+		includesFrom: "Pro",
+		features: [
+			"Auto top-up & spend caps",
+			"Gmail, S3 & Web Crawler connectors",
+			"Dedicated support",
+		],
+		highlight: true,
+	},
+	{
+		id: "enterprise",
+		name: "Enterprise",
+		price: "Custom",
+		period: "",
+		credits: "Unlimited",
+		productId: "api_enterprise",
+		description: "Custom deployments with dedicated engineering",
+		includesFrom: "Scale",
+		features: [
+			"Custom metering & billing",
+			"Custom integrations & SSO",
+			"Forward-deployed engineer",
+		],
+		isContactSales: true,
+	},
+]
+
+const PLAN_RANK: Record<PlanCardDefinition["id"], number> = {
+	free: 0,
+	pro: 1,
+	scale: 2,
+	enterprise: 3,
+}
 
 function SectionTitle({
 	children,
@@ -157,10 +206,24 @@ function PlanCard({
 			className={cn(
 				"relative flex min-h-[416px] flex-col overflow-hidden rounded-[14px] border p-5",
 				"shadow-[inset_2.42px_2.42px_4.263px_rgba(11,15,21,0.7)]",
-				"border-white/[0.08] bg-[#14161A]",
+				plan.highlight
+					? "border-[#0B65C9] bg-[#14161A] shadow-[inset_2.42px_2.42px_4.263px_rgba(11,15,21,0.7),0_0_0_1px_rgba(11,101,201,0.72)]"
+					: "border-white/[0.08] bg-[#14161A]",
 			)}
 		>
-			<p className="font-mono text-[10px] font-medium uppercase tracking-[0.18em] text-[#737373]">
+			{plan.highlight ? (
+				<div className="-translate-x-1/2 absolute top-[-1px] left-1/2 whitespace-nowrap">
+					<span className="rounded-full bg-[#1688FF] px-3 py-1 text-[10px] font-bold uppercase leading-none tracking-[0.32px] text-white">
+						Most popular
+					</span>
+				</div>
+			) : null}
+			<p
+				className={cn(
+					"font-mono text-[10px] font-medium uppercase tracking-[0.18em]",
+					plan.highlight ? "text-[#4BA0FA]" : "text-[#737373]",
+				)}
+			>
 				{plan.name}
 			</p>
 
@@ -187,25 +250,68 @@ function PlanCard({
 				{plan.description}
 			</p>
 
-			<div className="mt-5 flex items-center gap-2 rounded-[8px] bg-white/[0.04] px-3 py-2.5 text-[#A3A3A3]">
-				<Coins className="size-3.5 shrink-0 text-[#737373]" />
-				<div className="min-w-0">
-					<p className="text-[12px] font-semibold leading-none text-[#C8D0DA] tabular-nums">
-						{plan.credits}
-					</p>
-					<p className="mt-0.5 text-[10px] leading-none text-[#737373]">
-						of usage included
-					</p>
+			{plan.isContactSales ? null : (
+				<div
+					className={cn(
+						"mt-5 flex items-center gap-2 rounded-[8px] px-3 py-2.5 text-[#A3A3A3]",
+						plan.highlight ? "bg-[#061B38]" : "bg-white/[0.04]",
+					)}
+				>
+					<Coins
+						className={cn(
+							"size-3.5 shrink-0",
+							plan.highlight ? "text-[#4BA0FA]" : "text-[#737373]",
+						)}
+					/>
+					<div className="min-w-0">
+						<p
+							className={cn(
+								"text-[12px] font-semibold leading-none tabular-nums",
+								plan.highlight ? "text-[#4BA0FA]" : "text-[#C8D0DA]",
+							)}
+						>
+							{plan.credits}
+						</p>
+						<p
+							className={cn(
+								"mt-0.5 text-[10px] leading-none",
+								plan.highlight ? "text-[#4BA0FA]/75" : "text-[#737373]",
+							)}
+						>
+							of usage included
+						</p>
+					</div>
 				</div>
-			</div>
+			)}
 
-			<ul className="mt-5 mb-6 flex flex-1 flex-col gap-3">
+			{plan.includesFrom ? (
+				<div className="mt-5 flex items-center gap-3">
+					<div className="h-px flex-1 bg-white/[0.08]" />
+					<span className="whitespace-nowrap text-[10px] text-[#737373]">
+						Everything in {plan.includesFrom}, plus
+					</span>
+					<div className="h-px flex-1 bg-white/[0.08]" />
+				</div>
+			) : null}
+
+			<ul
+				className={cn(
+					"mb-6 flex flex-1 flex-col gap-3",
+					plan.includesFrom ? "mt-5" : "mt-5",
+					plan.isContactSales && !plan.includesFrom && "mt-7",
+				)}
+			>
 				{plan.features.map((feature) => (
 					<li
 						className="flex items-start gap-2 text-[13px] leading-snug text-[#C8D0DA]"
 						key={feature}
 					>
-						<Check className="mt-0.5 size-3.5 shrink-0 text-[#737373]" />
+						<Check
+							className={cn(
+								"mt-0.5 size-3.5 shrink-0",
+								plan.highlight ? "text-[#4BA0FA]" : "text-[#737373]",
+							)}
+						/>
 						<span>{feature}</span>
 					</li>
 				))}
@@ -349,6 +455,7 @@ export default function Billing() {
 	const [isCancelling, setIsCancelling] = useState(false)
 	const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false)
 	const [isCreditsDialogOpen, setIsCreditsDialogOpen] = useState(false)
+	const [showOtherPlans, setShowOtherPlans] = useState(false)
 	const [topUpAmount, setTopUpAmount] = useState<number>(25)
 	const [customTopUpAmount, setCustomTopUpAmount] = useState("")
 	const [topUpPendingAmount, setTopUpPendingAmount] = useState<number | null>(
@@ -446,11 +553,11 @@ export default function Billing() {
 
 	const planDisplayNames = PLAN_DISPLAY_NAMES
 
-	const handleUpgrade = async () => {
+	const handleUpgrade = async (planId: "api_pro" | "api_scale") => {
 		setIsUpgrading(true)
 		try {
 			const result = await autumn.attach({
-				planId: "api_pro",
+				planId,
 				successUrl: `${window.location.origin}/settings#billing`,
 			})
 			if ((result as { paymentUrl?: string })?.paymentUrl) {
@@ -604,6 +711,10 @@ export default function Billing() {
 	}
 
 	const getPlanCardAction = (plan: PlanCardDefinition) => {
+		const disabled = isUpgrading || isCheckingStatus || autumn.isLoading
+		const isCurrentPlan = plan.id === currentPlan
+		const isIncludedPlan = PLAN_RANK[currentPlan] > PLAN_RANK[plan.id]
+
 		if (plan.id === "free") {
 			return (
 				<button
@@ -620,7 +731,7 @@ export default function Billing() {
 			)
 		}
 
-		if (currentPlan === "pro") {
+		if (isCurrentPlan) {
 			return (
 				<button
 					type="button"
@@ -636,7 +747,7 @@ export default function Billing() {
 			)
 		}
 
-		if (currentPlan === "scale" || currentPlan === "enterprise") {
+		if (isIncludedPlan) {
 			return (
 				<button
 					type="button"
@@ -652,21 +763,40 @@ export default function Billing() {
 			)
 		}
 
+		if (plan.isContactSales) {
+			return (
+				<a
+					href="mailto:support@supermemory.com?subject=Enterprise%20plan"
+					className={cn(
+						dmSans125ClassName(),
+						PLAN_CARD_ACTION_CLASS,
+						"border border-white/[0.08] bg-transparent text-[#FAFAFA] hover:bg-white/[0.04]",
+					)}
+				>
+					Contact sales
+				</a>
+			)
+		}
+
+		const checkoutPlanId =
+			plan.productId === "api_pro" || plan.productId === "api_scale"
+				? plan.productId
+				: null
+		if (!checkoutPlanId) return null
+
 		return (
 			<button
 				type="button"
-				onClick={handleUpgrade}
-				disabled={isUpgrading || isCheckingStatus || autumn.isLoading}
+				onClick={() => handleUpgrade(checkoutPlanId)}
+				disabled={disabled}
 				className={cn(
 					dmSans125ClassName(),
 					PLAN_CARD_ACTION_CLASS,
 					"bg-[#0054AD] text-[#FAFAFA] hover:bg-[#0B65C9]",
 				)}
 			>
-				{isUpgrading || isCheckingStatus || autumn.isLoading ? (
-					<LoaderIcon className="size-4 animate-spin" />
-				) : null}
-				Upgrade to Pro
+				{disabled ? <LoaderIcon className="size-4 animate-spin" /> : null}
+				Upgrade to {plan.name}
 			</button>
 		)
 	}
@@ -864,6 +994,31 @@ export default function Billing() {
 						/>
 					))}
 				</div>
+				{showOtherPlans ? (
+					<div className="grid gap-4 md:grid-cols-2">
+						{ADVANCED_PLAN_CARDS.map((plan) => (
+							<PlanCard
+								action={getPlanCardAction(plan)}
+								key={plan.id}
+								plan={plan}
+							/>
+						))}
+					</div>
+				) : (
+					<div className="flex justify-center pt-1">
+						<button
+							type="button"
+							onClick={() => setShowOtherPlans(true)}
+							className={cn(
+								dmSans125ClassName(),
+								"inline-flex h-9 items-center justify-center gap-2 rounded-full border border-white/[0.08] bg-white/[0.02] px-4 text-[13px] font-semibold text-[#A3A3A3] transition-colors hover:border-[#0B65C9]/60 hover:bg-[#061B38] hover:text-[#FAFAFA]",
+							)}
+						>
+							See other plans
+							<ArrowRight className="size-3.5" />
+						</button>
+					</div>
+				)}
 			</section>
 
 			<section className="flex flex-col gap-4">

--- a/apps/web/components/settings/billing.tsx
+++ b/apps/web/components/settings/billing.tsx
@@ -14,6 +14,8 @@ import { useQuery, useQueryClient } from "@tanstack/react-query"
 import { useCustomer } from "autumn-js/react"
 import {
 	Check,
+	ChevronLeft,
+	ChevronRight,
 	Coins,
 	ExternalLink,
 	LoaderIcon,
@@ -413,7 +415,8 @@ export default function Billing() {
 	const [isCancelling, setIsCancelling] = useState(false)
 	const [isCancelDialogOpen, setIsCancelDialogOpen] = useState(false)
 	const [isCreditsDialogOpen, setIsCreditsDialogOpen] = useState(false)
-	const [showOtherPlans, setShowOtherPlans] = useState(false)
+	const [isPlanCarouselActive, setIsPlanCarouselActive] = useState(false)
+	const [planPage, setPlanPage] = useState<0 | 1>(0)
 	const [topUpAmount, setTopUpAmount] = useState<number>(25)
 	const [customTopUpAmount, setCustomTopUpAmount] = useState("")
 	const [topUpPendingAmount, setTopUpPendingAmount] = useState<number | null>(
@@ -942,31 +945,70 @@ export default function Billing() {
 			</section>
 
 			<section id="billing-plans" className="flex flex-col gap-4">
-				<SectionTitle>Plans</SectionTitle>
-				<div className="grid gap-4 md:grid-cols-2">
-					{PLAN_CARDS.map((plan) => (
-						<PlanCard
-							action={getPlanCardAction(plan)}
-							key={plan.id}
-							plan={plan}
-						/>
-					))}
-				</div>
-				{showOtherPlans ? (
-					<div className="grid gap-4 md:grid-cols-2">
-						{ADVANCED_PLAN_CARDS.map((plan) => (
-							<PlanCard
-								action={getPlanCardAction(plan)}
-								key={plan.id}
-								plan={plan}
-							/>
-						))}
+				<SectionTitle
+					aside={
+						isPlanCarouselActive ? (
+							<div className="flex items-center gap-1.5">
+								<button
+									type="button"
+									onClick={() => setPlanPage(0)}
+									disabled={planPage === 0}
+									className="flex size-8 items-center justify-center rounded-full border border-white/[0.08] bg-white/[0.02] text-[#A3A3A3] transition-colors hover:bg-white/[0.05] hover:text-[#FAFAFA] disabled:cursor-not-allowed disabled:opacity-35"
+									aria-label="Show Free and Pro plans"
+								>
+									<ChevronLeft className="size-4" />
+								</button>
+								<button
+									type="button"
+									onClick={() => setPlanPage(1)}
+									disabled={planPage === 1}
+									className="flex size-8 items-center justify-center rounded-full border border-white/[0.08] bg-white/[0.02] text-[#A3A3A3] transition-colors hover:bg-white/[0.05] hover:text-[#FAFAFA] disabled:cursor-not-allowed disabled:opacity-35"
+									aria-label="Show Scale and Enterprise plans"
+								>
+									<ChevronRight className="size-4" />
+								</button>
+							</div>
+						) : undefined
+					}
+				>
+					Plans
+				</SectionTitle>
+				<div className="overflow-hidden">
+					<div
+						className="flex gap-4 transition-transform duration-300 ease-out"
+						style={{
+							transform:
+								planPage === 1 ? "translateX(calc(-100% - 1rem))" : "none",
+						}}
+					>
+						<div className="grid w-full shrink-0 gap-4 md:grid-cols-2">
+							{PLAN_CARDS.map((plan) => (
+								<PlanCard
+									action={getPlanCardAction(plan)}
+									key={plan.id}
+									plan={plan}
+								/>
+							))}
+						</div>
+						<div className="grid w-full shrink-0 gap-4 md:grid-cols-2">
+							{ADVANCED_PLAN_CARDS.map((plan) => (
+								<PlanCard
+									action={getPlanCardAction(plan)}
+									key={plan.id}
+									plan={plan}
+								/>
+							))}
+						</div>
 					</div>
-				) : (
+				</div>
+				{isPlanCarouselActive ? null : (
 					<div className="flex justify-end px-2 pt-1">
 						<button
 							type="button"
-							onClick={() => setShowOtherPlans(true)}
+							onClick={() => {
+								setIsPlanCarouselActive(true)
+								setPlanPage(1)
+							}}
 							className={cn(
 								dmSans125ClassName(),
 								"inline-flex items-center justify-center gap-1.5 text-[13px] font-semibold text-[#A3A3A3] underline underline-offset-4 transition-colors hover:text-[#FAFAFA]",

--- a/apps/web/components/settings/billing.tsx
+++ b/apps/web/components/settings/billing.tsx
@@ -15,7 +15,6 @@ import { useCustomer } from "autumn-js/react"
 import {
 	Check,
 	Coins,
-	ArrowRight,
 	ExternalLink,
 	LoaderIcon,
 	Plus,
@@ -964,17 +963,17 @@ export default function Billing() {
 						))}
 					</div>
 				) : (
-					<div className="flex justify-center pt-1">
+					<div className="flex justify-end px-2 pt-1">
 						<button
 							type="button"
 							onClick={() => setShowOtherPlans(true)}
 							className={cn(
 								dmSans125ClassName(),
-								"inline-flex h-9 items-center justify-center gap-2 rounded-full border border-white/[0.08] bg-white/[0.02] px-4 text-[13px] font-semibold text-[#A3A3A3] transition-colors hover:border-[#0B65C9]/60 hover:bg-[#061B38] hover:text-[#FAFAFA]",
+								"inline-flex items-center justify-center gap-1.5 text-[13px] font-semibold text-[#A3A3A3] underline underline-offset-4 transition-colors hover:text-[#FAFAFA]",
 							)}
 						>
-							See other plans
-							<ArrowRight className="size-3.5" />
+							Other plans
+							<span aria-hidden="true">-&gt;</span>
 						</button>
 					</div>
 				)}

--- a/apps/web/components/settings/billing.tsx
+++ b/apps/web/components/settings/billing.tsx
@@ -75,7 +75,6 @@ type PlanCardDefinition = {
 	description: string
 	includesFrom?: string
 	features: string[]
-	highlight?: boolean
 	isContactSales?: boolean
 }
 
@@ -125,7 +124,6 @@ const ADVANCED_PLAN_CARDS: PlanCardDefinition[] = [
 			"Gmail, S3 & Web Crawler connectors",
 			"Dedicated support",
 		],
-		highlight: true,
 	},
 	{
 		id: "enterprise",
@@ -206,24 +204,10 @@ function PlanCard({
 			className={cn(
 				"relative flex min-h-[416px] flex-col overflow-hidden rounded-[14px] border p-5",
 				"shadow-[inset_2.42px_2.42px_4.263px_rgba(11,15,21,0.7)]",
-				plan.highlight
-					? "border-[#0B65C9] bg-[#14161A] shadow-[inset_2.42px_2.42px_4.263px_rgba(11,15,21,0.7),0_0_0_1px_rgba(11,101,201,0.72)]"
-					: "border-white/[0.08] bg-[#14161A]",
+				"border-white/[0.08] bg-[#14161A]",
 			)}
 		>
-			{plan.highlight ? (
-				<div className="-translate-x-1/2 absolute top-[-1px] left-1/2 whitespace-nowrap">
-					<span className="rounded-full bg-[#1688FF] px-3 py-1 text-[10px] font-bold uppercase leading-none tracking-[0.32px] text-white">
-						Most popular
-					</span>
-				</div>
-			) : null}
-			<p
-				className={cn(
-					"font-mono text-[10px] font-medium uppercase tracking-[0.18em]",
-					plan.highlight ? "text-[#4BA0FA]" : "text-[#737373]",
-				)}
-			>
+			<p className="font-mono text-[10px] font-medium uppercase tracking-[0.18em] text-[#737373]">
 				{plan.name}
 			</p>
 
@@ -251,33 +235,13 @@ function PlanCard({
 			</p>
 
 			{plan.isContactSales ? null : (
-				<div
-					className={cn(
-						"mt-5 flex items-center gap-2 rounded-[8px] px-3 py-2.5 text-[#A3A3A3]",
-						plan.highlight ? "bg-[#061B38]" : "bg-white/[0.04]",
-					)}
-				>
-					<Coins
-						className={cn(
-							"size-3.5 shrink-0",
-							plan.highlight ? "text-[#4BA0FA]" : "text-[#737373]",
-						)}
-					/>
+				<div className="mt-5 flex items-center gap-2 rounded-[8px] bg-white/[0.04] px-3 py-2.5 text-[#A3A3A3]">
+					<Coins className="size-3.5 shrink-0 text-[#737373]" />
 					<div className="min-w-0">
-						<p
-							className={cn(
-								"text-[12px] font-semibold leading-none tabular-nums",
-								plan.highlight ? "text-[#4BA0FA]" : "text-[#C8D0DA]",
-							)}
-						>
+						<p className="text-[12px] font-semibold leading-none text-[#C8D0DA] tabular-nums">
 							{plan.credits}
 						</p>
-						<p
-							className={cn(
-								"mt-0.5 text-[10px] leading-none",
-								plan.highlight ? "text-[#4BA0FA]/75" : "text-[#737373]",
-							)}
-						>
+						<p className="mt-0.5 text-[10px] leading-none text-[#737373]">
 							of usage included
 						</p>
 					</div>
@@ -306,12 +270,7 @@ function PlanCard({
 						className="flex items-start gap-2 text-[13px] leading-snug text-[#C8D0DA]"
 						key={feature}
 					>
-						<Check
-							className={cn(
-								"mt-0.5 size-3.5 shrink-0",
-								plan.highlight ? "text-[#4BA0FA]" : "text-[#737373]",
-							)}
-						/>
+						<Check className="mt-0.5 size-3.5 shrink-0 text-[#737373]" />
 						<span>{feature}</span>
 					</li>
 				))}

--- a/apps/web/components/settings/billing.tsx
+++ b/apps/web/components/settings/billing.tsx
@@ -1011,11 +1011,13 @@ export default function Billing() {
 							}}
 							className={cn(
 								dmSans125ClassName(),
-								"inline-flex items-center justify-center gap-1.5 text-[13px] font-semibold text-[#A3A3A3] underline underline-offset-4 transition-colors hover:text-[#FAFAFA]",
+								"inline-flex items-center justify-center gap-2 text-[13px] font-semibold text-[#A3A3A3] transition-colors hover:text-[#FAFAFA]",
 							)}
 						>
-							Other plans
-							<span aria-hidden="true">-&gt;</span>
+							<span className="underline underline-offset-4">Other plans</span>
+							<span className="translate-x-1 text-[15px]" aria-hidden="true">
+								&rarr;
+							</span>
 						</button>
 					</div>
 				)}

--- a/apps/web/components/settings/billing.tsx
+++ b/apps/web/components/settings/billing.tsx
@@ -876,17 +876,8 @@ export default function Billing() {
 			</section>
 
 			<section id="billing-plans" className="flex flex-col gap-4">
-				<div className="flex flex-col gap-1 px-2">
+				<div className="px-2">
 					<SectionTitle>Plans</SectionTitle>
-					<p
-						className={cn(
-							dmSans125ClassName(),
-							"text-[13px] leading-relaxed text-[#A3A3A3]",
-						)}
-					>
-						All plans include usage-metered access. Top-ups roll over with paid
-						plans.
-					</p>
 				</div>
 				<div className="grid gap-4 md:grid-cols-2">
 					{PLAN_CARDS.map((plan) => (

--- a/apps/web/components/settings/billing.tsx
+++ b/apps/web/components/settings/billing.tsx
@@ -849,28 +849,6 @@ export default function Billing() {
 									: "Usage resets with your billing cycle"}
 							</p>
 						</div>
-
-						{!hasPaidPlan ? (
-							<button
-								type="button"
-								onClick={handleUpgrade}
-								disabled={isUpgrading || isCheckingStatus || autumn.isLoading}
-								title={
-									autumn.isLoading && !isUpgrading && !isCheckingStatus
-										? "Loading billing details…"
-										: undefined
-								}
-								className={cn(
-									dmSans125ClassName(),
-									"inline-flex h-10 w-full items-center justify-center gap-2 rounded-[10px] bg-[#0054AD] text-[14px] font-semibold text-[#FAFAFA] transition-colors hover:bg-[#0B65C9] disabled:cursor-not-allowed disabled:opacity-60",
-								)}
-							>
-								{isUpgrading || isCheckingStatus || autumn.isLoading ? (
-									<LoaderIcon className="size-4 animate-spin" />
-								) : null}
-								Upgrade to Pro - $19/month
-							</button>
-						) : null}
 					</div>
 				</SettingsCard>
 			</section>

--- a/apps/web/components/settings/billing.tsx
+++ b/apps/web/components/settings/billing.tsx
@@ -1014,7 +1014,9 @@ export default function Billing() {
 								"inline-flex items-center justify-center gap-2 text-[13px] font-semibold text-[#A3A3A3] transition-colors hover:text-[#FAFAFA]",
 							)}
 						>
-							<span className="underline underline-offset-4">Other plans</span>
+							<span className="relative after:absolute after:right-0 after:-bottom-0.5 after:left-0 after:h-px after:origin-left after:scale-x-0 after:bg-current after:transition-transform after:duration-200 hover:after:scale-x-100">
+								Other plans
+							</span>
 							<span className="translate-x-1 text-[15px]" aria-hidden="true">
 								&rarr;
 							</span>

--- a/apps/web/lib/url-helpers.ts
+++ b/apps/web/lib/url-helpers.ts
@@ -1,4 +1,22 @@
 const PROXY_LOCAL_HOSTS = new Set(["localhost", "127.0.0.1", "::1"])
+const DEV_APP_ORIGIN = "https://app.dev.supermemory.ai"
+const PROD_APP_ORIGIN = "https://app.supermemory.ai"
+
+export function getAppOriginForCurrentEnvironment(hostname?: string): string {
+	const currentHostname =
+		hostname ?? (typeof window !== "undefined" ? window.location.hostname : "")
+	const normalized = currentHostname.toLowerCase()
+	const isLocalOrDev =
+		process.env.NODE_ENV !== "production" ||
+		PROXY_LOCAL_HOSTS.has(normalized) ||
+		normalized.includes("app.dev.supermemory")
+
+	return isLocalOrDev ? DEV_APP_ORIGIN : PROD_APP_ORIGIN
+}
+
+export function getBillingSettingsUrl(hostname?: string): string {
+	return `${getAppOriginForCurrentEnvironment(hostname)}/settings#billing`
+}
 
 /** Reconstruct the browser-facing URL when running behind portless (or similar). */
 export function getPublicRequestUrl(request: Request): URL {


### PR DESCRIPTION
## Summary
- Add a blue Upgrade CTA in the web header immediately before Add memory
- Add a web-styled Free/Pro Plans section to the Billing settings tab using the same plan copy and Pro checkout flow as the existing billing UI.
- Add the Upgrade option to the mobile header menu so the action remains available on small screens.

<img width="1913" height="903" alt="image" src="https://github.com/user-attachments/assets/10663832-526e-4f69-99e8-5945d27ee84c" />
<img width="1912" height="897" alt="image" src="https://github.com/user-attachments/assets/4cf2150a-c098-4c6f-b670-42e034e75b16" />
