### PR TITLE
docs: add Supermemory CLI docs and embed SMFS into main nav

### DIFF
--- a/apps/docs/cli/commands.mdx
+++ b/apps/docs/cli/commands.mdx
@@ -1,0 +1,318 @@
+---
+title: "Command Reference"
+sidebarTitle: "Command Reference"
+description: "Every Supermemory CLI command, subcommand, and flag."
+icon: "list"
+---
+
+All commands below assume you've [authenticated](/cli/overview#authenticate). Use the bare `supermemory` form if installed globally, or prefix with `npx`. Every command accepts the [global flags](/cli/overview#global-flags) `--json`, `--tag`, and `--help`.
+
+## Core memory operations
+
+### `add` — Ingest content
+
+Ingest text, files, or URLs and extract memories into a container tag.
+
+```bash
+# Add text
+supermemory add "User prefers TypeScript over JavaScript"
+
+# Add a file (PDF, markdown, text, etc.)
+supermemory add ./meeting-notes.pdf --tag meetings
+
+# Add a URL
+supermemory add https://docs.example.com/api --tag docs
+
+# Read from stdin
+cat file.txt | supermemory add --stdin
+echo "some content" | supermemory add --stdin --tag notes
+
+# With metadata, title, and custom ID
+supermemory add "Design doc v2" \
+  --title "Design Doc" \
+  --metadata '{"category": "engineering", "priority": "high"}' \
+  --id custom-doc-id --tag project
+
+# Batch mode (JSONL from stdin, one {"content": "...", "tag": "..."} per line)
+cat batch.jsonl | supermemory add --batch
+```
+
+| Flag | Description |
+|---|---|
+| `--tag <string>` | Container tag |
+| `--stdin` | Read content from stdin |
+| `--title <string>` | Document title |
+| `--metadata <json>` | JSON metadata object |
+| `--id <string>` | Custom document ID |
+| `--batch` | Batch mode, reads JSONL from stdin |
+
+### `search` — Search memories
+
+Semantic search across memories with filtering and reranking.
+
+```bash
+# Basic search
+supermemory search "authentication patterns"
+
+# Scoped to a tag, with a limit
+supermemory search "auth" --tag api --limit 5
+
+# Reranking and LLM query rewriting for better relevance
+supermemory search "database migrations" --rerank
+supermemory search "how do we handle auth" --rewrite
+
+# Search modes
+supermemory search "user prefs" --mode memories    # extracted memories only
+supermemory search "user prefs" --mode hybrid      # memories + document chunks
+supermemory search "user prefs" --mode documents   # full documents only
+
+# Include specific fields and filter by metadata
+supermemory search "api design" --include summary,chunks,memories
+supermemory search "design" --filter '{"AND": [{"key": "category", "value": "engineering"}]}'
+
+# Similarity threshold (0-1)
+supermemory search "preferences" --threshold 0.5
+```
+
+| Flag | Description |
+|---|---|
+| `--tag <string>` | Filter by container tag |
+| `--limit <number>` | Max results (default: 10) |
+| `--threshold <number>` | Similarity threshold 0-1 (default: 0) |
+| `--rerank` | Enable reranking for better relevance |
+| `--rewrite` | Rewrite the query using an LLM |
+| `--mode <string>` | `memories` \| `hybrid` \| `documents` (default: `memories`) |
+| `--include <string>` | Fields: `summary`, `chunks`, `memories`, `document` |
+| `--filter <json>` | Metadata filter object |
+
+### `remember` — Store a memory directly
+
+Store a specific fact without ingesting a full document.
+
+```bash
+supermemory remember "User prefers dark mode" --tag user_123
+
+# Permanent / static memory (won't decay)
+supermemory remember "User is a senior engineer at Acme Corp" --static --tag user_123
+
+# With metadata
+supermemory remember "Discussed Q3 roadmap" --tag meetings --metadata '{"type": "decision"}'
+```
+
+| Flag | Description |
+|---|---|
+| `--tag <string>` | Container tag |
+| `--static` | Mark as a permanent memory |
+| `--metadata <json>` | JSON metadata |
+
+### `forget` — Delete a memory
+
+```bash
+supermemory forget mem_abc123 --tag default
+supermemory forget --content "outdated preference" --tag default
+supermemory forget mem_abc123 --reason "User corrected this information"
+```
+
+| Flag | Description |
+|---|---|
+| `--tag <string>` | Container tag |
+| `--reason <string>` | Reason for forgetting |
+| `--content <string>` | Forget by content match instead of ID |
+
+### `update` — Update an existing memory
+
+```bash
+supermemory update mem_123 "Updated preference: prefers Bun over Node"
+supermemory update mem_123 "New content" --metadata '{"updated": true}'
+```
+
+| Flag | Description |
+|---|---|
+| `--tag <string>` | Container tag |
+| `--metadata <json>` | Updated metadata |
+| `--reason <string>` | Reason for the update |
+
+### `profile` — Get a user profile
+
+Retrieve the auto-generated user profile (static facts + dynamic context) for a container tag.
+
+```bash
+supermemory profile                                   # default tag
+supermemory profile user_123                          # specific tag
+supermemory profile user_123 --query "programming preferences"
+```
+
+## Document management
+
+### `docs` — Manage documents
+
+```bash
+supermemory docs list --tag default --limit 20
+supermemory docs get doc_abc123
+supermemory docs status doc_abc123       # processing status
+supermemory docs chunks doc_abc123       # view chunks
+supermemory docs delete doc_abc123 --yes
+```
+
+**Subcommands:** `list`, `get`, `delete`, `chunks`, `status`
+
+## Container tags
+
+### `tags` — Manage container tags
+
+Container tags scope memories to users, projects, or any logical grouping.
+
+```bash
+supermemory tags list
+supermemory tags info user_123                                 # counts and metadata
+supermemory tags create my-new-project
+supermemory tags context user_123 --set "This user is a premium customer"
+supermemory tags context user_123 --clear
+supermemory tags merge old-tag --into new-tag --yes
+supermemory tags delete old-tag --yes
+```
+
+**Subcommands:** `list`, `info`, `create`, `delete`, `context`, `merge`
+
+## API keys
+
+### `keys` — Manage API keys
+
+```bash
+supermemory keys list
+supermemory keys create --name my-agent --permission write
+supermemory keys create --name bot-key --tag user_123 --expires 30   # scoped + expiring
+supermemory keys revoke key_abc123 --yes
+supermemory keys toggle key_abc123                                    # enable/disable
+```
+
+**Subcommands:** `list`, `create`, `revoke`, `toggle`
+
+## Connectors
+
+### `connectors` — External data sources
+
+Connect Google Drive, Notion, OneDrive, and other services to sync documents automatically.
+
+```bash
+supermemory connectors list
+supermemory connectors connect google-drive --tag docs   # opens OAuth flow
+supermemory connectors sync conn_abc123
+supermemory connectors history conn_abc123 --limit 10
+supermemory connectors resources conn_abc123
+supermemory connectors disconnect conn_abc123 --yes
+```
+
+**Subcommands:** `list`, `connect`, `sync`, `history`, `disconnect`, `resources`
+
+## Plugins
+
+### `plugins` — IDE and tool integrations
+
+Connect the CLI to Claude Code, Cursor, and other tools.
+
+```bash
+supermemory plugins list
+supermemory plugins connect claude-code --auto-configure
+supermemory plugins status claude-code
+supermemory plugins revoke claude-code --yes
+```
+
+**Subcommands:** `list`, `connect`, `revoke`, `status`
+
+## Team management
+
+### `team` — Manage team members
+
+```bash
+supermemory team list
+supermemory team invite user@example.com --role admin
+supermemory team role member_123 admin
+supermemory team remove member_123 --yes
+supermemory team invitations
+```
+
+**Subcommands:** `list`, `invite`, `remove`, `role`, `invitations`
+
+## Monitoring
+
+### `status` — Account dashboard
+
+```bash
+supermemory status
+supermemory status --period 7d    # 24h, 7d, 30d, all
+```
+
+Shows memory count, document count, API usage, and storage.
+
+### `logs` — Request logs
+
+```bash
+supermemory logs
+supermemory logs --period 7d
+supermemory logs --status error
+supermemory logs --type search
+supermemory logs get req_abc123
+```
+
+### `billing` — Usage and billing
+
+```bash
+supermemory billing            # overview
+supermemory billing usage      # detailed breakdown
+supermemory billing invoices   # past invoices
+```
+
+## Utility
+
+```bash
+# Open the console in your browser
+supermemory open
+supermemory open graph     # also: billing, settings, docs, keys
+
+# Machine-readable help (useful for LLM agents)
+supermemory help --json
+supermemory help --all
+
+# Per-command help
+supermemory search --help
+supermemory tags --help --json
+```
+
+## Scoped keys mode
+
+When you authenticate with a scoped API key (restricted to a single container tag), only these commands are available, and the tag is taken automatically from the key's scope — no `--tag` needed:
+
+`search`, `add`, `remember`, `forget`, `update`, `profile`, `whoami`
+
+## Common patterns
+
+### Pipe content from other tools
+
+```bash
+git log --oneline -20 | supermemory add --stdin --tag git-history
+curl -s https://api.example.com/docs | supermemory add --stdin --tag api-docs
+supermemory search "auth" --json | jq '.results[].memory'
+```
+
+### Scripting with JSON output
+
+Every command supports `--json` for machine-readable output:
+
+```bash
+supermemory search "query" --json
+supermemory tags list --json
+supermemory status --json | jq '.memoryCount'
+```
+
+### CI/CD integration
+
+```bash
+export SUPERMEMORY_API_KEY=sm_xxx
+
+# Ingest docs on deploy, replacing the previous version by ID
+supermemory add ./docs/api-reference.md --tag api-docs --id api-ref-latest
+
+# Gate on status
+supermemory status --json | jq '.memoryCount'
+```

--- a/apps/docs/cli/local.mdx
+++ b/apps/docs/cli/local.mdx
@@ -1,0 +1,86 @@
+---
+title: "Local server"
+sidebarTitle: "Local server"
+description: "npx supermemory local — run the full memory engine on your own machine. One binary, zero config."
+icon: "server"
+---
+
+`npx supermemory local` downloads and runs Supermemory's self-hosted memory engine on your machine. It's the same engine behind the [hosted platform](https://console.supermemory.ai) — ingestion, memory extraction, hybrid semantic search, and the full API — as a single self-contained binary.
+
+No Docker, no database to provision, no config files. It boots in seconds with everything built in, and it's [open source](https://git.new/memory).
+
+## Run it
+
+<Tabs>
+<Tab title="npx">
+```bash
+npx supermemory local
+```
+</Tab>
+<Tab title="bunx">
+```bash
+bunx supermemory local
+```
+</Tab>
+<Tab title="curl">
+```bash
+curl -fsSL https://supermemory.ai/install | bash
+```
+</Tab>
+</Tabs>
+
+The installer detects your OS and architecture, downloads the right binary, verifies it, and (when run interactively) prompts you for an LLM API key. Then start the server:
+
+```bash
+supermemory-server
+```
+
+First boot sets everything up — the embedded graph engine, local embeddings, and your credentials — and prints an API key:
+
+```
+  ┌──────────────────────────────────────────────────┐
+  │  url       http://localhost:6767                 │
+  │  database  ./.supermemory                        │
+  │  api key   sm_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx     │
+  │  org id    xxxxxxxxxxxxxxxxxxxxxx                │
+  └──────────────────────────────────────────────────┘
+```
+
+Save that API key — it's your bearer token for every request. Then point any Supermemory SDK at your local server with a one-line change:
+
+```typescript
+const client = new Supermemory({
+  apiKey: "sm_...",                  // printed on first boot
+  baseURL: "http://localhost:6767",  // that's the only change
+})
+```
+
+## Cloud CLI vs. local server
+
+Both ship under `npx supermemory`, but they're different things:
+
+| | `supermemory <command>` | `supermemory local` |
+|---|---|---|
+| What it talks to | The [hosted platform](https://console.supermemory.ai) | A server running on your machine |
+| Auth | Your account ([`login`](/cli/overview#authenticate)) | Auto-generated key on first boot |
+| Use case | Manage cloud memory from the terminal | Local-first, air-gapped, privacy-sensitive workloads |
+| Reference | [Command reference](/cli/commands) | This page + [Self-hosting docs](/self-hosting/overview) |
+
+## Learn more
+
+The local server has its own full documentation — bringing your own model (or running fully offline with Ollama), configuration, and how it compares to Enterprise:
+
+<CardGroup cols={2}>
+  <Card title="Self-hosting quickstart" icon="play" href="/self-hosting/quickstart">
+    Install, run, and store your first memory in under two minutes.
+  </Card>
+  <Card title="Configuration" icon="settings" href="/self-hosting/configuration">
+    Every environment variable: LLM providers, local models, storage, tuning.
+  </Card>
+  <Card title="Overview" icon="server" href="/self-hosting/overview">
+    What's built in, what runs offline, and how it matches the platform API.
+  </Card>
+  <Card title="Local vs. Enterprise" icon="building-2" href="/self-hosting/local-vs-enterprise">
+    When to run it yourself and when to move to the managed platform.
+  </Card>
+</CardGroup>

--- a/apps/docs/cli/overview.mdx
+++ b/apps/docs/cli/overview.mdx
@@ -1,0 +1,125 @@
+---
+title: "Supermemory CLI"
+sidebarTitle: "Overview"
+description: "Supermemory from the terminal. One command — npx supermemory — for your cloud memory and a local server."
+icon: "square-terminal"
+---
+
+The Supermemory CLI is the complete interface to Supermemory from your terminal. Add memories, search, manage documents, configure projects, connect data sources, administer teams — all programmatically, all from `npx supermemory`.
+
+It does two things:
+
+<CardGroup cols={2}>
+  <Card title="Manage your cloud memory" icon="cloud" href="/cli/commands">
+    `npx supermemory <command>` talks to the [hosted platform](https://console.supermemory.ai). Add, search, and manage memories, documents, tags, keys, connectors, and teams.
+  </Card>
+  <Card title="Run a local server" icon="server" href="/cli/local">
+    `npx supermemory local` downloads and runs the self-hosted memory engine on your machine — one binary, zero config.
+  </Card>
+</CardGroup>
+
+## Install
+
+You can run every command through `npx` with no install:
+
+```bash
+npx supermemory whoami
+npx supermemory search "authentication patterns"
+npx supermemory local
+```
+
+Or install it globally and drop the `npx`:
+
+<CodeGroup>
+```bash npm
+npm install -g supermemory
+```
+
+```bash bun
+bun add -g supermemory
+```
+</CodeGroup>
+
+```bash
+supermemory whoami
+```
+
+The rest of these docs use the bare `supermemory` form — prefix with `npx` if you haven't installed globally.
+
+## Authenticate
+
+Most commands act on your cloud account, so authenticate first:
+
+```bash
+# Browser OAuth flow
+supermemory login
+
+# Or pass an API key directly
+supermemory login --api-key sm_xxx
+
+# Confirm who you are
+supermemory whoami
+```
+
+In CI or scripts, set the API key as an environment variable instead of logging in:
+
+```bash
+export SUPERMEMORY_API_KEY=sm_xxx
+```
+
+<Note>
+`npx supermemory local` does **not** require authentication — it runs entirely on your machine and generates its own API key on first boot. See [Local server](/cli/local).
+</Note>
+
+## Configuration
+
+The CLI resolves config from three scopes, most specific wins:
+
+| Scope | File | Use case |
+|---|---|---|
+| `project` | `.supermemory/config.json` (gitignored) | Per-machine secrets, API keys |
+| `team` | `.supermemory/team.json` (committed) | Shared container tag, team-wide defaults |
+| `global` | `~/.config/supermemory/config.json` | Defaults for all projects on this machine |
+
+```bash
+# Interactive setup wizard
+supermemory init
+
+# Non-interactive
+supermemory init --scope project --tag my-bot
+supermemory init --scope team --tag shared-project
+
+# View / get / set values
+supermemory config
+supermemory config get tag
+supermemory config set tag my-project
+```
+
+### Environment variables
+
+| Variable | Description |
+|---|---|
+| `SUPERMEMORY_API_KEY` | API key for authentication |
+| `SUPERMEMORY_TAG` | Override the default container tag |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` | OpenTelemetry collector endpoint |
+
+### Global flags
+
+Available on every command:
+
+| Flag | Description |
+|---|---|
+| `--json` | Force machine-readable JSON output |
+| `--tag <string>` | Override the default container tag for this command |
+| `--help` | Show help for any command |
+
+## Next steps
+
+<CardGroup cols={2}>
+  <Card title="Command reference" icon="list" href="/cli/commands">
+    Every command and flag — add, search, docs, tags, keys, connectors, teams, and more.
+  </Card>
+  <Card title="Local server" icon="server" href="/cli/local">
+    `npx supermemory local` — run the memory engine on your own machine.
+  </Card>
+</CardGroup>

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -44,6 +44,10 @@
 	"navbar": {
 		"links": [
 			{
+				"href": "/self-hosting/overview",
+				"label": "Self-host"
+			},
+			{
 				"href": "mailto:support@supermemory.com",
 				"label": "Support"
 			}

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -72,6 +72,11 @@
 								"pages": ["intro", "quickstart", "vibe-coding"]
 							},
 							{
+								"group": "Command Line (CLI)",
+								"icon": "square-terminal",
+								"pages": ["cli/overview", "cli/commands", "cli/local"]
+							},
+							{
 								"group": "Self-Hosting",
 								"pages": [
 									"self-hosting/overview",
@@ -132,6 +137,28 @@
 								]
 							},
 							{
+								"group": "SMFS (Memory Filesystem)",
+								"icon": "database",
+								"pages": [
+									"smfs/overview",
+									"smfs/install",
+									"smfs/mount",
+									"smfs/bash-tool",
+									"smfs/bash-tool-python",
+									{
+										"group": "Providers",
+										"icon": "cloud",
+										"pages": [
+											"smfs/providers/daytona",
+											"smfs/providers/e2b",
+											"smfs/providers/vercel",
+											"smfs/providers/cloudflare"
+										]
+									},
+									"smfs/examples"
+								]
+							},
+							{
 								"group": "Migration Guides",
 								"pages": [
 									{
@@ -154,28 +181,6 @@
 								"icon": "layers",
 								"pages": ["supermemory-mcp/claude-desktop"]
 							}
-						]
-					},
-					{
-						"anchor": "SMFS",
-						"icon": "database",
-						"pages": [
-							"smfs/overview",
-							"smfs/install",
-							"smfs/mount",
-							"smfs/bash-tool",
-							"smfs/bash-tool-python",
-							{
-								"group": "Providers",
-								"icon": "cloud",
-								"pages": [
-									"smfs/providers/daytona",
-									"smfs/providers/e2b",
-									"smfs/providers/vercel",
-									"smfs/providers/cloudflare"
-								]
-							},
-							"smfs/examples"
 						]
 					}
 				],

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -72,17 +72,17 @@
 								"pages": ["intro", "quickstart", "vibe-coding"]
 							},
 							{
-								"group": "Command Line (CLI)",
-								"icon": "square-terminal",
-								"pages": ["cli/overview", "cli/commands", "cli/local"]
-							},
-							{
-								"group": "Self-Hosting",
+								"group": "Core Features",
 								"pages": [
-									"self-hosting/overview",
-									"self-hosting/quickstart",
-									"self-hosting/configuration",
-									"self-hosting/local-vs-enterprise"
+									"add-memories",
+									"search",
+									"user-profiles",
+									{
+										"group": "Manage Content",
+										"icon": "folder-cog",
+										"pages": ["document-operations", "memory-operations"]
+									},
+									"overview/use-cases"
 								]
 							},
 							{
@@ -98,20 +98,6 @@
 									"concepts/user-profiles",
 									"concepts/customization",
 									"authentication"
-								]
-							},
-							{
-								"group": "Using supermemory",
-								"pages": [
-									"add-memories",
-									"search",
-									"user-profiles",
-									{
-										"group": "Manage Content",
-										"icon": "folder-cog",
-										"pages": ["document-operations", "memory-operations"]
-									},
-									"overview/use-cases"
 								]
 							},
 							{
@@ -137,6 +123,30 @@
 								]
 							},
 							{
+								"group": "Migration Guides",
+								"pages": [
+									{
+										"group": "From another provider",
+										"icon": "truck",
+										"pages": ["migration/from-mem0", "migration/from-zep"]
+									}
+								]
+							},
+							{
+								"group": "Self-Hosting",
+								"pages": [
+									"self-hosting/overview",
+									"self-hosting/quickstart",
+									"self-hosting/configuration",
+									"self-hosting/local-vs-enterprise"
+								]
+							},
+							{
+								"group": "Command Line (CLI)",
+								"icon": "square-terminal",
+								"pages": ["cli/overview", "cli/commands", "cli/local"]
+							},
+							{
 								"group": "SMFS (Memory Filesystem)",
 								"icon": "database",
 								"pages": [
@@ -156,16 +166,6 @@
 										]
 									},
 									"smfs/examples"
-								]
-							},
-							{
-								"group": "Migration Guides",
-								"pages": [
-									{
-										"group": "From another provider",
-										"icon": "truck",
-										"pages": ["migration/from-mem0", "migration/from-zep"]
-									}
 								]
 							}
 						]

--- a/apps/docs/intro.mdx
+++ b/apps/docs/intro.mdx
@@ -4,81 +4,82 @@ sidebarTitle: "Overview"
 icon: "book-open"
 ---
 
-Supermemory is the long-term and short-term memory and context infrastructure for AI agents. It is the [state of the art](https://supermemory.ai/research) across multiple benchmarks, including LongMemEval and LoCoMo.
+Supermemory is the memory and context engine for AI agents — and it's the state of the art, ranked **#1 on every major memory benchmark**: [LongMemEval](https://github.com/xiaowu0162/LongMemEval), [LoCoMo](https://github.com/snap-research/locomo), and [ConvoMem](https://github.com/Salesforce/ConvoMem).
 
-With supermemory, you give your agents perfect recall about their users — so they're more intelligent, more personalized, and more consistent. Every piece of the context stack is built in, behind one API.
+Your AI forgets everything between conversations. Supermemory fixes that. It learns from every interaction, **reasons over a directed knowledge graph** to resolve contradictions and track how facts change over time, forgets what's expired, and serves the right context at the right moment — through one API.
+
+## State of the art, by the numbers
+
+Most memory systems claim to be better. Supermemory is measurably ahead — first place across all three independent benchmarks the field uses to grade AI memory.
+
+| Benchmark | What it measures | Supermemory |
+|---|---|---|
+| [LongMemEval](https://github.com/xiaowu0162/LongMemEval) | Long-term memory across sessions, with knowledge updates | **81.6% — #1** |
+| [LoCoMo](https://github.com/snap-research/locomo) | Fact recall across long conversations (multi-hop, temporal, adversarial) | **#1** |
+| [ConvoMem](https://github.com/Salesforce/ConvoMem) | Personalization and preference learning | **#1** |
+
+Read the full methodology on the [research page](https://supermemory.ai/research), or reproduce it yourself with [MemoryBench](/memorybench/overview), our open-source benchmarking framework.
+
+## What makes Supermemory different
+
+Most "memory layers" are a vector store that retrieves the nearest chunk. Supermemory is an engine that *understands* — which is why it tops the benchmarks instead of just claiming to.
+
+<CardGroup cols={2}>
+  <Card title="It reasons — not just retrieves" icon="brain" href="/concepts/how-it-works">
+    Resolves contradictions, tracks temporal change, follows multi-hop relationships, and forgets expired facts automatically. Reasoning is why it wins every benchmark.
+  </Card>
+  <Card title="A directed knowledge graph" icon="git-fork" href="/concepts/graph-memory">
+    One evolving directed graph and a single ontology across all your data — not a flat vector store, and not a raw graph you have to traverse yourself.
+  </Card>
+  <Card title="The whole context stack, one system" icon="layers" href="/concepts/super-rag">
+    Memory, user profiles, hybrid search (RAG), connectors, and file processing — together, sharing one context pool. No stitching five tools together.
+  </Card>
+  <Card title="Multi-modal — everything in" icon="file-text" href="/concepts/content-types">
+    Text, conversations, PDFs, images (OCR), video (transcription), and code (AST-aware chunking). Upload it and it just works.
+  </Card>
+  <Card title="Built to build on" icon="blocks" href="/integrations/supermemory-sdk">
+    One API, plus SDKs, a CLI, a memory filesystem, and MCP. Infrastructure you ship products on — not a closed box.
+  </Card>
+  <Card title="Run it anywhere" icon="server" href="/self-hosting/overview">
+    Hosted for zero-ops scale, or the full engine as one self-hosted binary — fully offline if you want, same API either way.
+  </Card>
+</CardGroup>
 
 <Tip>
 **Hosted or self-hosted — same API.** Use the [managed platform](https://console.supermemory.ai) for zero-ops scale, or [run the entire engine on your own machine](/self-hosting/overview) — one binary, zero config, fully offline. Move between them by changing a single `baseURL`.
 </Tip>
-
-## What you can build with it
-
-<CardGroup cols={2}>
-  <Card title="Agent memory" icon="brain" href="/concepts/graph-memory">
-    Extract and evolve facts about each user over time — knowledge updates, temporal changes, automatic forgetting.
-  </Card>
-  <Card title="User profiles" icon="user-round" href="/concepts/user-profiles">
-    A live blend of static and dynamic context your agent should always know, built automatically from memory.
-  </Card>
-  <Card title="Hybrid search (RAG)" icon="search" href="/search">
-    Semantic search with metadata filtering, contextual chunking, and reranking — over memories and raw documents in one query.
-  </Card>
-  <Card title="Content extraction" icon="file-text" href="/concepts/content-types">
-    Ingest text, conversations, PDFs, images, and even video — all turned into searchable, structured context.
-  </Card>
-  <Card title="Connectors and sync" icon="plug" href="/connectors/overview">
-    Continuously pull from Google Drive, Notion, Gmail, OneDrive, and more, with no pipeline to maintain.
-  </Card>
-  <Card title="Managed RAG platform" icon="layers" href="/concepts/super-rag">
-    Production-grade retrieval as a service, tuned to work alongside the memory engine.
-  </Card>
-</CardGroup>
-
-All of it shares the **same context pool** for a given user (`containerTag`), so memory and search reinforce each other instead of living in separate silos.
 
 ## How does it work? (at a glance)
 
 ![](/images/232.png)
 
 - You send Supermemory text, files, and chats.
-- Supermemory [intelligently indexes them](/concepts/how-it-works) and builds a semantic understanding graph on top of an entity (e.g., a user, a document, a project, an organization).
-- At query time, we fetch only the most relevant context and pass it to your models.
+- It [indexes them intelligently](/concepts/how-it-works) and builds a directed knowledge graph on top of an entity (a user, document, project, or organization).
+- At query time, it fetches only the most relevant context and passes it to your models.
 
-## Supermemory is context engineering
+## Three ways to add context
 
-We offer three ways to add context to your LLMs — mix and match them as your use case needs.
+Memory, profiles, and search all draw from the **same context pool** for a given user (`containerTag`) — so they reinforce each other instead of living in silos. Mix and match as your use case needs.
 
 #### Memory API — learned user context
 
 ![memory graph](/images/memory-graph.png)
 
-Supermemory learns and builds memory for each user. These are extracted facts that:
+Supermemory learns and builds memory for each user — extracted facts that:
 - [Evolve on top of existing context about the user](/concepts/graph-memory), **in real time**
-- Handle **knowledge updates, temporal changes, and forgetfulness**
+- Handle **knowledge updates, temporal changes, and contradictions**
 - Power a **user profile** that acts as the default context provider for the LLM
-
-_Provide this to your LLM for more contextual, personalized responses._
 
 #### User profiles
 
-The latest, evolving context about a user also produces a [**User Profile**](/concepts/user-profiles) — static and dynamic facts the agent should **always** know:
+The evolving context produces a [**User Profile**](/concepts/user-profiles) — the facts your agent should **always** know, in one ~50ms call:
 
-- **Static:** information the agent should **always** know.
-- **Dynamic:** **episodic** information about the last few conversations.
-
-Configure what counts as static vs. dynamic for your use case for extremely personalized retrieval.
+- **Static:** stable facts the agent should always know.
+- **Dynamic:** episodic context from the last few conversations.
 
 #### RAG — advanced semantic search
 
-Alongside user context, run search over the raw content. Full RAG-as-a-service, with:
-- Advanced metadata filtering
-- Contextual chunking
-- Tight integration with the memory engine
-
-<Note>
-All three approaches share the **same context pool** when using the same user ID (`containerTag`). Mix and match based on your needs.
-</Note>
+Run hybrid [search](/search) over the raw content too: advanced metadata filtering, contextual chunking, and reranking — tightly integrated with the memory engine, in a single query.
 
 ## Start building
 

--- a/apps/docs/intro.mdx
+++ b/apps/docs/intro.mdx
@@ -8,6 +8,10 @@ Supermemory is the long-term and short-term memory and context infrastructure fo
 
 With supermemory, you give your agents perfect recall about their users — so they're more intelligent, more personalized, and more consistent. Every piece of the context stack is built in, behind one API.
 
+<Tip>
+**Hosted or self-hosted — same API.** Use the [managed platform](https://console.supermemory.ai) for zero-ops scale, or [run the entire engine on your own machine](/self-hosting/overview) — one binary, zero config, fully offline. Move between them by changing a single `baseURL`.
+</Tip>
+
 ## What you can build with it
 
 <CardGroup cols={2}>

--- a/apps/docs/intro.mdx
+++ b/apps/docs/intro.mdx
@@ -4,15 +4,34 @@ sidebarTitle: "Overview"
 icon: "book-open"
 ---
 
-Supermemory is the long-term and short-term memory and context infrastructure for AI agents. It is the [state of the art](https://supermemory.ai/research) across multiple different benchmarks, like LongMemEval and LoCoMo.
+Supermemory is the long-term and short-term memory and context infrastructure for AI agents. It is the [state of the art](https://supermemory.ai/research) across multiple benchmarks, including LongMemEval and LoCoMo.
 
-With supermemory, developers can provide perfect recall about their users to build AI agents that are more intelligent, more personalized, and more consistent. Additionally, *supermemory* has all the pieces of the context stack built in:
-- [Agent memory](/concepts/graph-memory)
-- [Content extraction](/concepts/content-types)
-- [Connectors and syncing](/connectors/overview)
-- [Managed RAG platform](/concepts/super-rag)
+With supermemory, you give your agents perfect recall about their users — so they're more intelligent, more personalized, and more consistent. Every piece of the context stack is built in, behind one API.
 
-All this, coming together, makes supermemory the best abstraction to provide to agents.
+## What you can build with it
+
+<CardGroup cols={2}>
+  <Card title="Agent memory" icon="brain" href="/concepts/graph-memory">
+    Extract and evolve facts about each user over time — knowledge updates, temporal changes, automatic forgetting.
+  </Card>
+  <Card title="User profiles" icon="user-round" href="/concepts/user-profiles">
+    A live blend of static and dynamic context your agent should always know, built automatically from memory.
+  </Card>
+  <Card title="Hybrid search (RAG)" icon="search" href="/search">
+    Semantic search with metadata filtering, contextual chunking, and reranking — over memories and raw documents in one query.
+  </Card>
+  <Card title="Content extraction" icon="file-text" href="/concepts/content-types">
+    Ingest text, conversations, PDFs, images, and even video — all turned into searchable, structured context.
+  </Card>
+  <Card title="Connectors and sync" icon="plug" href="/connectors/overview">
+    Continuously pull from Google Drive, Notion, Gmail, OneDrive, and more, with no pipeline to maintain.
+  </Card>
+  <Card title="Managed RAG platform" icon="layers" href="/concepts/super-rag">
+    Production-grade retrieval as a service, tuned to work alongside the memory engine.
+  </Card>
+</CardGroup>
+
+All of it shares the **same context pool** for a given user (`containerTag`), so memory and search reinforce each other instead of living in separate silos.
 
 ## How does it work? (at a glance)
 
@@ -22,68 +41,70 @@ All this, coming together, makes supermemory the best abstraction to provide to 
 - Supermemory [intelligently indexes them](/concepts/how-it-works) and builds a semantic understanding graph on top of an entity (e.g., a user, a document, a project, an organization).
 - At query time, we fetch only the most relevant context and pass it to your models.
 
-## Supermemory is context engineering.
+## Supermemory is context engineering
 
-#### Ingestion and Extraction
+We offer three ways to add context to your LLMs — mix and match them as your use case needs.
 
-Supermemory handles all the extraction, for [any data type that you have](/concepts/content-types).
-- Text
-- Conversations
-- Files (PDF, Images, Docs)
-- Even videos!
-
-... and then,
-
-We offer three ways to add context to your LLMs:
-
-#### Memory API — Learned user context
+#### Memory API — learned user context
 
 ![memory graph](/images/memory-graph.png)
 
-Supermemory learns and builds the memory for the user. These are extracted facts about the user, that:
+Supermemory learns and builds memory for each user. These are extracted facts that:
 - [Evolve on top of existing context about the user](/concepts/graph-memory), **in real time**
-- Handle **knowledge updates, temporal changes, forgetfulness**
-- Creates a **user profile** as the default context provider for the LLM.
+- Handle **knowledge updates, temporal changes, and forgetfulness**
+- Power a **user profile** that acts as the default context provider for the LLM
 
-_This can then be provided to the LLM, to give more contextual, personalized responses._
+_Provide this to your LLM for more contextual, personalized responses._
 
 #### User profiles
 
-Having the latest, evolving context about the user allows us to also create a [**User Profile**](/concepts/user-profiles). This is a combination of static and dynamic facts about the user, that the agent should **always know**
-Developers can configure supermemory with what static and dynamic contents are, depending on their use case.
+The latest, evolving context about a user also produces a [**User Profile**](/concepts/user-profiles) — static and dynamic facts the agent should **always** know:
 
-- Static: Information that the agent should **always** know.
-- Dynamic: **Episodic** information, about last few conversations etc.
+- **Static:** information the agent should **always** know.
+- **Dynamic:** **episodic** information about the last few conversations.
 
-This leads to a much better retrieval system, and extremely personalized responses.
+Configure what counts as static vs. dynamic for your use case for extremely personalized retrieval.
 
-#### RAG - Advanced semantic search
+#### RAG — advanced semantic search
 
-Along with the user context, developers can also choose to do a search on the raw context. We provide full RAG-as-a-service, along with
-- Full advanced metadata filtering
+Alongside user context, run search over the raw content. Full RAG-as-a-service, with:
+- Advanced metadata filtering
 - Contextual chunking
-- Works well with the memory engine
-
-<Info>
-    See the full API Reference tab for detailed endpoint documentation.
-</Info>
-
+- Tight integration with the memory engine
 
 <Note>
-All three approaches share the **same context pool** when using the same user ID (`containerTag`). You can mix and match based on your needs.
+All three approaches share the **same context pool** when using the same user ID (`containerTag`). Mix and match based on your needs.
 </Note>
 
-## Next steps
+## Start building
 
-<CardGroup cols={2}>
+<CardGroup cols={3}>
   <Card title="Quickstart" icon="play" href="/quickstart">
-    Make your first API call in minutes
+    Make your first API call in minutes.
   </Card>
-  <Card title="How it Works" icon="cpu" href="/concepts/how-it-works">
-    Understand the knowledge graph architecture
+  <Card title="Add your first memory" icon="plus" href="/add-memories">
+    Ingest text, files, and conversations into a container.
   </Card>
-  <Card title="Self-host it" icon="server" href="/self-hosting/overview">
-    Run Supermemory on your own machine — one binary, zero config, fully offline
+  <Card title="Search it" icon="search" href="/search">
+    Retrieve the most relevant context with hybrid semantic search.
   </Card>
 </CardGroup>
 
+## Ways to use Supermemory
+
+The API is the core — but you don't have to talk to it directly. Reach Supermemory however fits your workflow:
+
+<CardGroup cols={2}>
+  <Card title="SDKs" icon="code" href="/integrations/supermemory-sdk">
+    Official TypeScript and Python SDKs, plus drop-in plugins for the AI SDK, OpenAI, LangChain, and more.
+  </Card>
+  <Card title="Command line (CLI)" icon="square-terminal" href="/cli/overview">
+    Manage memories, search, and scripting from your terminal — it's all `npx supermemory`.
+  </Card>
+  <Card title="Memory filesystem (SMFS)" icon="database" href="/smfs/overview">
+    Mount a container as a real directory your agent can `ls`, `cat`, and semantically `grep`.
+  </Card>
+  <Card title="Self-host it" icon="server" href="/self-hosting/overview">
+    Run the full memory engine on your own machine — one binary, zero config, fully offline.
+  </Card>
+</CardGroup>


### PR DESCRIPTION
## What

- **New CLI docs.** The Supermemory CLI (`npx supermemory`) had no documentation. Adds a **Command Line (CLI)** group under the Developer Platform tab:
  - `cli/overview` — what the CLI is, install (`npx supermemory` or global), auth, config scopes, env vars, global flags, and the two-things framing (manage cloud memory vs. run a local server).
  - `cli/commands` — complete command/flag reference: `add`, `search`, `remember`, `forget`, `update`, `profile`, `docs`, `tags`, `keys`, `connectors`, `plugins`, `team`, `status`, `logs`, `billing`, utility commands, scoped-keys mode, and scripting/CI patterns.
  - `cli/local` — documents `npx supermemory local` (the self-hosted server) with a cloud-CLI-vs-local-server comparison table, cross-linked into the existing Self-Hosting docs rather than duplicating them.

- **SMFS embedded into main nav.** SMFS was a separate top-level anchor (its own dropdown), which made it feel detached. Moved it to a group inside the main Developer Platform anchor ("SMFS (Memory Filesystem)", after Connectors) and removed the standalone anchor.

## Why

Surfaces the CLI (cloud commands + `npx supermemory local`) which was undocumented, and brings SMFS into the main docs flow so it's discoverable instead of sitting off on its own.

## Notes for reviewers

- Commands were verified against the actual CLI source (`apps/cli/src/commands/*`, `apps/cli/src/index.ts` in the mono repo) and the existing self-hosting docs.
- SMFS page URLs (`smfs/*`) are unchanged — nav placement only, so **no redirects needed**.
- Invocation is written as `npx supermemory` per how the product is presented. If the published npm package name is `@supermemory/cli` rather than bare `supermemory`, the install / `npx` lines in `cli/overview` and `cli/local` should be adjusted.
- `docs.json` validated as JSON; all referenced pages exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)