### PR TITLE
fix(nova): keep user message when stopping generation early

### DIFF
--- a/apps/web/components/chat/index.tsx
+++ b/apps/web/components/chat/index.tsx
@@ -563,16 +563,11 @@ export function ChatSidebar({
 		}
 	}
 
-	// When the user stops generation before any assistant response arrives,
-	// remove the dangling user message so it isn't duplicated on the next send.
+	// Keep the user message on stop so it isn't lost when generation is halted
+	// before any assistant response arrives (ENG-732).
 	const handleStop = useCallback(() => {
 		stop()
-		setMessages((prev) => {
-			const last = prev[prev.length - 1]
-			if (last?.role === "user") return prev.slice(0, -1)
-			return prev
-		})
-	}, [stop, setMessages])
+	}, [stop])
 
 	const handleCopyMessage = useCallback((messageId: string, text: string) => {
 		analytics.chatMessageCopied({ message_id: messageId })


### PR DESCRIPTION
Clicking stop before the first assistant token streamed in deleted the triggering user message: handleStop unconditionally sliced off a trailing user message, which during the submitted/thinking window is the user's own
message. Drop the slice so the message is preserved on stop.

ENG-732