### PR TITLE
Add 30s request timeouts to supermemory-mcp to prevent Durable Object stalls

### DIFF
--- a/apps/mcp/src/auth.ts
+++ b/apps/mcp/src/auth.ts
@@ -32,6 +32,7 @@ export async function validateApiKey(
 			headers: {
 				Authorization: `Bearer ${apiKey}`,
 			},
+			signal: AbortSignal.timeout(30_000),
 		})
 
 		if (!sessionResponse.ok) {
@@ -103,6 +104,7 @@ export async function validateOAuthToken(
 			headers: {
 				Authorization: `Bearer ${token}`,
 			},
+			signal: AbortSignal.timeout(30_000),
 		})
 
 		if (!sessionResponse.ok) {

--- a/apps/mcp/src/client.ts
+++ b/apps/mcp/src/client.ts
@@ -142,6 +142,7 @@ export class SupermemoryClient {
 		this.client = new Supermemory({
 			apiKey: bearerToken,
 			baseURL: apiUrl,
+			timeout: 30_000,
 		})
 		this.containerTag = containerTag || DEFAULT_PROJECT_ID
 	}
@@ -336,6 +337,7 @@ export class SupermemoryClient {
 					Authorization: `Bearer ${this.bearerToken}`,
 					"Content-Type": "application/json",
 				},
+				signal: AbortSignal.timeout(30_000),
 			})
 
 			if (!response.ok) {
@@ -374,6 +376,7 @@ export class SupermemoryClient {
 					order: "desc",
 					containerTags,
 				}),
+				signal: AbortSignal.timeout(30_000),
 			})
 			if (!response.ok) {
 				throw Object.assign(new Error("Failed to fetch documents"), {
@@ -387,6 +390,19 @@ export class SupermemoryClient {
 	}
 
 	private handleError(error: unknown): never {
+		// Handle request timeout errors (AbortError from AbortSignal.timeout or SDK TimeoutError)
+		if (error instanceof Error) {
+			if (
+				error.name === "AbortError" ||
+				error.name === "TimeoutError" ||
+				error.message.toLowerCase().includes("timeout")
+			) {
+				throw new Error(
+					"Request to Supermemory API timed out. Please try again.",
+				)
+			}
+		}
+
 		// Handle network/fetch errors
 		if (error instanceof TypeError) {
 			if (

--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -89,6 +89,7 @@ app.get("/.well-known/oauth-authorization-server", async (c) => {
 		// Fetch the authorization server metadata from the main API
 		const response = await fetch(
 			`${apiUrl}/.well-known/oauth-authorization-server`,
+			{ signal: AbortSignal.timeout(30_000) },
 		)
 
 		if (!response.ok) {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a production incident where `supermemory-mcp` made unbounded upstream fetches that blocked the `SupermemoryMCP` Durable Object event loop for hundreds of seconds, causing `durable_object_subrequest` wall-time to spike >100x. Telemetry confirmed subrequests with wall times of thousands of seconds but only ~12 ms CPU — classic I/O blocking on unbounded fetches.

## Changes

### `apps/mcp/src/client.ts`
- Add `timeout: 30_000` to the `Supermemory` SDK constructor so all SDK calls (`search`, `add`, `forget`, `profile`) are bounded by 30 seconds
- Add `signal: AbortSignal.timeout(30_000)` to the manual `fetch` in `getProjects()`
- Add `signal: AbortSignal.timeout(30_000)` to the manual `fetch` in `getDocuments()`
- Add `AbortError`/`TimeoutError` guard in `handleError()` that maps timeout errors to a clear user-facing message: `"Request to Supermemory API timed out. Please try again."`

### `apps/mcp/src/auth.ts`
- Add `signal: AbortSignal.timeout(30_000)` to the `fetch` in `validateApiKey()`
- Add `signal: AbortSignal.timeout(30_000)` to the `fetch` in `validateOAuthToken()`

### `apps/mcp/src/index.ts`
- Add `signal: AbortSignal.timeout(30_000)` to the `fetch` in the `/.well-known/oauth-authorization-server` proxy handler

## Assumptions

- 30 seconds is chosen as the timeout per the incident investigation recommendation. The Supermemory SDK's default is 1 minute; overriding to 30s keeps Durable Object event-loop slots free.
- `AbortSignal.timeout()` is available in the Cloudflare Workers runtime (it has been since 2022).
- No application behavior changes beyond adding timeouts and the corresponding error handling.

## Testing

- TypeScript check (`tsc --noEmit --skipLibCheck`) on `apps/mcp` passes cleanly with exit code 0.
- Pre-existing type errors in `@supermemory/tools` are unrelated to this change and existed before this PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a322624-4114-4870-b9f3-5941774af7f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a322624-4114-4870-b9f3-5941774af7f7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

