### PR TITLE
Add Cursor & granola plugin card in Integrations page

### DIFF
--- a/apps/web/components/integrations-view.tsx
+++ b/apps/web/components/integrations-view.tsx
@@ -16,7 +16,13 @@ import {
 	AppleShortcutsIcon,
 	RaycastIcon,
 } from "@/components/integration-icons"
-import { GoogleDrive, Notion, OneDrive, MCPIcon } from "@ui/assets/icons"
+import {
+	GoogleDrive,
+	Notion,
+	OneDrive,
+	MCPIcon,
+	Granola,
+} from "@ui/assets/icons"
 import * as DialogPrimitive from "@radix-ui/react-dialog"
 import {
 	ArrowLeft,
@@ -57,10 +63,11 @@ import {
 } from "@/lib/plugin-catalog"
 import { INSET, InstallSteps, PillButton } from "./integrations/install-steps"
 import { MCPSteps } from "./mcp-modal/mcp-detail-view"
+import { GranolaConnectModal } from "./granola-connect-modal"
 
 type Connection = z.infer<typeof ConnectionResponseSchema>
 
-type ConnectorProvider = "google-drive" | "notion" | "onedrive"
+type ConnectorProvider = "google-drive" | "notion" | "onedrive" | "granola"
 
 interface ConnectedKey {
 	keyId: string
@@ -276,6 +283,7 @@ interface BaseItem {
 	icon: ReactNode
 	docsUrl?: string
 	pro?: boolean
+	max?: boolean
 	kind: ItemKind
 	simpleTitle?: string
 	dev?: boolean
@@ -403,6 +411,16 @@ const SECTIONS: Array<{
 				icon: <OneDrive className="size-6" />,
 				pro: true,
 			},
+			{
+				kind: "connector",
+				id: "granola",
+				provider: "granola",
+				name: "Granola",
+				tagline: "Sync AI meeting notes into your memory",
+				simpleTitle: "Your meeting notes, ready to recall",
+				icon: <Granola className="size-6" />,
+				max: true,
+			},
 		],
 	},
 	{
@@ -493,7 +511,7 @@ export function DetailWrapper({
 	)
 }
 
-function ProChip() {
+function ProChip({ children = "Pro" }: { children?: ReactNode }) {
 	return (
 		<span
 			className={cn(
@@ -501,7 +519,7 @@ function ProChip() {
 				"ml-auto shrink-0 pl-2 text-[10px] font-semibold uppercase tracking-wide text-[#4BA0FA]",
 			)}
 		>
-			Pro
+			{children}
 		</span>
 	)
 }
@@ -634,6 +652,7 @@ function ItemCard({
 	name,
 	tagline,
 	pro,
+	max,
 	isNew,
 	docsUrl,
 	leftIndicator,
@@ -643,6 +662,7 @@ function ItemCard({
 	name: string
 	tagline: string
 	pro?: boolean
+	max?: boolean
 	isNew?: boolean
 	docsUrl?: string
 	leftIndicator?: ReactNode
@@ -681,7 +701,7 @@ function ItemCard({
 							{name}
 						</span>
 						{isNew && <NewChip />}
-						{pro && <ProChip />}
+						{max ? <ProChip>Max</ProChip> : pro && <ProChip />}
 					</div>
 					<p
 						className={cn(
@@ -1081,11 +1101,13 @@ export function IntegrationsView() {
 	const { org } = useAuth()
 	const autumn = useCustomer()
 	const hasProProduct = hasActivePlan(autumn.data?.subscriptions, "api_pro")
+	const hasMaxProduct = hasActivePlan(autumn.data?.subscriptions, "api_max")
 	const isAutumnLoading = autumn.isLoading
 
 	const [connectingPlugin, setConnectingPlugin] = useState<string | null>(null)
 	const [connectingProvider, setConnectingProvider] =
 		useState<ConnectorProvider | null>(null)
+	const [granolaModalOpen, setGranolaModalOpen] = useState(false)
 	const [newKey, setNewKey] = useState<{
 		open: boolean
 		key: string
@@ -1188,6 +1210,7 @@ export function IntegrationsView() {
 			"google-drive": [],
 			notion: [],
 			onedrive: [],
+			granola: [],
 		}
 		for (const c of connections) {
 			const p = c.provider as ConnectorProvider
@@ -1276,10 +1299,10 @@ export function IntegrationsView() {
 		}
 	}
 
-	const handleUpgrade = async () => {
+	const handleUpgrade = async (planId: "api_pro" | "api_max" = "api_pro") => {
 		try {
 			const result = await autumn.attach({
-				planId: "api_pro",
+				planId,
 				successUrl: `${window.location.origin}/?view=integrations`,
 			})
 			if (result?.paymentUrl) {
@@ -1583,7 +1606,9 @@ export function IntegrationsView() {
 			}
 			case "connector": {
 				const count = connectionsByProvider[item.provider].length
-				const needsProUpgrade = !isAutumnLoading && !hasProProduct
+				const isGranola = item.provider === "granola"
+				const needsPlanUpgrade =
+					!isAutumnLoading && (isGranola ? !hasMaxProduct : !hasProProduct)
 				if (count > 0) {
 					return (
 						<div className="flex w-full items-center justify-between gap-2">
@@ -1594,6 +1619,14 @@ export function IntegrationsView() {
 								title="Add another knowledge source"
 								onClick={() => {
 									trackCard(item)
+									if (isGranola) {
+										if (!hasMaxProduct) {
+											handleUpgrade("api_max")
+											return
+										}
+										setGranolaModalOpen(true)
+										return
+									}
 									void setAddDoc("connect")
 								}}
 								className={cn(
@@ -1606,9 +1639,11 @@ export function IntegrationsView() {
 						</div>
 					)
 				}
-				if (needsProUpgrade) {
+				if (needsPlanUpgrade) {
 					return (
-						<PillButton onClick={handleUpgrade}>
+						<PillButton
+							onClick={() => handleUpgrade(isGranola ? "api_max" : "api_pro")}
+						>
 							<Zap className="size-3.5 text-[#4BA0FA]" /> Upgrade
 						</PillButton>
 					)
@@ -1618,6 +1653,14 @@ export function IntegrationsView() {
 					<PillButton
 						onClick={() => {
 							trackCard(item)
+							if (isGranola) {
+								if (!hasMaxProduct) {
+									handleUpgrade("api_max")
+									return
+								}
+								setGranolaModalOpen(true)
+								return
+							}
 							addConnectionMutation.mutate(item.provider)
 						}}
 						disabled={!!connectingProvider}
@@ -1700,6 +1743,7 @@ export function IntegrationsView() {
 			name={item.name}
 			tagline={item.tagline}
 			pro={item.pro}
+			max={item.max}
 			isNew={item.isNew}
 			docsUrl={item.docsUrl}
 			leftIndicator={renderLeftIndicator(item)}
@@ -2243,6 +2287,11 @@ export function IntegrationsView() {
 					</div>
 				</DialogContent>
 			</Dialog>
+
+			<GranolaConnectModal
+				open={granolaModalOpen}
+				onOpenChange={setGranolaModalOpen}
+			/>
 		</div>
 	)
 }

--- a/apps/web/components/integrations-view.tsx
+++ b/apps/web/components/integrations-view.tsx
@@ -210,6 +210,7 @@ function mcpClientIconSrc(key: MCPClientKey): string {
 const PLUGIN_SIMPLE_TITLES: Record<string, string> = {
 	claude_code: "Remembers your code conventions and decisions",
 	codex: "Codex sessions that remember your project",
+	cursor: "Cursor sessions with persistent project memory",
 	opencode: "OpenCode with persistent project memory",
 	openclaw: "Save chats from Telegram, Discord and Slack",
 	hermes: "Persistent memory for the Hermes agent",

--- a/apps/web/lib/plugin-catalog.ts
+++ b/apps/web/lib/plugin-catalog.ts
@@ -77,22 +77,36 @@ export const PLUGIN_CATALOG: Record<string, PluginInfo> = {
 	cursor: {
 		id: "cursor",
 		name: "Cursor",
-		tagline: "Persistent memory for your Cursor coding sessions",
+		tagline: "Persistent memory, session hooks, and MCP tools inside Cursor",
 		icon: "/images/plugins/cursor.png",
-		docsUrl: "https://docs.supermemory.ai/supermemory-mcp/setup#cursor",
+		docsUrl: "https://github.com/supermemoryai/cursor-supermemory#readme",
+		githubUrl: "https://github.com/supermemoryai/cursor-supermemory",
 		installSteps: [
 			{
-				title: "Add Supermemory to Cursor",
+				title: "Install the Cursor plugin",
 				description:
-					"Paste this into ~/.cursor/mcp.json. This key is shown only once â€” save it now.",
-				code: '{\n  "mcpServers": {\n    "supermemory": {\n      "url": "https://mcp.supermemory.ai/mcp",\n      "headers": {\n        "Authorization": "Bearer sm_..."\n      }\n    }\n  }\n}',
-				copyLabel: "Cursor config",
+					"Install cursor-supermemory from the Cursor Marketplace, then run the auth command on the machine where Cursor runs.",
+				code: "bunx cursor-supermemory@latest login",
+				copyLabel: "Login command",
+			},
+			{
+				title: "Finish browser authentication",
+				description:
+					"The login command opens Supermemory in your browser and stores Cursor credentials in ~/.supermemory-cursor/credentials.json.",
+			},
+			{
+				title: "Manual API-key fallback",
+				description:
+					"If browser login is not available, set this environment variable before starting Cursor. This key is shown only once - save it now.",
+				code: 'export SUPERMEMORY_API_KEY="sm_..."',
+				copyLabel: "API key command",
 				secret: true,
+				optional: true,
 			},
 			{
 				title: "Restart Cursor",
 				description:
-					"Restart Cursor so it reloads the MCP server configuration.",
+					"Restart Cursor after installing or changing credentials so the plugin hooks and MCP tools are loaded.",
 			},
 		],
 	},

--- a/apps/web/lib/plugin-catalog.ts
+++ b/apps/web/lib/plugin-catalog.ts
@@ -74,6 +74,28 @@ export const PLUGIN_CATALOG: Record<string, PluginInfo> = {
 			},
 		],
 	},
+	cursor: {
+		id: "cursor",
+		name: "Cursor",
+		tagline: "Persistent memory for your Cursor coding sessions",
+		icon: "/images/plugins/cursor.png",
+		docsUrl: "https://docs.supermemory.ai/supermemory-mcp/setup#cursor",
+		installSteps: [
+			{
+				title: "Add Supermemory to Cursor",
+				description:
+					"Paste this into ~/.cursor/mcp.json. This key is shown only once â€” save it now.",
+				code: '{\n  "mcpServers": {\n    "supermemory": {\n      "url": "https://mcp.supermemory.ai/mcp",\n      "headers": {\n        "Authorization": "Bearer sm_..."\n      }\n    }\n  }\n}',
+				copyLabel: "Cursor config",
+				secret: true,
+			},
+			{
+				title: "Restart Cursor",
+				description:
+					"Restart Cursor so it reloads the MCP server configuration.",
+			},
+		],
+	},
 	opencode: {
 		id: "opencode",
 		name: "OpenCode",
@@ -143,6 +165,7 @@ export const PLUGIN_CATALOG: Record<string, PluginInfo> = {
 const SPACE_TO_CATALOG_ID: Record<string, string> = {
 	"claude-code": "claude_code",
 	codex: "codex",
+	cursor: "cursor",
 	opencode: "opencode",
 	openclaw: "openclaw",
 	hermes: "hermes",


### PR DESCRIPTION
## Summary
- Add Cursor to the shared web plugin catalog so it appears with the other plugin cards.
- Reuse the existing Cursor image asset/
- Add the matching simple title used by the integrations grid.

<img width="1917" height="907" alt="image" src="https://github.com/user-attachments/assets/ba31df60-98da-4d43-a63d-9d819139eb98" />
