### PR TITLE
Fix plugin logos and recent rows for saved OpenClaw/Hermes memories

### DIFF
--- a/apps/web/components/dashboard-view.tsx
+++ b/apps/web/components/dashboard-view.tsx
@@ -40,6 +40,7 @@ import {
 	type Profession,
 } from "@/hooks/use-personalization"
 import { normalizePluginClientId } from "@/lib/plugin-catalog"
+import { detectPluginSpace } from "@/lib/plugin-space"
 
 type DocumentsResponse = z.infer<typeof DocumentsWithMemoriesResponseSchema>
 type DocumentWithMemories = DocumentsResponse["documents"][0]
@@ -443,6 +444,23 @@ function hasClaudeCodeContainer(document: DocumentWithMemories): boolean {
 	)
 }
 
+function getPluginClientFromSpace(
+	document: DocumentWithMemories,
+): string | null {
+	const containerTags =
+		(document as { containerTags?: string[] }).containerTags ?? []
+	const memorySpaceTags = (document.memoryEntries ?? [])
+		.map((entry) => entry.spaceContainerTag)
+		.filter((tag): tag is string => !!tag)
+
+	for (const tag of [...containerTags, ...memorySpaceTags]) {
+		const plugin = detectPluginSpace(tag)
+		if (plugin) return normalizePluginClientId(plugin.pluginId)
+	}
+
+	return null
+}
+
 function getPluginClientFromDocument(
 	document: DocumentWithMemories,
 ): string | null {
@@ -461,6 +479,9 @@ function getPluginClientFromDocument(
 	}
 
 	if (hasClaudeCodeContainer(document)) return "claude_code"
+
+	const pluginClientFromSpace = getPluginClientFromSpace(document)
+	if (pluginClientFromSpace) return pluginClientFromSpace
 
 	const content = getDocumentText(document)
 	const title = document.title ?? ""
@@ -689,6 +710,26 @@ function parseToolUsage(
 	}
 
 	// Attach latest document info to plugin items where available from MCP documents
+	for (const [pluginId, docInfo] of latestDocPerPlugin) {
+		const itemKey = `plugin_${pluginId}`
+		if (toolMap.has(itemKey)) continue
+
+		const catalog = PLUGIN_DISPLAY_CATALOG[pluginId]
+		toolMap.set(itemKey, {
+			id: itemKey,
+			name: catalog?.name ?? docInfo.title,
+			type: "Plugin",
+			icon: catalog?.icon ?? null,
+			lastUsedAt: docInfo.at,
+			hasBeenUsed: true,
+			connectedAt: null,
+			lastDocumentTitle: null,
+			lastDocumentId: null,
+			lastDocumentPreview: null,
+			lastDocument: null,
+		})
+	}
+
 	for (const [, item] of toolMap) {
 		if (item.type === "Plugin" && !item.lastDocumentTitle) {
 			const pluginId = item.id.replace(/^plugin_/, "")

--- a/apps/web/lib/plugin-document.ts
+++ b/apps/web/lib/plugin-document.ts
@@ -456,6 +456,34 @@ function parseRoleBlockTranscript(
 	}
 }
 
+function parsePluginSpaceNote(
+	document: DocumentWithMemories,
+	content: string,
+	plugin: PluginIdentity | null,
+): ParsedPluginDocument | null {
+	if (!plugin) return null
+
+	const summary = typeof document.summary === "string" ? document.summary : ""
+	const memoryText = firstMemoryEntryText(document)
+	const preview = takePreview(memoryText || summary || content, 220)
+
+	return {
+		kind: plugin.pluginId === "codex" ? "codex-save" : "plugin-save",
+		pluginLabel: plugin.label,
+		pluginIconSrc: plugin.iconSrc ?? undefined,
+		formatLabel: "Note",
+		title:
+			(typeof document.title === "string" && document.title.trim()) ||
+			`${plugin.label} memory`,
+		preview,
+		summary: takePreview(summary || memoryText || content, 220),
+		artifacts: [],
+		messages: [],
+		sections: [],
+		rawContent: content,
+	}
+}
+
 function withIcon(
 	parsed: ParsedPluginDocument | null,
 ): ParsedPluginDocument | null {
@@ -693,6 +721,9 @@ export function parsePluginDocument(
 		const roleBlockSession = parseRoleBlockTranscript(content, plugin)
 		if (roleBlockSession) return withIcon(roleBlockSession)
 	}
+
+	const pluginSpaceNote = parsePluginSpaceNote(document, content, plugin)
+	if (pluginSpaceNote) return withIcon(pluginSpaceNote)
 
 	return withIcon(parseClaudeCodeByMetadata(document, metadata))
 }


### PR DESCRIPTION
This fixes plugin attribution for memories saved inside plugin spaces like OpenClaw and Hermes.

Previously, some saved memories showed up as plain generic notes even though they belonged to a plugin space. This happened mostly for memories saved directly through a save tool, because those notes did not always have the transcript-style content that the frontend parser expected.

Also fixes Recents section on main dashboard to render all plugins