### PR TITLE
Merge timeout fix PR #1142 to stop supermemory MCP stalls

### DIFF
--- a/apps/mcp/src/auth.ts
+++ b/apps/mcp/src/auth.ts
@@ -4,11 +4,25 @@
  * This validates OAuth tokens and API keys by calling the main Supermemory API,
  */
 
+import { FETCH_TIMEOUT_MS } from "./constants"
+
 export interface AuthUser {
 	userId: string
 	apiKey: string
 	email?: string
 	name?: string
+}
+
+export type AuthValidationResult =
+	| { status: "success"; user: AuthUser }
+	| { status: "invalid" }
+	| { status: "timeout" }
+
+function isFetchTimeout(error: unknown): boolean {
+	return (
+		error instanceof Error &&
+		(error.name === "AbortError" || error.name === "TimeoutError")
+	)
 }
 
 /**
@@ -25,13 +39,14 @@ export function isApiKey(token: string): boolean {
 export async function validateApiKey(
 	apiKey: string,
 	apiUrl: string,
-): Promise<AuthUser | null> {
+): Promise<AuthValidationResult> {
 	try {
 		const sessionResponse = await fetch(`${apiUrl}/v3/session`, {
 			method: "GET",
 			headers: {
 				Authorization: `Bearer ${apiKey}`,
 			},
+			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
 		})
 
 		if (!sessionResponse.ok) {
@@ -56,7 +71,7 @@ export async function validateApiKey(
 			} else {
 				console.error("API key validation failed:", status, responseText)
 			}
-			return null
+			return { status: "invalid" }
 		}
 
 		const sessionData = (await sessionResponse.json()) as {
@@ -72,20 +87,27 @@ export async function validateApiKey(
 
 		if (!sessionData?.user?.id) {
 			console.error("Missing user.id in session response:", sessionData)
-			return null
+			return { status: "invalid" }
 		}
 
 		console.log("API key validated for user:", sessionData.user.id)
 
 		return {
-			userId: sessionData.user.id,
-			apiKey: apiKey,
-			email: sessionData.user.email,
-			name: sessionData.user.name,
+			status: "success",
+			user: {
+				userId: sessionData.user.id,
+				apiKey: apiKey,
+				email: sessionData.user.email,
+				name: sessionData.user.name,
+			},
 		}
 	} catch (error) {
+		if (isFetchTimeout(error)) {
+			console.error("API key validation timed out")
+			return { status: "timeout" }
+		}
 		console.error("API key validation error:", error)
-		return null
+		return { status: "invalid" }
 	}
 }
 
@@ -96,14 +118,14 @@ export async function validateApiKey(
 export async function validateOAuthToken(
 	token: string,
 	apiUrl: string,
-): Promise<AuthUser | null> {
+): Promise<AuthValidationResult> {
 	try {
 		const sessionResponse = await fetch(`${apiUrl}/v3/mcp/session-with-key`, {
 			method: "GET",
 			headers: {
 				Authorization: `Bearer ${token}`,
 			},
-			signal: AbortSignal.timeout(30_000),
+			signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
 		})
 
 		if (!sessionResponse.ok) {
@@ -128,7 +150,7 @@ export async function validateOAuthToken(
 			} else {
 				console.error("Token validation failed:", status, responseText)
 			}
-			return null
+			return { status: "invalid" }
 		}
 
 		const sessionData = (await sessionResponse.json()) as {
@@ -144,19 +166,26 @@ export async function validateOAuthToken(
 				"Missing userId or apiKey in session response:",
 				sessionData,
 			)
-			return null
+			return { status: "invalid" }
 		}
 
 		console.log("OAuth validated, got API key for user:", sessionData.userId)
 
 		return {
-			userId: sessionData.userId,
-			apiKey: sessionData.apiKey,
-			email: sessionData.email,
-			name: sessionData.name,
+			status: "success",
+			user: {
+				userId: sessionData.userId,
+				apiKey: sessionData.apiKey,
+				email: sessionData.email,
+				name: sessionData.name,
+			},
 		}
 	} catch (error) {
+		if (isFetchTimeout(error)) {
+			console.error("Token validation timed out")
+			return { status: "timeout" }
+		}
 		console.error("Token validation error:", error)
-		return null
+		return { status: "invalid" }
 	}
 }

--- a/apps/mcp/src/auth.ts
+++ b/apps/mcp/src/auth.ts
@@ -103,6 +103,7 @@ export async function validateOAuthToken(
 			headers: {
 				Authorization: `Bearer ${token}`,
 			},
+			signal: AbortSignal.timeout(30_000),
 		})
 
 		if (!sessionResponse.ok) {

--- a/apps/mcp/src/client.ts
+++ b/apps/mcp/src/client.ts
@@ -2,6 +2,7 @@ import Supermemory from "supermemory"
 
 const MAX_CHARS = 200000 // ~50k tokens (character-based limit)
 const DEFAULT_PROJECT_ID = "sm_project_default"
+const FETCH_TIMEOUT_MS = 30_000
 
 interface MemoryRichFields {
 	metadata?: Record<string, unknown> | null
@@ -142,6 +143,7 @@ export class SupermemoryClient {
 		this.client = new Supermemory({
 			apiKey: bearerToken,
 			baseURL: apiUrl,
+			timeout: FETCH_TIMEOUT_MS,
 		})
 		this.containerTag = containerTag || DEFAULT_PROJECT_ID
 	}
@@ -328,14 +330,16 @@ export class SupermemoryClient {
 	}
 
 	// Get projects list
-	async getProjects(): Promise<string[]> {
+	async getProjects(options?: { signal?: AbortSignal }): Promise<string[]> {
 		try {
+			const signal = options?.signal ?? AbortSignal.timeout(FETCH_TIMEOUT_MS)
 			const response = await fetch(`${this.apiUrl}/v3/projects`, {
 				method: "GET",
 				headers: {
 					Authorization: `Bearer ${this.bearerToken}`,
 					"Content-Type": "application/json",
 				},
+				signal,
 			})
 
 			if (!response.ok) {
@@ -359,8 +363,10 @@ export class SupermemoryClient {
 		containerTags?: string[],
 		page = 1,
 		limit = 10,
+		options?: { signal?: AbortSignal },
 	): Promise<DocumentsApiResponse> {
 		try {
+			const signal = options?.signal ?? AbortSignal.timeout(FETCH_TIMEOUT_MS)
 			const response = await fetch(`${this.apiUrl}/v3/documents/documents`, {
 				method: "POST",
 				headers: {
@@ -374,6 +380,7 @@ export class SupermemoryClient {
 					order: "desc",
 					containerTags,
 				}),
+				signal,
 			})
 			if (!response.ok) {
 				throw Object.assign(new Error("Failed to fetch documents"), {
@@ -387,6 +394,14 @@ export class SupermemoryClient {
 	}
 
 	private handleError(error: unknown): never {
+		// Handle request timeout (AbortSignal.timeout or explicit abort)
+		if (
+			error instanceof Error &&
+			(error.name === "AbortError" || error.name === "TimeoutError")
+		) {
+			throw new Error("Request to Supermemory API timed out")
+		}
+
 		// Handle network/fetch errors
 		if (error instanceof TypeError) {
 			if (

--- a/apps/mcp/src/client.ts
+++ b/apps/mcp/src/client.ts
@@ -1,8 +1,9 @@
-import Supermemory from "supermemory"
+import Supermemory, { APIConnectionTimeoutError } from "supermemory"
+
+import { FETCH_TIMEOUT_MS } from "./constants"
 
 const MAX_CHARS = 200000 // ~50k tokens (character-based limit)
 const DEFAULT_PROJECT_ID = "sm_project_default"
-const FETCH_TIMEOUT_MS = 30_000
 
 interface MemoryRichFields {
 	metadata?: Record<string, unknown> | null
@@ -144,6 +145,7 @@ export class SupermemoryClient {
 			apiKey: bearerToken,
 			baseURL: apiUrl,
 			timeout: FETCH_TIMEOUT_MS,
+			maxRetries: 0,
 		})
 		this.containerTag = containerTag || DEFAULT_PROJECT_ID
 	}
@@ -394,10 +396,10 @@ export class SupermemoryClient {
 	}
 
 	private handleError(error: unknown): never {
-		// Handle request timeout (AbortSignal.timeout or explicit abort)
 		if (
-			error instanceof Error &&
-			(error.name === "AbortError" || error.name === "TimeoutError")
+			error instanceof APIConnectionTimeoutError ||
+			(error instanceof Error &&
+				(error.name === "AbortError" || error.name === "TimeoutError"))
 		) {
 			throw new Error("Request to Supermemory API timed out")
 		}

--- a/apps/mcp/src/constants.ts
+++ b/apps/mcp/src/constants.ts
@@ -1,0 +1,1 @@
+export const FETCH_TIMEOUT_MS = 30_000

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -2,6 +2,7 @@ import { cors } from "hono/cors"
 import { Hono, type Context } from "hono"
 import { SupermemoryMCP } from "./server"
 import { isApiKey, validateApiKey, validateOAuthToken } from "./auth"
+import { FETCH_TIMEOUT_MS } from "./constants"
 import { initPosthog } from "./posthog"
 import type { ContentfulStatusCode } from "hono/utils/http-status"
 
@@ -89,7 +90,7 @@ app.get("/.well-known/oauth-authorization-server", async (c) => {
 		// Fetch the authorization server metadata from the main API
 		const response = await fetch(
 			`${apiUrl}/.well-known/oauth-authorization-server`,
-			{ signal: AbortSignal.timeout(30_000) },
+			{ signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) },
 		)
 
 		if (!response.ok) {
@@ -136,22 +137,32 @@ const handleMcpRequest = async (c: Context<{ Bindings: Bindings }>) => {
 		})
 	}
 
-	let authUser: {
-		userId: string
-		apiKey: string
-		email?: string
-		name?: string
-	} | null = null
+	let authResult = isApiKey(token)
+		? await validateApiKey(token, apiUrl)
+		: await validateOAuthToken(token, apiUrl)
 
-	if (isApiKey(token)) {
-		console.log("Authenticating with API key")
-		authUser = await validateApiKey(token, apiUrl)
-	} else {
-		console.log("Authenticating with OAuth token")
-		authUser = await validateOAuthToken(token, apiUrl)
+	if (authResult.status === "timeout") {
+		return new Response(
+			JSON.stringify({
+				jsonrpc: "2.0",
+				error: {
+					code: -32000,
+					message: "Authentication service timed out. Please try again.",
+				},
+				id: null,
+			}),
+			{
+				status: 504,
+				headers: {
+					"Content-Type": "application/json",
+					"Access-Control-Expose-Headers": "WWW-Authenticate",
+					"Access-Control-Allow-Origin": "*",
+				},
+			},
+		)
 	}
 
-	if (!authUser) {
+	if (authResult.status !== "success") {
 		const errorMessage = isApiKey(token)
 			? "Unauthorized: Invalid or expired API key"
 			: "Unauthorized: Invalid or expired token"
@@ -176,6 +187,8 @@ const handleMcpRequest = async (c: Context<{ Bindings: Bindings }>) => {
 			},
 		)
 	}
+
+	const authUser = authResult.user
 
 	// Create execution context with authenticated user props
 	const ctx = {

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -89,6 +89,7 @@ app.get("/.well-known/oauth-authorization-server", async (c) => {
 		// Fetch the authorization server metadata from the main API
 		const response = await fetch(
 			`${apiUrl}/.well-known/oauth-authorization-server`,
+			{ signal: AbortSignal.timeout(30_000) },
 		)
 
 		if (!response.ok) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Outbound requests from the `supermemory-mcp` Durable Object to `api.supermemory.ai` had no client-side timeout, causing stalls of up to ~318 seconds when downstream services (Turbopuffer, Gemini) were slow. Two code paths were affected:

1. **SDK calls** (`search`, `add`, `forget`, `profile`) — the `Supermemory` SDK client was constructed without a `timeout` option.
2. **Manual `fetch` calls** (`getProjects`, `getDocuments`, auth endpoints, OAuth metadata proxy) — no `signal` or `AbortSignal` at all, meaning stalls could last indefinitely.

## Changes

### `apps/mcp/src/client.ts`
- Added `FETCH_TIMEOUT_MS = 30_000` constant
- Passed `timeout: FETCH_TIMEOUT_MS` to the `Supermemory` SDK constructor to bound all SDK-backed calls
- Added `options?: { signal?: AbortSignal }` to `getProjects` and `getDocuments`, defaulting to `AbortSignal.timeout(FETCH_TIMEOUT_MS)`
- Extended `handleError` to catch `AbortError` / `TimeoutError` and surface a friendly `"Request to Supermemory API timed out"` message

### `apps/mcp/src/auth.ts`
- Added `signal: AbortSignal.timeout(30_000)` to the `validateOAuthToken` fetch call

### `apps/mcp/src/index.ts`
- Added `signal: AbortSignal.timeout(30_000)` to the OAuth authorization server metadata proxy fetch

## Assumptions

- 30 seconds is an appropriate upper bound for MCP tool calls (matches the existing timeout constant pattern used elsewhere in the repo).
- Callers in `server.ts` do not currently have a per-request `AbortSignal` from the `McpAgent`/`ExecutionContext`, so the `options` parameter serves as an extension point for future use; all existing call sites pick up the 30-second default automatically.
- Pre-existing type errors in unrelated packages (`@supermemory/tools`) are not caused by this change — the MCP package itself has no new type errors.

Closes the latency anomaly reported in Polylane investigation `fix_ee52cb420001xem6qyi2tc7t`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-70560bce-8e95-44d9-8b71-79612fbac796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-70560bce-8e95-44d9-8b71-79612fbac796"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/8a0213b0-8d79-4a6d-8e87-59b95c5a9ab4)
- Requested by: Mahesh Sanikommu (mahesh@supermemory.com)
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
