### PR TITLE
feat(mcp): add privacy-safe recall receipts

### DIFF
--- a/apps/mcp/src/retrieval-receipt.test.ts
+++ b/apps/mcp/src/retrieval-receipt.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from "vitest"
+import { createRetrievalReceipt, toScoreBucket } from "./retrieval-receipt"
+
+describe("retrieval receipts", () => {
+	it("hashes private values instead of exposing raw query, project, ids, or content", async () => {
+		const receipt = await createRetrievalReceipt({
+			query: "private cardiology PDF notes",
+			containerTag: "secret-client-project",
+			clientInfo: { name: "claude-code", version: "1.2.3" },
+			results: [
+				{
+					id: "mem_sensitive_1",
+					similarity: 0.87,
+					text: "Patient-specific private content",
+				},
+			],
+			total: 3,
+			latencyMs: 42,
+			profile: { staticCount: 2, dynamicCount: 1 },
+		})
+
+		expect(receipt).toMatchObject({
+			event: "memory.search.returned",
+			provider: "supermemory",
+			source: "mcp",
+			activation: "mcp_recall",
+			client: { name: "claude-code", version: "1.2.3" },
+			result: {
+				count: 1,
+				total: 3,
+				scoreBuckets: ["0.8-0.9"],
+			},
+			profile: { staticCount: 2, dynamicCount: 1 },
+			latencyMs: 42,
+			hashAlgorithm: "sha256-prefix-16",
+		})
+
+		expect(receipt.queryHash).toHaveLength(16)
+		expect(receipt.projectIdHash).toHaveLength(16)
+		expect(receipt.result.idsHash).toEqual([
+			expect.stringMatching(/^[a-f0-9]{16}$/),
+		])
+		expect(receipt.result.contentHashes).toEqual([
+			expect.stringMatching(/^[a-f0-9]{16}$/),
+		])
+		expect(JSON.stringify(receipt)).not.toContain("private cardiology")
+		expect(JSON.stringify(receipt)).not.toContain("secret-client-project")
+		expect(JSON.stringify(receipt)).not.toContain("mem_sensitive_1")
+		expect(JSON.stringify(receipt)).not.toContain("Patient-specific")
+	})
+
+	it("keeps score buckets bounded at edges", () => {
+		expect(toScoreBucket(1)).toBe("1.0")
+		expect(toScoreBucket(0)).toBe("0.0-0.1")
+		expect(toScoreBucket(-0.2)).toBe("0.0-0.1")
+		expect(toScoreBucket(0.42)).toBe("0.4-0.5")
+	})
+})

--- a/apps/mcp/src/retrieval-receipt.test.ts
+++ b/apps/mcp/src/retrieval-receipt.test.ts
@@ -32,7 +32,7 @@ describe("retrieval receipts", () => {
 			},
 			profile: { staticCount: 2, dynamicCount: 1 },
 			latencyMs: 42,
-			hashAlgorithm: "sha256-prefix-16",
+			hashAlgorithm: "hmac-sha256-ephemeral-salt-prefix-16",
 		})
 
 		expect(receipt.queryHash).toHaveLength(16)
@@ -47,6 +47,35 @@ describe("retrieval receipts", () => {
 		expect(JSON.stringify(receipt)).not.toContain("secret-client-project")
 		expect(JSON.stringify(receipt)).not.toContain("mem_sensitive_1")
 		expect(JSON.stringify(receipt)).not.toContain("Patient-specific")
+	})
+
+	it("keeps hashes equal within a receipt but unlinkable across receipts", async () => {
+		const args = {
+			query: "repeated query",
+			containerTag: "same-project",
+			results: [
+				{ id: "mem_dup", similarity: 0.5, text: "identical content" },
+				{ id: "mem_dup", similarity: 0.5, text: "identical content" },
+			],
+			latencyMs: 10,
+		}
+
+		const first = await createRetrievalReceipt(args)
+		const second = await createRetrievalReceipt(args)
+
+		// Within one receipt the same value hashes consistently, so duplicates
+		// remain detectable for debugging.
+		expect(first.result.idsHash[0]).toBe(first.result.idsHash[1])
+		expect(first.result.contentHashes[0]).toBe(first.result.contentHashes[1])
+
+		// Across receipts the same private value produces different tokens, so it
+		// cannot be correlated or dictionary-guessed without the ephemeral salt.
+		expect(second.queryHash).not.toBe(first.queryHash)
+		expect(second.projectIdHash).not.toBe(first.projectIdHash)
+		expect(second.result.idsHash[0]).not.toBe(first.result.idsHash[0])
+		expect(second.result.contentHashes[0]).not.toBe(
+			first.result.contentHashes[0],
+		)
 	})
 
 	it("keeps score buckets bounded at edges", () => {

--- a/apps/mcp/src/retrieval-receipt.ts
+++ b/apps/mcp/src/retrieval-receipt.ts
@@ -1,0 +1,103 @@
+export type ReceiptMemoryResult = {
+	id: string
+	similarity: number
+	text: string
+}
+
+export type RetrievalReceipt = {
+	event: "memory.search.returned"
+	provider: "supermemory"
+	source: "mcp"
+	activation: "mcp_recall"
+	client?: {
+		name: string
+		version?: string
+	}
+	projectIdHash?: string
+	queryHash: string
+	result: {
+		count: number
+		total?: number
+		idsHash: string[]
+		scoreBuckets: string[]
+		contentHashes: string[]
+	}
+	profile?: {
+		staticCount: number
+		dynamicCount: number
+	}
+	latencyMs: number
+	hashAlgorithm: "sha256-prefix-16"
+}
+
+type CreateRetrievalReceiptArgs = {
+	query: string
+	containerTag?: string
+	clientInfo?: { name: string; version?: string }
+	results: ReceiptMemoryResult[]
+	total?: number
+	latencyMs: number
+	profile?: {
+		staticCount: number
+		dynamicCount: number
+	}
+}
+
+const HASH_PREFIX_LENGTH = 16
+
+async function hashValue(value: string): Promise<string> {
+	const digest = await crypto.subtle.digest(
+		"SHA-256",
+		new TextEncoder().encode(value),
+	)
+	return [...new Uint8Array(digest)]
+		.map((byte) => byte.toString(16).padStart(2, "0"))
+		.join("")
+		.slice(0, HASH_PREFIX_LENGTH)
+}
+
+export function toScoreBucket(score: number): string {
+	if (score >= 1) return "1.0"
+	if (score <= 0) return "0.0-0.1"
+
+	const lower = Math.floor(score * 10) / 10
+	const upper = lower + 0.1
+	return `${lower.toFixed(1)}-${upper.toFixed(1)}`
+}
+
+export async function createRetrievalReceipt({
+	query,
+	containerTag,
+	clientInfo,
+	results,
+	total,
+	latencyMs,
+	profile,
+}: CreateRetrievalReceiptArgs): Promise<RetrievalReceipt> {
+	const [queryHash, projectIdHash, idsHash, contentHashes] = await Promise.all([
+		hashValue(query),
+		containerTag ? hashValue(containerTag) : Promise.resolve(undefined),
+		Promise.all(results.map((result) => hashValue(result.id))),
+		Promise.all(results.map((result) => hashValue(result.text))),
+	])
+
+	return {
+		event: "memory.search.returned",
+		provider: "supermemory",
+		source: "mcp",
+		activation: "mcp_recall",
+		...(clientInfo ? { client: clientInfo } : {}),
+		...(projectIdHash ? { projectIdHash } : {}),
+		queryHash,
+		result: {
+			count: results.length,
+			...(total === undefined ? {} : { total }),
+			idsHash,
+			scoreBuckets: results.map((result) => toScoreBucket(result.similarity)),
+			contentHashes,
+		},
+		...(profile ? { profile } : {}),
+		latencyMs,
+		hashAlgorithm: "sha256-prefix-16",
+	}
+}

--- a/apps/mcp/src/retrieval-receipt.ts
+++ b/apps/mcp/src/retrieval-receipt.ts
@@ -27,7 +27,7 @@ export type RetrievalReceipt = {
 		dynamicCount: number
 	}
 	latencyMs: number
-	hashAlgorithm: "sha256-prefix-16"
+	hashAlgorithm: "hmac-sha256-ephemeral-salt-prefix-16"
 }
 
 type CreateRetrievalReceiptArgs = {
@@ -44,16 +44,51 @@ type CreateRetrievalReceiptArgs = {
 }
 
 const HASH_PREFIX_LENGTH = 16
+const SALT_BYTES = 32
 
-async function hashValue(value: string): Promise<string> {
-	const digest = await crypto.subtle.digest(
-		"SHA-256",
-		new TextEncoder().encode(value),
+function bytesToHex(bytes: Uint8Array): string {
+	return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join(
+		"",
 	)
-	return [...new Uint8Array(digest)]
-		.map((byte) => byte.toString(16).padStart(2, "0"))
-		.join("")
-		.slice(0, HASH_PREFIX_LENGTH)
+}
+
+/**
+ * Builds a one-time keyed hasher for a single receipt.
+ *
+ * Plain deterministic SHA-256 is not privacy-safe for the values we hash here:
+ * queries, container tags, memory IDs, and (especially short) memory content
+ * are low-entropy, so a raw digest can be dictionary-guessed offline, and the
+ * same value would always produce the same digest and stay linkable across
+ * every receipt forever.
+ *
+ * Instead we key an HMAC with a cryptographically random salt that is generated
+ * per receipt and never emitted. Without the salt an attacker cannot precompute
+ * or brute-force the inputs, and because the salt is fresh for every receipt the
+ * same private value produces a different token each time, so receipts cannot be
+ * correlated against each other. Equality is preserved only within a single
+ * receipt (e.g. duplicate content in one result set), which is what debugging
+ * needs.
+ */
+async function createSaltedHasher(): Promise<
+	(value: string) => Promise<string>
+> {
+	const salt = crypto.getRandomValues(new Uint8Array(SALT_BYTES))
+	const key = await crypto.subtle.importKey(
+		"raw",
+		salt,
+		{ name: "HMAC", hash: "SHA-256" },
+		false,
+		["sign"],
+	)
+
+	return async (value: string): Promise<string> => {
+		const signature = await crypto.subtle.sign(
+			"HMAC",
+			key,
+			new TextEncoder().encode(value),
+		)
+		return bytesToHex(new Uint8Array(signature)).slice(0, HASH_PREFIX_LENGTH)
+	}
 }
 
 export function toScoreBucket(score: number): string {
@@ -74,11 +109,13 @@ export async function createRetrievalReceipt({
 	latencyMs,
 	profile,
 }: CreateRetrievalReceiptArgs): Promise<RetrievalReceipt> {
+	const hash = await createSaltedHasher()
+
 	const [queryHash, projectIdHash, idsHash, contentHashes] = await Promise.all([
-		hashValue(query),
-		containerTag ? hashValue(containerTag) : Promise.resolve(undefined),
-		Promise.all(results.map((result) => hashValue(result.id))),
-		Promise.all(results.map((result) => hashValue(result.text))),
+		hash(query),
+		containerTag ? hash(containerTag) : Promise.resolve(undefined),
+		Promise.all(results.map((result) => hash(result.id))),
+		Promise.all(results.map((result) => hash(result.text))),
 	])
 
 	return {
@@ -98,6 +135,6 @@ export async function createRetrievalReceipt({
 		},
 		...(profile ? { profile } : {}),
 		latencyMs,
-		hashAlgorithm: "sha256-prefix-16",
+		hashAlgorithm: "hmac-sha256-ephemeral-salt-prefix-16",
 	}
 }

--- a/apps/mcp/src/server.ts
+++ b/apps/mcp/src/server.ts
@@ -6,6 +6,7 @@ import {
 	RESOURCE_MIME_TYPE,
 } from "@modelcontextprotocol/ext-apps/server"
 import { SupermemoryClient, getMemoryText } from "./client"
+import { createRetrievalReceipt } from "./retrieval-receipt"
 import { initPosthog, posthog } from "./posthog"
 import { z } from "zod"
 import mcpAppHtml from "../dist/mcp-app.html"
@@ -86,6 +87,13 @@ export class SupermemoryMCP extends McpAgent<Env, unknown, Props> {
 				.max(1000, "Query exceeds maximum length of 1,000 characters")
 				.describe("The search query to find relevant memories"),
 			includeProfile: z.boolean().optional().default(true),
+			includeReceipt: z
+				.boolean()
+				.optional()
+				.default(false)
+				.describe(
+					"Include a privacy-safe retrieval receipt with hashed query, result IDs, and content hashes for debugging",
+				),
 			...(hasRootContainerTag ? {} : containerTagField),
 		})
 
@@ -619,9 +627,15 @@ export class SupermemoryMCP extends McpAgent<Env, unknown, Props> {
 	private async handleRecall(args: {
 		query: string
 		includeProfile?: boolean
+		includeReceipt?: boolean
 		containerTag?: string
 	}) {
-		const { query, includeProfile = true, containerTag } = args
+		const {
+			query,
+			includeProfile = true,
+			includeReceipt = false,
+			containerTag,
+		} = args
 
 		try {
 			const client = this.getClient(containerTag)
@@ -666,12 +680,14 @@ export class SupermemoryMCP extends McpAgent<Env, unknown, Props> {
 				}
 
 				const endTime = Date.now()
+				const searchResults = profileResult.searchResults?.results || []
+				const effectiveContainerTag = containerTag || this.props?.containerTag
 
 				// Track search event
 				posthog
 					.memorySearch({
 						query_length: query.length,
-						results_count: profileResult.searchResults?.results.length || 0,
+						results_count: searchResults.length,
 						search_duration_ms: endTime - startTime,
 						container_tags_count: 1,
 						source: "mcp",
@@ -679,25 +695,50 @@ export class SupermemoryMCP extends McpAgent<Env, unknown, Props> {
 						mcp_client_name: clientInfo?.name,
 						mcp_client_version: clientInfo?.version,
 						sessionId: this.getMcpSessionId(),
-						containerTag: containerTag || this.props?.containerTag,
+						containerTag: effectiveContainerTag,
 					})
 					.catch((error) => console.error("PostHog tracking error:", error))
 
+				const content = [
+					{
+						type: "text" as const,
+						text:
+							parts.length > 0
+								? parts.join("\n")
+								: "No memories or profile found.",
+					},
+				]
+
 				return {
-					content: [
-						{
-							type: "text" as const,
-							text:
-								parts.length > 0
-									? parts.join("\n")
-									: "No memories or profile found.",
-						},
-					],
+					content,
+					...(includeReceipt
+						? {
+								structuredContent: {
+									receipt: await createRetrievalReceipt({
+										query,
+										containerTag: effectiveContainerTag,
+										clientInfo,
+										results: searchResults.map((result) => ({
+											id: result.id,
+											similarity: result.similarity,
+											text: getMemoryText(result),
+										})),
+										total: profileResult.searchResults?.total,
+										latencyMs: endTime - startTime,
+										profile: {
+											staticCount: profileResult.profile.static.length,
+											dynamicCount: profileResult.profile.dynamic.length,
+										},
+									}),
+								},
+							}
+						: {}),
 				}
 			}
 
 			const searchResult = await client.search(query, 10)
 			const endTime = Date.now()
+			const effectiveContainerTag = containerTag || this.props?.containerTag
 
 			// Track search event
 			posthog
@@ -711,13 +752,27 @@ export class SupermemoryMCP extends McpAgent<Env, unknown, Props> {
 					mcp_client_name: clientInfo?.name,
 					mcp_client_version: clientInfo?.version,
 					sessionId: this.getMcpSessionId(),
-					containerTag: containerTag || this.props?.containerTag,
+					containerTag: effectiveContainerTag,
 				})
 				.catch((error) => console.error("PostHog tracking error:", error))
 
 			if (searchResult.results.length === 0) {
 				return {
 					content: [{ type: "text" as const, text: "No memories found." }],
+					...(includeReceipt
+						? {
+								structuredContent: {
+									receipt: await createRetrievalReceipt({
+										query,
+										containerTag: effectiveContainerTag,
+										clientInfo,
+										results: [],
+										total: searchResult.total,
+										latencyMs: endTime - startTime,
+									}),
+								},
+							}
+						: {}),
 				}
 			}
 
@@ -730,7 +785,27 @@ export class SupermemoryMCP extends McpAgent<Env, unknown, Props> {
 				parts.push(getMemoryText(memory))
 			}
 
-			return { content: [{ type: "text" as const, text: parts.join("\n") }] }
+			return {
+				content: [{ type: "text" as const, text: parts.join("\n") }],
+				...(includeReceipt
+					? {
+							structuredContent: {
+								receipt: await createRetrievalReceipt({
+									query,
+									containerTag: effectiveContainerTag,
+									clientInfo,
+									results: searchResult.results.map((result) => ({
+										id: result.id,
+										similarity: result.similarity,
+										text: getMemoryText(result),
+									})),
+									total: searchResult.total,
+									latencyMs: endTime - startTime,
+								}),
+							},
+						}
+					: {}),
+			}
 		} catch (error) {
 			const message =
 				error instanceof Error ? error.message : "An unexpected error occurred"


### PR DESCRIPTION
## Summary

Adds an optional `includeReceipt` flag to the MCP `recall` tool. When enabled, recall responses include a privacy-safe retrieval receipt in `structuredContent.receipt`.

The receipt helps users and maintainers debug cross-client memory retrieval without exposing raw memory text, raw queries, project names, transcripts, or private repository content.

Closes #985.

## What changed

- Added `includeReceipt` to the MCP recall schema.
- Added `createRetrievalReceipt()` helper.
- Receipt includes:
  - hashed query
  - hashed project/container tag
  - hashed result IDs
  - hashed returned memory/chunk content
  - result count / total
  - score buckets
  - latency
  - MCP client name/version when available
  - profile static/dynamic counts when profile recall is used
- Added tests verifying raw private values are not exposed.

## Validation

- `bunx biome check --write apps/mcp/src/server.ts apps/mcp/src/retrieval-receipt.ts apps/mcp/src/retrieval-receipt.test.ts`
- `bunx vitest run src/retrieval-receipt.test.ts`
- `bun run --cwd apps/mcp build:ui`

`bun run check-types` currently fails on existing unrelated `@supermemory/tools` type errors.
