### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/packages/agent-framework-python/README.md
+++ b/packages/agent-framework-python/README.md
@@ -25,7 +25,7 @@ For async HTTP support (recommended):
 ```bash
 uv add supermemory-agent-framework[async]
 # or
-pip install supermemory-agent-framework[async]
+pip install 'supermemory-agent-framework[async]'
 ```
 
 ## Quick Start

--- a/packages/openai-sdk-python/README.md
+++ b/packages/openai-sdk-python/README.md
@@ -23,7 +23,7 @@ For async HTTP support (recommended):
 ```bash
 uv add supermemory-openai-sdk[async]
 # or
-pip install supermemory-openai-sdk[async]
+pip install 'supermemory-openai-sdk[async]'
 ```
 
 ## Quick Start
@@ -416,7 +416,7 @@ Optional for testing:
 
 Install with async support:
 ```bash
-pip install supermemory-openai-sdk[async]
+pip install 'supermemory-openai-sdk[async]'
 ```
 
 ## Development

--- a/skills/supermemory/references/quickstart.md
+++ b/skills/supermemory/references/quickstart.md
@@ -24,7 +24,7 @@ npm install supermemory
 ```bash
 pip install supermemory
 # Or for async support with aiohttp
-pip install supermemory[aiohttp]
+pip install 'supermemory[aiohttp]'
 ```
 
 📦 View on PyPI: [https://pypi.org/project/supermemory/](https://pypi.org/project/supermemory/)

--- a/skills/supermemory/references/sdk-guide.md
+++ b/skills/supermemory/references/sdk-guide.md
@@ -21,7 +21,7 @@ pnpm add supermemory
 ```bash
 pip install supermemory
 # Or for async support with aiohttp
-pip install supermemory[aiohttp]
+pip install 'supermemory[aiohttp]'
 ```
 
 📦 View on PyPI: [https://pypi.org/project/supermemory/](https://pypi.org/project/supermemory/)


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `packages/agent-framework-python/README.md`
- `packages/openai-sdk-python/README.md`
- `skills/supermemory/references/quickstart.md`
- `skills/supermemory/references/sdk-guide.md`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`