### PR TITLE
fix(security): make same-repo gate on claude-auto-fix-ci.yml explicit

### DIFF
--- a/.github/workflows/claude-auto-fix-ci.yml
+++ b/.github/workflows/claude-auto-fix-ci.yml
@@ -15,9 +15,19 @@ permissions:
 
 jobs:
   auto-fix:
+    # Only run when the failing CI run came from a PR pushed to a branch in
+    # *this* repository. workflow_run executes in the base-repo context with
+    # access to repository secrets (CLAUDE_CODE_OAUTH_TOKEN, SUPERMEMORY_API_KEY,
+    # write-scoped GITHUB_TOKEN); checking out arbitrary PR code in that context
+    # is the canonical "pwn request" pattern. github.event.workflow_run.pull_requests
+    # is documented to be empty for fork PRs, but we add an explicit
+    # head_repository == repository check so the security intent is visible in
+    # the workflow file and not dependent on an implicit GitHub-side guarantee.
+    # See https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
     if: |
       github.event.workflow_run.conclusion == 'failure' &&
-      github.event.workflow_run.pull_requests[0]
+      github.event.workflow_run.pull_requests[0] &&
+      github.event.workflow_run.head_repository.full_name == github.event.workflow_run.repository.full_name
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code


### PR DESCRIPTION
## Summary

`.github/workflows/claude-auto-fix-ci.yml` runs on `workflow_run` after the public-input CI workflow completes, then checks out PR code (`ref: github.event.workflow_run.head_branch`) and runs `bun install` + Claude with `Bash(*)` in a context that has access to repository secrets (`CLAUDE_CODE_OAUTH_TOKEN`, `SUPERMEMORY_API_KEY`, write-scoped `GITHUB_TOKEN`). This is the canonical "pwn request" pattern documented by GitHub Security Lab — checking out untrusted code in a privileged workflow.

The existing gate `github.event.workflow_run.pull_requests[0]` happens to be empty for fork PRs today (documented GitHub behavior), but the security boundary is implicit and brittle to future GitHub behavior changes. This PR makes the boundary explicit.

## Impact

In the current implementation, with a `workflow_run` trigger plus untrusted-PR checkout plus `bun install`, a PR whose package manifest carries a `postinstall` script would execute that script in the privileged workflow context. Today the implicit guard prevents that for fork PRs; the addition here makes the same guarantee explicit and surface-visible so the security intent doesn't depend on a documented-but-non-contractual GitHub behavior.

Residual risk (out of scope for this PR): the workflow still trusts collaborators who can push branches to this repository. That trust boundary is intentional — auto-fix has to be able to read and modify PR code by design — but is worth documenting separately in a SECURITY.md or contributor guide.

## Location

`.github/workflows/claude-auto-fix-ci.yml:18-31`

## Fix

Adds an explicit head-repository identity check to the job-level `if:` condition:

```yaml
github.event.workflow_run.head_repository.full_name == github.event.workflow_run.repository.full_name
```

This means the job only runs when the failing CI run originated from a branch in *this* repository, not a fork. Same behavior as today via the implicit `pull_requests[0]` guard, but encoded as a first-class gate that any future workflow editor will see and not accidentally remove.

A multi-line YAML comment above the condition documents the threat model and links to the GitHub Security Lab article on pwn-request mitigation, so the next person to touch this file understands why the gate exists.

## Detected by

Aeon + Semgrep `p/security-audit` (rule `yaml.github-actions.security.workflow-run-target-code-checkout`).

- Severity: medium (defense-in-depth — the implicit `pull_requests[0]` gate covers the most exploitable fork-PR case today, but the explicit gate removes the reliance on undocumented behavior)
- CWE-913 (Improper Control of Dynamically-Managed Code Resources)

## Verification

`python3 -c "import yaml; yaml.safe_load(open('claude-auto-fix-ci.yml'))"` parses cleanly. The `if:` condition still triggers on the intended same-repo failing-PR case (verified by re-reading the parsed condition in the YAML AST). All steps, permissions, and secrets references unchanged.

---

Filed by [Aeon](https://github.com/aaronjmars/aeon-aaron).
