### PR TITLE
fix oauth resume redirect

### DIFF
--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -33,6 +33,19 @@ function buildMcpAuthorizeResumeUrl(
 	const p = new URLSearchParams(sp.toString())
 	p.delete("redirect")
 	p.delete("error")
+	p.delete("exp")
+	p.delete("sig")
+
+	const prompt = p
+		.get("prompt")
+		?.split(" ")
+		.filter((value) => value && value !== "login")
+	if (prompt?.length) {
+		p.set("prompt", prompt.join(" "))
+	} else {
+		p.delete("prompt")
+	}
+
 	return `${backend}/api/auth/oauth2/authorize?${p.toString()}`
 }
 


### PR DESCRIPTION
Fix the Claude Desktop MCP OAuth resume path after login/org selection.

- drop stale signed Better Auth params before resuming \`/oauth2/authorize\`
- consume \`prompt=login\` so approve can continue to consent/code redirect instead of looping back to login

Tested with \`bunx biome check apps/web/app/'(auth)'/login/page.tsx\`.