### PR TITLE
fix mcp consent org restore

### DIFF
--- a/packages/lib/auth-context.tsx
+++ b/packages/lib/auth-context.tsx
@@ -111,6 +111,11 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 
 		const run = async () => {
 			try {
+				// OAuth consent owns org selection for the authorization transaction.
+				const shouldRestoreSavedOrg =
+					typeof window === "undefined" ||
+					window.location.pathname !== "/oauth/consent"
+
 				if (orgs.length === 0) {
 					if (!cancelled) setOrg(null)
 					return
@@ -130,19 +135,21 @@ export function AuthProvider({ children }: { children: ReactNode }) {
 					return
 				}
 
-				const savedSlug = localStorage.getItem(STORAGE_KEY)
-				if (savedSlug) {
-					const match = orgs.find((o) => o.slug === savedSlug)
-					if (match) {
-						if (activeOrgId === match.id) {
-							const full = await authClient.organization.getFullOrganization()
-							if (!cancelled) setOrg(full?.data ?? null)
-						} else {
-							await setActiveOrg(savedSlug)
+				if (shouldRestoreSavedOrg) {
+					const savedSlug = localStorage.getItem(STORAGE_KEY)
+					if (savedSlug) {
+						const match = orgs.find((o) => o.slug === savedSlug)
+						if (match) {
+							if (activeOrgId === match.id) {
+								const full = await authClient.organization.getFullOrganization()
+								if (!cancelled) setOrg(full?.data ?? null)
+							} else {
+								await setActiveOrg(savedSlug)
+							}
+							return
 						}
-						return
+						localStorage.removeItem(STORAGE_KEY)
 					}
-					localStorage.removeItem(STORAGE_KEY)
 				}
 
 				if (activeOrgId) {


### PR DESCRIPTION
Stops Nova's saved active org from overriding the org picked on the MCP OAuth consent page.

- skips localStorage org restoration on `/oauth/consent`
- keeps normal Nova org restore behavior everywhere else

Testing:
- `bunx biome check --write packages/lib/auth-context.tsx`
- `bun run --filter @repo/web lint` passes with existing warnings
- `bunx tsc --noEmit --project apps/web/tsconfig.json` fails on existing unrelated type errors outside this change