### PR TITLE
Fix Granola Max upgrade gating

### DIFF
--- a/apps/web/components/add-document/connections.tsx
+++ b/apps/web/components/add-document/connections.tsx
@@ -948,8 +948,8 @@ export function ConnectContent({ selectedProject }: ConnectContentProps) {
 			/>
 
 			<GranolaConnectModal
-				open={granolaModalOpen}
-				onOpenChange={setGranolaModalOpen}
+				open={isMaxUser && granolaModalOpen}
+				onOpenChange={(open) => setGranolaModalOpen(open && isMaxUser)}
 				containerTags={[selectedProject]}
 			/>
 		</div>

--- a/apps/web/components/integrations-view.tsx
+++ b/apps/web/components/integrations-view.tsx
@@ -3066,8 +3066,9 @@ export function IntegrationsView({
 			case "connector": {
 				const count = connectionsByProvider[item.provider].length
 				const isGranola = item.provider === "granola"
-				const needsPlanUpgrade =
-					!isAutumnLoading && (isGranola ? !hasMaxProduct : !hasProProduct)
+				const needsPlanUpgrade = isGranola
+					? !hasMaxProduct
+					: !isAutumnLoading && !hasProProduct
 				if (count > 0) {
 					return (
 						<div className="flex w-full items-center justify-between gap-2">
@@ -3894,8 +3895,8 @@ export function IntegrationsView({
 			</Dialog>
 
 			<GranolaConnectModal
-				open={granolaModalOpen}
-				onOpenChange={setGranolaModalOpen}
+				open={hasMaxProduct && granolaModalOpen}
+				onOpenChange={(open) => setGranolaModalOpen(open && hasMaxProduct)}
 			/>
 		</div>
 	)


### PR DESCRIPTION
## Summary

- Keep the Granola integration card in Upgrade state unless the active plan includes Max or above.
- Prevent the Granola API-key modal from opening unless the active plan is Max or above in both the integrations grid and add-document connections UI.