### PR TITLE
Add request timeouts to Supermemory MCP client calls

### DIFF
--- a/apps/mcp/src/auth.ts
+++ b/apps/mcp/src/auth.ts
@@ -103,6 +103,7 @@ export async function validateOAuthToken(
 			headers: {
 				Authorization: `Bearer ${token}`,
 			},
+			signal: AbortSignal.timeout(30_000),
 		})
 
 		if (!sessionResponse.ok) {

--- a/apps/mcp/src/client.ts
+++ b/apps/mcp/src/client.ts
@@ -2,6 +2,7 @@ import Supermemory from "supermemory"
 
 const MAX_CHARS = 200000 // ~50k tokens (character-based limit)
 const DEFAULT_PROJECT_ID = "sm_project_default"
+const FETCH_TIMEOUT_MS = 30_000
 
 interface MemoryRichFields {
 	metadata?: Record<string, unknown> | null
@@ -142,6 +143,7 @@ export class SupermemoryClient {
 		this.client = new Supermemory({
 			apiKey: bearerToken,
 			baseURL: apiUrl,
+			timeout: FETCH_TIMEOUT_MS,
 		})
 		this.containerTag = containerTag || DEFAULT_PROJECT_ID
 	}
@@ -328,14 +330,16 @@ export class SupermemoryClient {
 	}
 
 	// Get projects list
-	async getProjects(): Promise<string[]> {
+	async getProjects(options?: { signal?: AbortSignal }): Promise<string[]> {
 		try {
+			const signal = options?.signal ?? AbortSignal.timeout(FETCH_TIMEOUT_MS)
 			const response = await fetch(`${this.apiUrl}/v3/projects`, {
 				method: "GET",
 				headers: {
 					Authorization: `Bearer ${this.bearerToken}`,
 					"Content-Type": "application/json",
 				},
+				signal,
 			})
 
 			if (!response.ok) {
@@ -359,8 +363,10 @@ export class SupermemoryClient {
 		containerTags?: string[],
 		page = 1,
 		limit = 10,
+		options?: { signal?: AbortSignal },
 	): Promise<DocumentsApiResponse> {
 		try {
+			const signal = options?.signal ?? AbortSignal.timeout(FETCH_TIMEOUT_MS)
 			const response = await fetch(`${this.apiUrl}/v3/documents/documents`, {
 				method: "POST",
 				headers: {
@@ -374,6 +380,7 @@ export class SupermemoryClient {
 					order: "desc",
 					containerTags,
 				}),
+				signal,
 			})
 			if (!response.ok) {
 				throw Object.assign(new Error("Failed to fetch documents"), {
@@ -387,6 +394,14 @@ export class SupermemoryClient {
 	}
 
 	private handleError(error: unknown): never {
+		// Handle request timeout (AbortSignal.timeout or explicit abort)
+		if (
+			error instanceof Error &&
+			(error.name === "AbortError" || error.name === "TimeoutError")
+		) {
+			throw new Error("Request to Supermemory API timed out")
+		}
+
 		// Handle network/fetch errors
 		if (error instanceof TypeError) {
 			if (

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -89,6 +89,7 @@ app.get("/.well-known/oauth-authorization-server", async (c) => {
 		// Fetch the authorization server metadata from the main API
 		const response = await fetch(
 			`${apiUrl}/.well-known/oauth-authorization-server`,
+			{ signal: AbortSignal.timeout(30_000) },
 		)
 
 		if (!response.ok) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Outbound requests from the `supermemory-mcp` Durable Object to `api.supermemory.ai` had no client-side timeout, causing stalls of up to ~318 seconds when downstream services (Turbopuffer, Gemini) were slow. Two separate code paths were affected:

1. **SDK calls** (`search`, `add`, `forget`, `profile`) — the `Supermemory` SDK client was constructed without a `timeout` option, so it defaulted to 60 seconds or whatever the underlying runtime allows.
2. **Manual `fetch` calls** (`getProjects`, `getDocuments`) — these had no `signal` or `AbortSignal` at all, meaning they could stall indefinitely.

## Changes (`apps/mcp/src/client.ts`)

- **`FETCH_TIMEOUT_MS = 30_000`** — new constant following the existing pattern in `apps/api/src/services/extraction/extractors/image.ts`.
- **SDK constructor** — pass `timeout: FETCH_TIMEOUT_MS` so all SDK-backed calls are bounded to 30 seconds.
- **`getProjects(options?: { signal?: AbortSignal })`** — thread an `AbortSignal` into the fetch; defaults to `AbortSignal.timeout(30_000)` when no caller-supplied signal is present.
- **`getDocuments(containerTags?, page?, limit?, options?: { signal?: AbortSignal })`** — same pattern.
- **`handleError`** — new guard catches `AbortError` / `TimeoutError` and surfaces a friendly `"Request to Supermemory API timed out"` message instead of an opaque crash, consistent with existing friendly error messages.

## Assumptions

- 30 seconds is an appropriate upper bound for MCP tool calls (matches the SDK default the plan recommended and the constant already used elsewhere in the repo).
- Callers in `server.ts` do not currently have an easy per-request `AbortSignal` from the `McpAgent`/`ExecutionContext`, so the `options` parameter is left as an extension point for future use; all existing call sites pick up the default 30-second timeout automatically.
- Pre-existing type errors in unrelated packages (`@supermemory/tools`, `@supermemory/ai-sdk`) are not caused by this change — the MCP package itself has no new type errors.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-710124c9-8167-4958-9a05-cfc1c88b4651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-710124c9-8167-4958-9a05-cfc1c88b4651"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

