### PR TITLE
docs(readme): add Supermemory local — self-hosted binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@
 <p align="center">
   <a href="https://supermemory.ai/docs">Docs</a> ·
   <a href="https://supermemory.ai/docs/quickstart">Quickstart</a> ·
+  <a href="https://supermemory.ai/docs/self-hosting/overview">Self-host</a> ·
   <a href="https://console.supermemory.ai">Dashboard</a> ·
   <a href="https://supermemory.link/discord">Discord</a>
 </p>
@@ -76,6 +77,21 @@ Add memory, RAG, user profiles, and connectors to your agents and apps with **a 
 No vector DB config. No embedding pipelines. No chunking strategies.
 
 **[→ Jump to developer quickstart](#build-with-supermemory-api)**
+
+</td>
+</tr>
+<tr>
+<td colspan="2" valign="top">
+
+<h3>🖥️ I want to run it myself</h3>
+
+State-of-the-art memory, on your machine. **One binary. Zero config.** Bring any model — or run fully offline with Ollama.
+
+```bash
+curl -fsSL https://supermemory.ai/install | bash
+```
+
+**[→ Jump to Supermemory local](#supermemory-local--run-it-yourself)**
 
 </td>
 </tr>
@@ -301,6 +317,38 @@ Full API reference → [supermemory.ai/docs](https://supermemory.ai/docs)
 
 ---
 
+## Supermemory local — run it yourself
+
+State-of-the-art memory, on your machine. One binary. Zero config.
+
+```bash
+curl -fsSL https://supermemory.ai/install | bash
+# or
+npx supermemory local
+```
+
+```bash
+supermemory-server
+```
+
+First boot sets up the embedded Supermemory graph engine, local embeddings, and your credentials, then prints an API key. The full Memory API — documents, memories, user profiles, hybrid search — runs against `http://localhost:6767`.
+
+```typescript
+const client = new Supermemory({
+  apiKey: "sm_...",
+  baseURL: "http://localhost:6767", // that's the only change
+});
+```
+
+- **Bring any model** — OpenAI, Anthropic, Gemini, Groq, or any OpenAI-compatible endpoint. An interactive wizard walks you through it on first boot.
+- **Fully offline if you want** — point it at Ollama (`gpt-oss:20b` works great) and nothing leaves your machine.
+- **Your data, one directory** — everything lives in `./.supermemory`, easy to back up or move.
+- **Same API as the platform** — prototype locally, ship on the hosted platform by changing `baseURL`.
+
+Read the [self-hosting docs](https://supermemory.ai/docs/self-hosting/overview) — quickstart, configuration, and [local vs. Enterprise](https://supermemory.ai/docs/self-hosting/local-vs-enterprise).
+
+---
+
 ## Benchmarks
 
 Supermemory is state of the art across all major AI memory benchmarks:
@@ -354,6 +402,7 @@ Your app / AI tool
 
 - 📖 [Documentation](https://supermemory.ai/docs)
 - 🚀 [Quickstart](https://supermemory.ai/docs/quickstart)
+- 🖥️ [Self-hosting (Supermemory local)](https://supermemory.ai/docs/self-hosting/overview)
 - 🧪 [MemoryBench](https://supermemory.ai/docs/memorybench/overview)
 - 🔌 [Integrations](https://supermemory.ai/docs/integrations)
 - 💬 [Discord](https://supermemory.link/discord)


### PR DESCRIPTION
## Summary
- Adds "Run it locally" as a first-class option in the README chooser table
- New "Supermemory local — run it yourself" section: install commands (curl + npx), first-boot flow, baseURL swap snippet, offline/Ollama support
- Adds Self-host link to the top nav and the Links list, pointing at the new self-hosting docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)