### PR TITLE
fix(web): harden integrations upgrade plan id

### DIFF
--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -92,7 +92,7 @@ export default function RootLayout({
 							process.env.NEXT_PUBLIC_BACKEND_URL ??
 							"https://api.supermemory.ai"
 						}
-						includeCredentials={true}
+						useBetterAuth={true}
 						headers={{ "X-App-Source": "nova" }}
 					>
 						<QueryProvider>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -92,7 +92,7 @@ export default function RootLayout({
 							process.env.NEXT_PUBLIC_BACKEND_URL ??
 							"https://api.supermemory.ai"
 						}
-						useBetterAuth={true}
+						includeCredentials={true}
 						headers={{ "X-App-Source": "nova" }}
 					>
 						<QueryProvider>

--- a/apps/web/components/add-document/connections.tsx
+++ b/apps/web/components/add-document/connections.tsx
@@ -328,11 +328,11 @@ export function ConnectContent({ selectedProject }: ConnectContentProps) {
 	const projects = (queryClient.getQueryData<Project[]>(["projects"]) ||
 		[]) as Project[]
 
-	const handleUpgrade = async () => {
+	const handleUpgrade = async (planId: "api_pro" | "api_max" = "api_pro") => {
 		setIsUpgrading(true)
 		try {
 			const result = await autumn.attach({
-				planId: "api_pro",
+				planId,
 				successUrl: window.location.href,
 			})
 			if (result?.paymentUrl) {
@@ -614,11 +614,21 @@ export function ConnectContent({ selectedProject }: ConnectContentProps) {
 												</span>
 											)}
 											<Button
-												onClick={() => setGranolaModalOpen(true)}
-												disabled={!isMaxUser}
+												onClick={() => {
+													if (!isMaxUser) {
+														handleUpgrade("api_max")
+														return
+													}
+													setGranolaModalOpen(true)
+												}}
+												disabled={isUpgrading || autumn.isLoading}
 												className="bg-[#4BA0FA] text-black hover:bg-[#4BA0FA]/90 text-[14px] font-medium px-3 py-1.5 h-8"
 											>
-												Connect
+												{!isMaxUser
+													? isUpgrading || autumn.isLoading
+														? "Upgrading..."
+														: "Upgrade"
+													: "Connect"}
 											</Button>
 										</>
 									) : (
@@ -783,8 +793,14 @@ export function ConnectContent({ selectedProject }: ConnectContentProps) {
 											</div>
 										</DropdownMenuItem>
 										<DropdownMenuItem
-											disabled={!isMaxUser}
-											onClick={() => setGranolaModalOpen(true)}
+											disabled={isUpgrading || autumn.isLoading}
+											onClick={() => {
+												if (!isMaxUser) {
+													handleUpgrade("api_max")
+													return
+												}
+												setGranolaModalOpen(true)
+											}}
 											className="flex items-start gap-2.5 px-3 py-2.5 rounded-md cursor-pointer text-white opacity-60 hover:opacity-100 hover:bg-[#293952]/40 focus:bg-[#293952]/40 focus:opacity-100 data-disabled:opacity-40 data-disabled:cursor-not-allowed data-disabled:hover:bg-transparent"
 										>
 											<Granola className="size-5 mt-0.5 shrink-0" />
@@ -798,7 +814,9 @@ export function ConnectContent({ selectedProject }: ConnectContentProps) {
 													)}
 												</span>
 												<span className="text-[11px] text-[#737373] leading-tight">
-													Meeting notes & transcripts
+													{isMaxUser
+														? "Meeting notes & transcripts"
+														: "Upgrade to Max"}
 												</span>
 											</div>
 										</DropdownMenuItem>

--- a/apps/web/components/integrations-view.tsx
+++ b/apps/web/components/integrations-view.tsx
@@ -2427,6 +2427,12 @@ export function IntegrationsView({
 
 	const handleUpgrade = async (planId?: unknown) => {
 		const checkoutPlanId = planId === "api_max" ? "api_max" : "api_pro"
+		if (publicMode || !org) {
+			const loginUrl = new URL("/login", window.location.origin)
+			loginUrl.searchParams.set("redirect", window.location.href)
+			window.location.assign(loginUrl.toString())
+			return
+		}
 		try {
 			const result = await autumn.attach({
 				planId: checkoutPlanId,

--- a/apps/web/components/integrations-view.tsx
+++ b/apps/web/components/integrations-view.tsx
@@ -2427,12 +2427,6 @@ export function IntegrationsView({
 
 	const handleUpgrade = async (planId?: unknown) => {
 		const checkoutPlanId = planId === "api_max" ? "api_max" : "api_pro"
-		if (publicMode || !org) {
-			const loginUrl = new URL("/login", window.location.origin)
-			loginUrl.searchParams.set("redirect", window.location.href)
-			window.location.assign(loginUrl.toString())
-			return
-		}
 		try {
 			const result = await autumn.attach({
 				planId: checkoutPlanId,

--- a/apps/web/components/integrations-view.tsx
+++ b/apps/web/components/integrations-view.tsx
@@ -2425,10 +2425,11 @@ export function IntegrationsView({
 		}
 	}
 
-	const handleUpgrade = async (planId: "api_pro" | "api_max" = "api_pro") => {
+	const handleUpgrade = async (planId?: unknown) => {
+		const checkoutPlanId = planId === "api_max" ? "api_max" : "api_pro"
 		try {
 			const result = await autumn.attach({
-				planId,
+				planId: checkoutPlanId,
 				successUrl: `${window.location.origin}/?view=integrations`,
 			})
 			if (result?.paymentUrl) {
@@ -2741,7 +2742,7 @@ export function IntegrationsView({
 				}
 				if (claudeCodeConnected) return
 				if (claudeCodeNeedsPro) {
-					handleUpgrade()
+					handleUpgrade("api_pro")
 					return
 				}
 				createPluginKeyMutation.mutate("claude_code")
@@ -2818,7 +2819,7 @@ export function IntegrationsView({
 							title="Connect another agent"
 							onClick={() => {
 								if (needsProUpgrade) {
-									handleUpgrade()
+									handleUpgrade("api_pro")
 									return
 								}
 								trackCard(item)
@@ -2850,7 +2851,7 @@ export function IntegrationsView({
 				}
 				if (needsProUpgrade) {
 					return (
-						<PillButton onClick={() => handleUpgrade()}>
+						<PillButton onClick={() => handleUpgrade("api_pro")}>
 							<Zap className="size-3.5 text-[#4BA0FA]" /> Upgrade
 						</PillButton>
 					)
@@ -3020,7 +3021,7 @@ export function IntegrationsView({
 						<PillButton
 							onClick={() => {
 								if (needsProUpgrade) {
-									handleUpgrade()
+									handleUpgrade("api_pro")
 									return
 								}
 								trackCard(item)
@@ -3465,7 +3466,7 @@ export function IntegrationsView({
 					</div>
 					<div className="flex shrink-0 items-center justify-between gap-2">
 						{connectedDialogNeedsPro ? (
-							<PillButton onClick={() => handleUpgrade()}>
+							<PillButton onClick={() => handleUpgrade("api_pro")}>
 								<Zap className="size-3.5 text-[#4BA0FA]" /> Upgrade to connect
 								more
 							</PillButton>

--- a/apps/web/components/integrations-view.tsx
+++ b/apps/web/components/integrations-view.tsx
@@ -2844,6 +2844,11 @@ export function IntegrationsView({
 						<FinishSetupButton
 							onClick={() => {
 								trackCard(item)
+								if (!PLUGIN_CATALOG[item.pluginId]?.usesOAuth) {
+									if (connectingPlugin) return
+									createPluginKeyMutation.mutate(item.pluginId)
+									return
+								}
 								setFinishSetupPluginId(item.pluginId)
 							}}
 						/>


### PR DESCRIPTION
## Summary
- Normalize integrations checkout plan IDs so unexpected click-event arguments fall back to `api_pro`
- Pass `api_pro` explicitly from plugin upgrade paths while preserving `api_max` for Granola


<img width="1603" height="873" alt="image" src="https://github.com/user-attachments/assets/c8c6b212-05f5-43c7-953e-4255277f5683" />
