### PR TITLE
fix(web): load space profile from profile API

### DIFF
--- a/apps/web/hooks/use-space-profile.ts
+++ b/apps/web/hooks/use-space-profile.ts
@@ -1,10 +1,19 @@
 import { useQuery } from "@tanstack/react-query"
-import { $fetch } from "@lib/api"
 import { useAuth } from "@lib/auth-context"
 
 export type SpaceProfile = {
 	static: string[]
 	dynamic: string[]
+}
+
+const API_BASE =
+	process.env.NEXT_PUBLIC_BACKEND_URL ?? "https://api.supermemory.ai"
+
+type SpaceProfileResponse = {
+	profile?: {
+		static?: string[] | null
+		dynamic?: string[] | null
+	} | null
 }
 
 export function useSpaceProfile(containerTag: string) {
@@ -14,21 +23,32 @@ export function useSpaceProfile(containerTag: string) {
 	return useQuery({
 		queryKey: ["space-profile", orgId, containerTag],
 		queryFn: async (): Promise<SpaceProfile> => {
-			const response = await $fetch(
-				"@get/container-tags/:containerTag/profile",
-				{
-					params: { containerTag },
+			const response = await fetch(`${API_BASE}/v4/profile`, {
+				method: "POST",
+				credentials: "include",
+				headers: {
+					"Content-Type": "application/json",
+					"X-App-Source": "nova",
 				},
-			)
-			if (response.error) {
+				body: JSON.stringify({ containerTag }),
+			})
+
+			if (!response.ok) {
+				const body = (await response.json().catch(() => ({}))) as {
+					error?: string
+					message?: string
+				}
 				throw new Error(
-					response.error.message || "Failed to load space profile",
+					body.message ?? body.error ?? "Failed to load space profile",
 				)
 			}
-			const profile = response.data.profile
+
+			const data = (await response.json()) as SpaceProfileResponse
+			const profile = data.profile
+
 			return {
-				static: profile.static ?? [],
-				dynamic: profile.dynamic ?? [],
+				static: profile?.static ?? [],
+				dynamic: profile?.dynamic ?? [],
 			}
 		},
 		enabled: !!orgId && !!containerTag,


### PR DESCRIPTION
## Summary
- Load Space Profile data from the stable /v4/profile endpoint with the selected containerTag
- Normalize missing/null profile arrays to empty arrays so the panel can render empty state safely

<img width="1680" height="1012" alt="User attachment" src="https://github.com/user-attachments/assets/605abb75-6d7e-4adf-9ef6-39f87d81a177" />

