### PR TITLE
Restore cf:service=supermemory tag on supermemory worker

### DIFF
--- a/apps/web/wrangler.jsonc
+++ b/apps/web/wrangler.jsonc
@@ -2,6 +2,7 @@
 	"$schema": "node_modules/wrangler/config-schema.json",
 	"main": ".open-next/worker.js",
 	"name": "supermemory-app",
+	"tags": ["cf:service=supermemory"],
 	"compatibility_date": "2024-12-30",
 	"compatibility_flags": [
 		// Enable Node.js API


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The Cloudflare Worker for the supermemory web application lost its `cf:service=supermemory` tag after a batch redeployment. This PR restores it by adding the `tags` field to `apps/web/wrangler.jsonc` so the tag is applied on every subsequent deploy.

## Changes

- `apps/web/wrangler.jsonc`: Added `"tags": ["cf:service=supermemory"]` to the top-level worker configuration.

## Assumptions & Investigation Notes

The Polylane autofix report referenced a Cloudflare Worker named **`supermemory`** (account `47c2b4d598af9d423c06fc9f936226d5`) that lost its `cf:service=supermemory` tag. After searching the repository:

- No wrangler config with `"name": "supermemory"` exists in this monorepo.
- Two workers are present: `supermemory-mcp` (`apps/mcp/wrangler.jsonc`) and `supermemory-app` (`apps/web/wrangler.jsonc`).
- The CLAUDE.md references a primary API backend (serving `api.supermemory.ai`) that is not tracked in this repo — that worker may be the one originally named `supermemory`.
- Git history shows the web app worker was introduced as `supermemory-consumer` then renamed to `supermemory-app`; neither matches `supermemory` exactly.

Given the ambiguity, the tag is applied to **`supermemory-app`** (the primary consumer-facing web application) as the best available candidate. If the tag should instead go on a different worker (e.g., a private API repo), this PR demonstrates the pattern to follow there.

## Scope

No worker code, bindings, routes, or observability configuration is changed. This is a pure metadata addition.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-b00d5a32-87cb-4f98-a526-74a486e72889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-b00d5a32-87cb-4f98-a526-74a486e72889"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

