### PR TITLE
fix(web): scope memory-of-day cache by org

### DIFF
--- a/apps/web/app/(app)/page.tsx
+++ b/apps/web/app/(app)/page.tsx
@@ -108,7 +108,7 @@ function ViewErrorFallback() {
 
 export default function NewPage() {
 	const isMobile = useIsMobile()
-	const { user, session, isSessionPending } = useAuth()
+	const { user, session, isSessionPending, org } = useAuth()
 
 	const { selectedProject, selectedProjects, setSelectedProject } = useProject()
 	const selectedProjectTag = selectedProjects[0]
@@ -369,10 +369,11 @@ export default function NewPage() {
 		queryKey: [
 			"memory-of-day",
 			user?.id,
+			org?.id,
 			new Date().toISOString().slice(0, 10),
 		],
 		queryFn: async (): Promise<MemoryOfDay | null> => {
-			const cacheKey = `memory-of-day:v2:${user?.id}:${new Date().toISOString().slice(0, 10)}`
+			const cacheKey = `memory-of-day:v2:${user?.id}:${org?.id}:${new Date().toISOString().slice(0, 10)}`
 			try {
 				const stored = localStorage.getItem(cacheKey)
 				if (stored) return JSON.parse(stored) as MemoryOfDay
@@ -393,7 +394,7 @@ export default function NewPage() {
 		},
 		staleTime: 24 * 60 * 60 * 1000,
 		refetchOnWindowFocus: false,
-		enabled: !!user,
+		enabled: !!user && !!org,
 	})
 
 	useHotkeys("c", () => {


### PR DESCRIPTION
Add org id to the memory-of-day react-query key and localStorage cache key, and gate the fetch on an active org, so one user's brief from another org no longer leaks across orgs.