### PR TITLE
Fix integrations page double-refresh on load

### DIFF
--- a/apps/web/components/ensure-workspace.tsx
+++ b/apps/web/components/ensure-workspace.tsx
@@ -29,8 +29,7 @@ export function EnsureWorkspace({ children }: { children: React.ReactNode }) {
 	// While the session is still pending we can't tell guest from logged-in, so
 	// rendering the public page optimistically here causes a logged-in user to
 	// see public content → loading shell → authenticated content (a double flash).
-	const isGuestPublicAppPage =
-		isPublicAppPage && !session && !isSessionPending
+	const isGuestPublicAppPage = isPublicAppPage && !session && !isSessionPending
 	const isOnboarding = pathname.startsWith("/onboarding")
 
 	useEffect(() => {

--- a/apps/web/components/ensure-workspace.tsx
+++ b/apps/web/components/ensure-workspace.tsx
@@ -25,10 +25,6 @@ export function EnsureWorkspace({ children }: { children: React.ReactNode }) {
 	const isPublicAppPage =
 		pathname === "/" &&
 		["integrations", "mcp"].includes(searchParams.get("view") ?? "")
-	// Only treat this as a guest page once the session state is actually known.
-	// While the session is still pending we can't tell guest from logged-in, so
-	// rendering the public page optimistically here causes a logged-in user to
-	// see public content → loading shell → authenticated content (a double flash).
 	const isGuestPublicAppPage = isPublicAppPage && !session && !isSessionPending
 	const isOnboarding = pathname.startsWith("/onboarding")
 

--- a/apps/web/components/ensure-workspace.tsx
+++ b/apps/web/components/ensure-workspace.tsx
@@ -20,12 +20,17 @@ export function EnsureWorkspace({ children }: { children: React.ReactNode }) {
 	const pathname = usePathname()
 	const router = useRouter()
 	const searchParams = useSearchParams()
-	const { session, organizations, isRestoring } = useAuth()
+	const { session, organizations, isRestoring, isSessionPending } = useAuth()
 
 	const isPublicAppPage =
 		pathname === "/" &&
 		["integrations", "mcp"].includes(searchParams.get("view") ?? "")
-	const isGuestPublicAppPage = isPublicAppPage && !session
+	// Only treat this as a guest page once the session state is actually known.
+	// While the session is still pending we can't tell guest from logged-in, so
+	// rendering the public page optimistically here causes a logged-in user to
+	// see public content → loading shell → authenticated content (a double flash).
+	const isGuestPublicAppPage =
+		isPublicAppPage && !session && !isSessionPending
 	const isOnboarding = pathname.startsWith("/onboarding")
 
 	useEffect(() => {


### PR DESCRIPTION
EnsureWorkspace treated /?view=integrations (and ?view=mcp) as a guest public page whenever there was no session object yet. During initial load the session is merely *pending*, not absent, so a logged-in user would:

  1. render the page optimistically (isGuestPublicAppPage = true), then
  2. have it swapped for the loading shell once the session resolved and org restore began (isRestoring), then
  3. re-render the page once restore finished.

That mount → loader → remount sequence is the visible "refresh twice".

Gate isGuestPublicAppPage on !isSessionPending so the guest/public path is only taken once the session state is actually known. While pending we now show the loading shell, giving a single clean transition to the authenticated page.


Claude-Session: https://claude.ai/code/session_01LShTAfUnV7zwXenzoH2dRE