### PR TITLE
docs: clarify self-hosted embedding model config

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,7 @@ Before you begin, ensure you have the following installed:
    if (url.hostname === "localhost") {
      return NextResponse.next();
    }
+   ```
 
 5. **Start the Development Server**
 

--- a/apps/docs/self-hosting/configuration.mdx
+++ b/apps/docs/self-hosting/configuration.mdx
@@ -39,6 +39,10 @@ With multiple providers configured, the first one in the order above is used.
 Image, video, and high-fidelity PDF understanding require a Gemini or Vertex AI key. Text ingestion, memory extraction, and search work with any provider.
 </Note>
 
+<Note>
+The provider variables above configure the LLM used for summarization, contextual chunking, and memory extraction. Vector embeddings are computed locally by the bundled embedding model; the self-hosted binary does not currently expose an environment variable for changing that embedding model. If a future version adds one, existing data should be re-ingested because vectors from different embedding models are not comparable.
+</Note>
+
 ### Fully offline with local models
 
 `OPENAI_API_KEY` + `OPENAI_BASE_URL` covers any OpenAI-compatible endpoint: Ollama, LM Studio, vLLM, llama.cpp server, Together, Fireworks, and more.

--- a/apps/docs/self-hosting/overview.mdx
+++ b/apps/docs/self-hosting/overview.mdx
@@ -24,11 +24,11 @@ No Docker. No database to provision. No config files. It boots in seconds with e
 Run the binary with nothing set and you get a complete memory system:
 
 - **The Supermemory graph engine, embedded** — created automatically on first boot. No database to stand up, no connection strings.
-- **Built-in local embeddings** — vectors are computed on your machine. Nothing is sent anywhere to be embedded.
+- **Built-in local embeddings** — vectors are computed on your machine by the bundled embedding model. Nothing is sent anywhere to be embedded.
 - **An API key, generated for you** — printed on first boot, ready to paste into any SDK.
 - **The full Memory API** — `/v3/documents`, `/v4/search`, `/v4/profile`, spaces, the works.
 
-The only thing you bring is a model. In production, Supermemory runs its own proprietary models, purpose-tuned for long-horizon data understanding and memory extraction. Self-hosted, the same pipeline runs on whatever model you point it at — OpenAI, Anthropic, Gemini, Groq, or any OpenAI-compatible endpoint. Bring a key and go. Or don't bring one at all:
+The only thing you bring is a model for the LLM-powered parts of the pipeline. In production, Supermemory runs its own proprietary models, purpose-tuned for long-horizon data understanding and memory extraction. Self-hosted, the same extraction pipeline runs on whatever LLM you point it at — OpenAI, Anthropic, Gemini, Groq, or any OpenAI-compatible endpoint. Bring a key and go. Or don't bring one at all:
 
 ## Runs fully offline
 
@@ -42,6 +42,10 @@ supermemory-server
 ```
 
 Local graph engine, local embeddings, local LLM. Your data never leaves the building.
+
+<Note>
+The LLM settings above do not change the local embedding model used for vector search. The self-hosted binary currently ships with its embedding model built in; if that changes in a future release, existing memories should be re-ingested so all stored vectors come from the same model.
+</Note>
 
 ## Drop-in with your existing code
 

--- a/apps/docs/self-hosting/quickstart.mdx
+++ b/apps/docs/self-hosting/quickstart.mdx
@@ -50,6 +50,10 @@ Save that API key — it's your bearer token for every request.
 In production, Supermemory runs proprietary models tuned for long-horizon data understanding. Self-hosted, you bring any model: if no provider key is set, first boot launches an interactive setup wizard — pick a provider (OpenAI, Anthropic, Gemini, Groq, or any OpenAI-compatible endpoint like Ollama), paste your key, and it's saved encrypted for every future launch. See [all providers](/self-hosting/configuration#llm-providers), including [fully-offline local models](/self-hosting/configuration#fully-offline-with-local-models).
 </Note>
 
+<Note>
+This provider choice controls the LLM used for extraction, chunking, and summaries. Search embeddings are still generated locally by the bundled embedding model; changing embedding models is not currently configurable and would require re-ingesting existing memories once supported.
+</Note>
+
 ## Add your first memory
 
 <Tabs>


### PR DESCRIPTION
## Summary
- clarify that self-hosted LLM provider settings do not change the bundled local embedding model
- note that changing embedding models in a future release would require re-ingesting existing memories
- fix the missing closing code fence in CONTRIBUTING.md

## Context
This does not implement the binary-level embedding override requested in #1104 because the self-hosted server source/release pipeline does not appear to live in this monorepo. It reduces the current docs ambiguity around “bring your own model” while that work is pending.

## Validation
- Parsed the changed MDX files with @mdx-js/mdx
- Checked markdown code fences and whitespace with a small local script plus git diff --check
- bun run check-types currently fails in @supermemory/tools with existing TypeScript errors unrelated to these docs changes
- Mintlify validation/dev is blocked in this environment because the CLI rejects Node v26.3.0 and requires an LTS Node version