### PR TITLE
Add fetch timeouts to MCP server HTTP calls

### DIFF
--- a/apps/mcp/src/auth.ts
+++ b/apps/mcp/src/auth.ts
@@ -32,7 +32,7 @@ export async function validateApiKey(
 			headers: {
 				Authorization: `Bearer ${apiKey}`,
 			},
-			signal: AbortSignal.timeout(10000),
+			signal: AbortSignal.timeout(2000),
 		})
 
 		if (!sessionResponse.ok) {
@@ -84,7 +84,10 @@ export async function validateApiKey(
 			email: sessionData.user.email,
 			name: sessionData.user.name,
 		}
-	} catch (error) {
+	} catch (error: any) {
+		if (error.name === "TimeoutError" || error.name === "AbortError") {
+			throw new Error("Authentication request timed out. Please try again.")
+		}
 		console.error("API key validation error:", error)
 		return null
 	}
@@ -104,7 +107,7 @@ export async function validateOAuthToken(
 			headers: {
 				Authorization: `Bearer ${token}`,
 			},
-			signal: AbortSignal.timeout(10000),
+			signal: AbortSignal.timeout(2000),
 		})
 
 		if (!sessionResponse.ok) {
@@ -156,7 +159,10 @@ export async function validateOAuthToken(
 			email: sessionData.email,
 			name: sessionData.name,
 		}
-	} catch (error) {
+	} catch (error: any) {
+		if (error.name === "TimeoutError" || error.name === "AbortError") {
+			throw new Error("Authentication request timed out. Please try again.")
+		}
 		console.error("Token validation error:", error)
 		return null
 	}

--- a/apps/mcp/src/auth.ts
+++ b/apps/mcp/src/auth.ts
@@ -11,6 +11,10 @@ export interface AuthUser {
 	name?: string
 }
 
+export type AuthResult =
+	| { ok: true; user: AuthUser }
+	| { ok: false; error: "timeout" | "unauthorized" }
+
 /**
  * Check if a token is an API key (starts with "sm_")
  */
@@ -25,7 +29,7 @@ export function isApiKey(token: string): boolean {
 export async function validateApiKey(
 	apiKey: string,
 	apiUrl: string,
-): Promise<AuthUser | null> {
+): Promise<AuthResult> {
 	try {
 		const sessionResponse = await fetch(`${apiUrl}/v3/session`, {
 			method: "GET",
@@ -57,7 +61,7 @@ export async function validateApiKey(
 			} else {
 				console.error("API key validation failed:", status, responseText)
 			}
-			return null
+			return { ok: false, error: "unauthorized" }
 		}
 
 		const sessionData = (await sessionResponse.json()) as {
@@ -73,23 +77,26 @@ export async function validateApiKey(
 
 		if (!sessionData?.user?.id) {
 			console.error("Missing user.id in session response:", sessionData)
-			return null
+			return { ok: false, error: "unauthorized" }
 		}
 
 		console.log("API key validated for user:", sessionData.user.id)
 
 		return {
-			userId: sessionData.user.id,
-			apiKey: apiKey,
-			email: sessionData.user.email,
-			name: sessionData.user.name,
+			ok: true,
+			user: {
+				userId: sessionData.user.id,
+				apiKey: apiKey,
+				email: sessionData.user.email,
+				name: sessionData.user.name,
+			},
 		}
 	} catch (error: any) {
 		if (error.name === "TimeoutError" || error.name === "AbortError") {
-			throw new Error("Authentication request timed out. Please try again.")
+			return { ok: false, error: "timeout" }
 		}
 		console.error("API key validation error:", error)
-		return null
+		return { ok: false, error: "unauthorized" }
 	}
 }
 
@@ -100,7 +107,7 @@ export async function validateApiKey(
 export async function validateOAuthToken(
 	token: string,
 	apiUrl: string,
-): Promise<AuthUser | null> {
+): Promise<AuthResult> {
 	try {
 		const sessionResponse = await fetch(`${apiUrl}/v3/mcp/session-with-key`, {
 			method: "GET",
@@ -132,7 +139,7 @@ export async function validateOAuthToken(
 			} else {
 				console.error("Token validation failed:", status, responseText)
 			}
-			return null
+			return { ok: false, error: "unauthorized" }
 		}
 
 		const sessionData = (await sessionResponse.json()) as {
@@ -148,22 +155,25 @@ export async function validateOAuthToken(
 				"Missing userId or apiKey in session response:",
 				sessionData,
 			)
-			return null
+			return { ok: false, error: "unauthorized" }
 		}
 
 		console.log("OAuth validated, got API key for user:", sessionData.userId)
 
 		return {
-			userId: sessionData.userId,
-			apiKey: sessionData.apiKey,
-			email: sessionData.email,
-			name: sessionData.name,
+			ok: true,
+			user: {
+				userId: sessionData.userId,
+				apiKey: sessionData.apiKey,
+				email: sessionData.email,
+				name: sessionData.name,
+			},
 		}
 	} catch (error: any) {
 		if (error.name === "TimeoutError" || error.name === "AbortError") {
-			throw new Error("Authentication request timed out. Please try again.")
+			return { ok: false, error: "timeout" }
 		}
 		console.error("Token validation error:", error)
-		return null
+		return { ok: false, error: "unauthorized" }
 	}
 }

--- a/apps/mcp/src/auth.ts
+++ b/apps/mcp/src/auth.ts
@@ -32,6 +32,7 @@ export async function validateApiKey(
 			headers: {
 				Authorization: `Bearer ${apiKey}`,
 			},
+			signal: AbortSignal.timeout(10000),
 		})
 
 		if (!sessionResponse.ok) {
@@ -103,6 +104,7 @@ export async function validateOAuthToken(
 			headers: {
 				Authorization: `Bearer ${token}`,
 			},
+			signal: AbortSignal.timeout(10000),
 		})
 
 		if (!sessionResponse.ok) {

--- a/apps/mcp/src/client.ts
+++ b/apps/mcp/src/client.ts
@@ -389,6 +389,16 @@ export class SupermemoryClient {
 	}
 
 	private handleError(error: unknown): never {
+		// Handle explicit timeouts
+		if (
+			error instanceof Error &&
+			(error.name === "TimeoutError" || error.name === "AbortError")
+		) {
+			throw new Error(
+				"Request timed out. The server is taking too long to respond, please try again.",
+			)
+		}
+
 		// Handle network/fetch errors
 		if (error instanceof TypeError) {
 			if (

--- a/apps/mcp/src/client.ts
+++ b/apps/mcp/src/client.ts
@@ -336,6 +336,7 @@ export class SupermemoryClient {
 					Authorization: `Bearer ${this.bearerToken}`,
 					"Content-Type": "application/json",
 				},
+				signal: AbortSignal.timeout(10000),
 			})
 
 			if (!response.ok) {
@@ -374,6 +375,7 @@ export class SupermemoryClient {
 					order: "desc",
 					containerTags,
 				}),
+				signal: AbortSignal.timeout(30000),
 			})
 			if (!response.ok) {
 				throw Object.assign(new Error("Failed to fetch documents"), {

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -136,22 +136,31 @@ const handleMcpRequest = async (c: Context<{ Bindings: Bindings }>) => {
 		})
 	}
 
-	let authUser: {
-		userId: string
-		apiKey: string
-		email?: string
-		name?: string
-	} | null = null
+	const authResult = isApiKey(token)
+		? await validateApiKey(token, apiUrl)
+		: await validateOAuthToken(token, apiUrl)
 
-	if (isApiKey(token)) {
-		console.log("Authenticating with API key")
-		authUser = await validateApiKey(token, apiUrl)
-	} else {
-		console.log("Authenticating with OAuth token")
-		authUser = await validateOAuthToken(token, apiUrl)
-	}
+	if (!authResult.ok) {
+		if (authResult.error === "timeout") {
+			return new Response(
+				JSON.stringify({
+					jsonrpc: "2.0",
+					error: {
+						code: -32000,
+						message: "Authentication timed out. Please try again.",
+					},
+					id: null,
+				}),
+				{
+					status: 504,
+					headers: {
+						"Content-Type": "application/json",
+						"Access-Control-Allow-Origin": "*",
+					},
+				},
+			)
+		}
 
-	if (!authUser) {
 		const errorMessage = isApiKey(token)
 			? "Unauthorized: Invalid or expired API key"
 			: "Unauthorized: Invalid or expired token"
@@ -177,15 +186,14 @@ const handleMcpRequest = async (c: Context<{ Bindings: Bindings }>) => {
 		)
 	}
 
-	// Create execution context with authenticated user props
 	const ctx = {
 		...c.executionCtx,
 		props: {
-			userId: authUser.userId,
-			apiKey: authUser.apiKey,
+			userId: authResult.user.userId,
+			apiKey: authResult.user.apiKey,
 			containerTag,
-			email: authUser.email,
-			name: authUser.name,
+			email: authResult.user.email,
+			name: authResult.user.name,
 		} satisfies Props,
 	} as ExecutionContext & { props: Props }
 

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -89,6 +89,7 @@ app.get("/.well-known/oauth-authorization-server", async (c) => {
 		// Fetch the authorization server metadata from the main API
 		const response = await fetch(
 			`${apiUrl}/.well-known/oauth-authorization-server`,
+			{ signal: AbortSignal.timeout(10000) },
 		)
 
 		if (!response.ok) {


### PR DESCRIPTION
5 fetch() calls in the MCP server were missing timeouts — auth validation, project listing, document fetching, OAuth metadata proxy. In CF Workers a hanging request blocks the Durable Object and eats CPU time.

Added AbortSignal.timeout() to each one. 10s for lightweight calls (auth, projects, metadata), 30s for document listing. Standard Web API, no new deps. Existing try/catch handles the TimeoutError that gets thrown.