### PR TITLE
fix(openai-sdk): use AsyncSupermemory and correct client API calls

### DIFF
--- a/packages/openai-sdk-python/pyproject.toml
+++ b/packages/openai-sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "supermemory-openai-sdk"
-version = "1.0.3"
+version = "1.0.4"
 description = "Memory tools for OpenAI function calling with supermemory"
 readme = "README.md"
 license = "MIT"

--- a/packages/openai-sdk-python/src/supermemory_openai/middleware.py
+++ b/packages/openai-sdk-python/src/supermemory_openai/middleware.py
@@ -230,7 +230,7 @@ async def add_memory_tool(
             add_params["custom_id"] = custom_id
 
         # Handle both sync and async supermemory clients
-        result = client.add(**add_params)
+        result = client.memories.add(**add_params)
         if inspect.isawaitable(result):
             response = await result
         else:

--- a/packages/openai-sdk-python/src/supermemory_openai/tools.py
+++ b/packages/openai-sdk-python/src/supermemory_openai/tools.py
@@ -125,7 +125,7 @@ class SupermemoryTools:
         if config.get("base_url"):
             client_kwargs["base_url"] = config["base_url"]
 
-        self.client = supermemory.Supermemory(**client_kwargs)
+        self.client = supermemory.AsyncSupermemory(**client_kwargs)
 
         # Set container tags
         if config.get("project_id"):
@@ -197,7 +197,7 @@ class SupermemoryTools:
 
             return MemorySearchResult(
                 success=True,
-                results=response.results,
+                results=[r.model_dump() for r in response.results],
                 count=len(response.results),
             )
         except (OSError, ConnectionError) as network_error:
@@ -221,20 +221,16 @@ class SupermemoryTools:
             MemoryAddResult
         """
         try:
-            metadata: Dict[str, object] = {}
-
             add_params = {
                 "content": memory,
                 "container_tags": self.container_tags,
             }
-            if metadata:
-                add_params["metadata"] = metadata
 
-            response: MemoryAddResponse = await self.client.add(**add_params)
+            response: MemoryAddResponse = await self.client.memories.add(**add_params)
 
             return MemoryAddResult(
                 success=True,
-                memory=response,
+                memory=response.model_dump(),
             )
         except (OSError, ConnectionError) as network_error:
             return MemoryAddResult(

--- a/packages/openai-sdk-python/tests/test_tools.py
+++ b/packages/openai-sdk-python/tests/test_tools.py
@@ -12,8 +12,7 @@ load_dotenv()
 
 # Import from the installed package or src directly
 try:
-    # Try importing from the installed package first
-    from supermemory_openai_sdk import (
+    from supermemory_openai import (
         SupermemoryTools,
         SupermemoryToolsConfig,
         create_supermemory_tools,
@@ -23,13 +22,14 @@ try:
         create_add_memory_tool,
     )
 except ImportError:
-    # Fallback to importing from src directory
     import sys
     import os
 
-    # Add src directory to path
-    sys.path.insert(0, os.path.join(os.path.dirname(os.path.dirname(__file__)), "src"))
-    from tools import (
+    sys.path.insert(
+        0,
+        os.path.join(os.path.dirname(os.path.dirname(__file__)), "src"),
+    )
+    from supermemory_openai.tools import (
         SupermemoryTools,
         SupermemoryToolsConfig,
         create_supermemory_tools,


### PR DESCRIPTION
The openai-sdk `SupermemoryTools` class initializes a sync `Supermemory()` client but all its methods are `async` and `await` it `TypeError` at runtime. On top of that, every `.add()` call targets the top-level client, but `AsyncSupermemory` exposes `add()` on the `.memories` sub-resource (`client.memories.add(...)`). Confirmed locally with the installed SDK:

    `client.add(...)` raises `AttributeError: 'AsyncSupermemory' object has no attribute 'add'`
    `client.memories.add(...)` works correctly
    `client.memories` exists, `client` does not have `add`

That missing method means every memory-add call silently hits the `except Exception` handler and returns `{"success": false, "error": "..."}`. Even if it did reach the API, the raw Pydantic response gets fed to `json.dumps()` without `.model_dump()`  another `TypeError`.

This rewrites the client init to use `AsyncSupermemory`, changes all `.add()` calls to `.memories.add()`, and calls `.model_dump()` on Pydantic responses before serialization. Test imports are also fixed  ,the first fallback referenced a non-existent package name (`supermemory_openai_sdk`) and the second used a wrong module path.
