### PR TITLE
Add Agents space for shared coding memories

### DIFF
--- a/apps/web/components/memories-grid.tsx
+++ b/apps/web/components/memories-grid.tsx
@@ -35,6 +35,7 @@ import { QuickNoteCard } from "./quick-note-card"
 import type { HighlightItem } from "./highlights-card"
 import { Button } from "@ui/components/button"
 import {
+	agentSourceParam,
 	categoriesParam,
 	type IntegrationParamValue,
 } from "@/lib/search-params"
@@ -88,8 +89,17 @@ type DocumentFacet = {
 	label: string
 }
 
+type AgentSource = "claude-code" | "codex"
+
+type SourceFacet = {
+	source: AgentSource
+	count: number
+	label: string
+}
+
 type FacetsResponse = {
 	facets: DocumentFacet[]
+	sourceFacets?: SourceFacet[]
 	total: number
 }
 
@@ -278,6 +288,10 @@ export function MemoriesGrid({
 		"categories",
 		categoriesParam,
 	)
+	const [selectedAgentSource, setSelectedAgentSource] = useQueryState(
+		"source",
+		agentSourceParam,
+	)
 	const selectedCategoriesSet = useMemo(
 		() => new Set(selectedCategories),
 		[selectedCategories],
@@ -315,6 +329,7 @@ export function MemoriesGrid({
 			"documents-with-memories",
 			effectiveContainerTags,
 			selectedCategories,
+			selectedAgentSource,
 		],
 		initialPageParam: 1,
 		queryFn: async ({ pageParam }) => {
@@ -327,6 +342,7 @@ export function MemoriesGrid({
 					containerTags: effectiveContainerTags,
 					categories:
 						selectedCategories.length > 0 ? selectedCategories : undefined,
+					sources: selectedAgentSource ? [selectedAgentSource] : undefined,
 				},
 				disableValidation: true,
 			})
@@ -381,9 +397,17 @@ export function MemoriesGrid({
 		[setSelectedCategories],
 	)
 
+	const handleAgentSourceToggle = useCallback(
+		(source: AgentSource) => {
+			setSelectedAgentSource((prev) => (prev === source ? null : source))
+		},
+		[setSelectedAgentSource],
+	)
+
 	const handleSelectAll = useCallback(() => {
 		setSelectedCategories(null)
-	}, [setSelectedCategories])
+		setSelectedAgentSource(null)
+	}, [setSelectedCategories, setSelectedAgentSource])
 
 	const documents = useMemo(() => {
 		return (
@@ -559,6 +583,10 @@ export function MemoriesGrid({
 	const allVisibleSelected =
 		documents.length > 0 &&
 		documents.every((d) => d.id && selectedDocumentIds.has(d.id))
+	const agentSourceFacets =
+		facetsData?.sourceFacets?.filter(
+			(facet) => facet.source === "claude-code" || facet.source === "codex",
+		) ?? []
 
 	return (
 		<div className="relative flex h-full min-h-0 flex-col">
@@ -573,6 +601,7 @@ export function MemoriesGrid({
 								dmSansClassName(),
 								"shrink-0 whitespace-nowrap rounded-full border border-[#161F2C] bg-[#0D121A] px-2.5 py-1 text-xs h-auto hover:bg-[#00173C] hover:border-[#2261CA33]",
 								selectedCategories.length === 0 &&
+									!selectedAgentSource &&
 									"bg-[#00173C] border-[#2261CA33]",
 							)}
 							onClick={handleSelectAll}
@@ -594,6 +623,21 @@ export function MemoriesGrid({
 										"bg-[#00173C] border-[#2261CA33]",
 								)}
 								onClick={() => handleCategoryToggle(facet.category)}
+							>
+								{facet.label}
+								<span className="ml-1 text-[#737373]">({facet.count})</span>
+							</Button>
+						))}
+						{agentSourceFacets.map((facet) => (
+							<Button
+								key={facet.source}
+								className={cn(
+									dmSansClassName(),
+									"shrink-0 whitespace-nowrap rounded-full border border-[#161F2C] bg-[#0D121A] px-2.5 py-1 text-xs h-auto hover:bg-[#00173C] hover:border-[#2261CA33]",
+									selectedAgentSource === facet.source &&
+										"bg-[#00173C] border-[#2261CA33]",
+								)}
+								onClick={() => handleAgentSourceToggle(facet.source)}
 							>
 								{facet.label}
 								<span className="ml-1 text-[#737373]">({facet.count})</span>

--- a/apps/web/components/select-spaces-modal.tsx
+++ b/apps/web/components/select-spaces-modal.tsx
@@ -34,8 +34,11 @@ import {
 	spaceSelectorDisplayName,
 } from "@/lib/ingest-auto-space"
 import {
+	AGENT_SPACE_CATEGORY_LABEL,
 	detectAgentSpace,
 	detectPluginSpace,
+	getAgentSpaceDisplayName,
+	getAgentSpaceSecondaryLabel,
 	pluginInitial,
 	type PluginSpaceInfo,
 } from "@/lib/plugin-space"
@@ -172,7 +175,7 @@ export function SelectSpacesModal({
 			if (!agent || agent.isSharedRepo) return true
 
 			// Claude Code already uses repo-based tags, so once the shared
-			// Agents row exists we should not show an extra source-specific row.
+			// Agent Spaces row exists we should not show an extra source-specific row.
 			if (!agent.sourceIds.includes("claude-code")) return true
 
 			const metaProject = pluginMetaMap.get(project.containerTag)?.projectName
@@ -251,7 +254,7 @@ export function SelectSpacesModal({
 					? [
 							{
 								id: "agents" as CategoryId,
-								label: "Agents",
+								label: AGENT_SPACE_CATEGORY_LABEL,
 								iconSrc: "/images/logo.png",
 								emoji: null,
 								count: agentCount,
@@ -290,7 +293,14 @@ export function SelectSpacesModal({
 		setLastBulkDeleteTag(null)
 	}, [activeDiscoverId])
 
-	const { org, user } = useAuth()
+	const modalSubtitle = useMemo(() => {
+		if (isBulkDeleteMode) return "Choose spaces to permanently delete"
+		if (activeCategory === "agents") {
+			return "Memories from Claude, Codex, and other agents"
+		}
+		return "Filter your memories by space"
+	}, [activeCategory, isBulkDeleteMode])
+
 	const queryClient = useQueryClient()
 	const [connectingPluginId, setConnectingPluginId] = useState<string | null>(
 		null,
@@ -531,6 +541,7 @@ export function SelectSpacesModal({
 				(p.name ?? "").toLowerCase().includes(query) ||
 				displayName.toLowerCase().includes(query) ||
 				(agent?.label.toLowerCase().includes(query) ?? false) ||
+				(agent?.isSharedRepo && "agent space".includes(query)) ||
 				(agent?.projectId?.toLowerCase().includes(query) ?? false) ||
 				(plugin?.label.toLowerCase().includes(query) ?? false) ||
 				(plugin?.projectId?.toLowerCase().includes(query) ?? false) ||
@@ -644,7 +655,17 @@ export function SelectSpacesModal({
 				project.containerTag,
 			)?.projectName
 			const pluginIdLabel = pluginProjectName || plugin?.projectId
-			const agentIdLabel = pluginProjectName || agent?.projectId
+			const agentPrimaryLabel = agent
+				? getAgentSpaceDisplayName(agent, {
+						projectName: pluginProjectName,
+						inAgentCategory: activeCategory === "agents",
+					})
+				: null
+			const agentSecondaryLabel = agent
+				? getAgentSpaceSecondaryLabel(agent, {
+						inAllSpaces: activeCategory === "all",
+					})
+				: null
 			const displayName = spaceSelectorDisplayName(
 				project,
 				project.containerTag,
@@ -804,10 +825,10 @@ export function SelectSpacesModal({
 							>
 								{agent ? (
 									<>
-										{agent.label}
-										{agentIdLabel && (
+										{agentPrimaryLabel}
+										{agentSecondaryLabel && (
 											<span className="ml-1.5 text-[12px] text-[#737373]">
-												· {agentIdLabel}
+												· {agentSecondaryLabel}
 											</span>
 										)}
 									</>
@@ -864,6 +885,7 @@ export function SelectSpacesModal({
 			)
 		},
 		[
+			activeCategory,
 			cancelEditing,
 			bulkDeleteTags,
 			currentSelection,
@@ -1136,9 +1158,7 @@ export function SelectSpacesModal({
 								Select Space
 							</p>
 							<p className="text-[13px] font-medium leading-[1.35] text-[#737373]">
-								{isBulkDeleteMode
-									? "Choose spaces to permanently delete"
-									: "Filter your memories by space"}
+								{modalSubtitle}
 							</p>
 						</div>
 						<div className="flex shrink-0 items-center gap-2">
@@ -1221,9 +1241,7 @@ export function SelectSpacesModal({
 							Select Space
 						</DialogTitle>
 						<p className="text-[#737373] font-medium text-[14px] leading-[1.35]">
-							{isBulkDeleteMode
-								? "Choose spaces to permanently delete"
-								: "Filter your memories by space"}
+							{modalSubtitle}
 						</p>
 					</div>
 					<div className="flex shrink-0 items-center gap-2">

--- a/apps/web/components/select-spaces-modal.tsx
+++ b/apps/web/components/select-spaces-modal.tsx
@@ -34,6 +34,7 @@ import {
 	spaceSelectorDisplayName,
 } from "@/lib/ingest-auto-space"
 import {
+	detectAgentSpace,
 	detectPluginSpace,
 	pluginInitial,
 	type PluginSpaceInfo,
@@ -79,6 +80,7 @@ interface SelectSpacesModalProps {
 type CategoryId =
 	| "all"
 	| "my"
+	| "agents"
 	| `plugin:${PluginSpaceInfo["pluginId"]}`
 	| `discover:${string}`
 
@@ -88,6 +90,10 @@ type Category = {
 	iconSrc: string | null
 	emoji: string | null
 	count: number
+}
+
+function normalizeAgentProjectKey(value: string | null | undefined) {
+	return value?.trim().replace(/_/g, "-").toLowerCase() || null
 }
 
 export function SelectSpacesModal({
@@ -148,6 +154,37 @@ export function SelectSpacesModal({
 		return [defaultSpace, ...rest]
 	}, [projects])
 
+	const visibleSpaces = useMemo(() => {
+		const sharedRepoProjects = new Set<string>()
+
+		for (const project of allSpaces) {
+			const agent = detectAgentSpace(project.containerTag)
+			if (!agent?.isSharedRepo) continue
+
+			const projectKey = normalizeAgentProjectKey(agent.projectId)
+			if (projectKey) sharedRepoProjects.add(projectKey)
+		}
+
+		if (sharedRepoProjects.size === 0) return allSpaces
+
+		return allSpaces.filter((project) => {
+			const agent = detectAgentSpace(project.containerTag)
+			if (!agent || agent.isSharedRepo) return true
+
+			// Claude Code already uses repo-based tags, so once the shared
+			// Agents row exists we should not show an extra source-specific row.
+			if (!agent.sourceIds.includes("claude-code")) return true
+
+			const metaProject = pluginMetaMap.get(project.containerTag)?.projectName
+			const projectKeys = [
+				normalizeAgentProjectKey(metaProject),
+				normalizeAgentProjectKey(agent.projectId),
+			].filter((key): key is string => !!key)
+
+			return !projectKeys.some((key) => sharedRepoProjects.has(key))
+		})
+	}, [allSpaces, pluginMetaMap])
+
 	const { categories, connectedCatalogIds } = useMemo<{
 		categories: Category[]
 		connectedCatalogIds: Set<string>
@@ -156,8 +193,14 @@ export function SelectSpacesModal({
 			PluginSpaceInfo["pluginId"],
 			{ label: string; iconSrc: string | null; count: number }
 		>()
+		let agentCount = 0
 		let myCount = 0
-		for (const p of allSpaces) {
+		for (const p of visibleSpaces) {
+			const agent = detectAgentSpace(p.containerTag)
+			if (agent) {
+				agentCount += 1
+				continue
+			}
 			const plugin = detectPluginSpace(p.containerTag)
 			if (plugin) {
 				const prev = pluginCounts.get(plugin.pluginId)
@@ -184,6 +227,10 @@ export function SelectSpacesModal({
 			const catalogId = spacePluginIdToCatalogId(pluginId)
 			if (catalogId) connectedIds.add(catalogId)
 		}
+		if (agentCount > 0) {
+			connectedIds.add("claude_code")
+			connectedIds.add("codex")
+		}
 		return {
 			categories: [
 				{
@@ -191,7 +238,7 @@ export function SelectSpacesModal({
 					label: "All Spaces",
 					iconSrc: null,
 					emoji: null,
-					count: allSpaces.length,
+					count: visibleSpaces.length,
 				},
 				{
 					id: "my",
@@ -200,15 +247,27 @@ export function SelectSpacesModal({
 					emoji: "📁",
 					count: myCount,
 				},
+				...(agentCount > 0
+					? [
+							{
+								id: "agents" as CategoryId,
+								label: "Agents",
+								iconSrc: "/images/logo.png",
+								emoji: null,
+								count: agentCount,
+							},
+						]
+					: []),
 				...pluginCats,
 			],
 			connectedCatalogIds: connectedIds,
 		}
-	}, [allSpaces])
+	}, [visibleSpaces])
 
 	const defaultCategory = useMemo<CategoryId>(() => {
 		if (!currentSelection) return "all"
 		if (currentSelection === AUTO_CHAT_SPACE_ID) return "all"
+		if (detectAgentSpace(currentSelection)) return "agents"
 		const plugin = detectPluginSpace(currentSelection)
 		if (plugin) return `plugin:${plugin.pluginId}`
 		return "my"
@@ -450,15 +509,18 @@ export function SelectSpacesModal({
 	)
 
 	const filteredProjects = useMemo(() => {
-		const byCategory = allSpaces.filter((p) => {
+		const byCategory = visibleSpaces.filter((p) => {
 			if (activeCategory === "all") return true
+			const agent = detectAgentSpace(p.containerTag)
+			if (activeCategory === "agents") return !!agent
 			const plugin = detectPluginSpace(p.containerTag)
-			if (activeCategory === "my") return !plugin
+			if (activeCategory === "my") return !plugin && !agent
 			return plugin && `plugin:${plugin.pluginId}` === activeCategory
 		})
 		if (!searchQuery.trim()) return byCategory
 		const query = searchQuery.trim().toLowerCase()
 		return byCategory.filter((p) => {
+			const agent = detectAgentSpace(p.containerTag)
 			const plugin = detectPluginSpace(p.containerTag)
 			const projectName = pluginMetaMap.get(p.containerTag)?.projectName
 			const displayName = spaceSelectorDisplayName(p, p.containerTag, {
@@ -468,18 +530,20 @@ export function SelectSpacesModal({
 				p.containerTag.toLowerCase().includes(query) ||
 				(p.name ?? "").toLowerCase().includes(query) ||
 				displayName.toLowerCase().includes(query) ||
+				(agent?.label.toLowerCase().includes(query) ?? false) ||
+				(agent?.projectId?.toLowerCase().includes(query) ?? false) ||
 				(plugin?.label.toLowerCase().includes(query) ?? false) ||
 				(plugin?.projectId?.toLowerCase().includes(query) ?? false) ||
 				(projectName?.toLowerCase().includes(query) ?? false)
 			)
 		})
-	}, [allSpaces, activeCategory, searchQuery, pluginMetaMap, user?.id])
+	}, [visibleSpaces, activeCategory, searchQuery, pluginMetaMap, user?.id])
 
 	const recentProjects = useMemo<ContainerTagListType[]>(() => {
 		if (!recents?.length) return []
 		if (searchQuery.trim()) return []
 		if (activeCategory !== "all") return []
-		const byTag = new Map(allSpaces.map((p) => [p.containerTag, p]))
+		const byTag = new Map(visibleSpaces.map((p) => [p.containerTag, p]))
 		const out: ContainerTagListType[] = []
 		for (const tag of recents) {
 			const p = byTag.get(tag)
@@ -487,7 +551,7 @@ export function SelectSpacesModal({
 			if (out.length >= 5) break
 		}
 		return out
-	}, [recents, searchQuery, activeCategory, allSpaces])
+	}, [recents, searchQuery, activeCategory, visibleSpaces])
 
 	const recentSet = useMemo(
 		() => new Set(recentProjects.map((p) => p.containerTag)),
@@ -574,11 +638,13 @@ export function SelectSpacesModal({
 	const renderRow = useCallback(
 		(project: ContainerTagListType) => {
 			const isSelected = currentSelection === project.containerTag
-			const plugin = detectPluginSpace(project.containerTag)
+			const agent = detectAgentSpace(project.containerTag)
+			const plugin = agent ? null : detectPluginSpace(project.containerTag)
 			const pluginProjectName = pluginMetaMap.get(
 				project.containerTag,
 			)?.projectName
 			const pluginIdLabel = pluginProjectName || plugin?.projectId
+			const agentIdLabel = pluginProjectName || agent?.projectId
 			const displayName = spaceSelectorDisplayName(
 				project,
 				project.containerTag,
@@ -588,7 +654,7 @@ export function SelectSpacesModal({
 			)
 			const isDefault = project.containerTag === DEFAULT_PROJECT_ID
 			const isOwnSpace = isOwnConversationSpace(project, user?.id)
-			const canEdit = !isDefault && !plugin && !isOwnSpace
+			const canEdit = !isDefault && !plugin && !agent && !isOwnSpace
 			const canBulkDelete = enableDelete && !isDefault
 			const isEditing = editingProject?.containerTag === project.containerTag
 			const isBulkDeleteSelected = bulkDeleteTags.has(project.containerTag)
@@ -696,7 +762,16 @@ export function SelectSpacesModal({
 							disabled={isBulkDeleteMode && !canBulkDelete}
 							className="flex min-w-0 flex-1 items-center gap-3 text-left cursor-pointer focus:outline-none focus:ring-0 disabled:cursor-not-allowed"
 						>
-							{plugin ? (
+							{agent ? (
+								<Image
+									src={agent.iconSrc}
+									alt=""
+									width={20}
+									height={20}
+									className="shrink-0 rounded-[4px]"
+									aria-hidden
+								/>
+							) : plugin ? (
 								plugin.iconSrc ? (
 									<Image
 										src={plugin.iconSrc}
@@ -725,9 +800,18 @@ export function SelectSpacesModal({
 							)}
 							<span
 								className="min-w-0 flex-1 truncate text-[#fafafa] text-sm font-medium"
-								title={plugin ? project.containerTag : displayName}
+								title={agent || plugin ? project.containerTag : displayName}
 							>
-								{plugin ? (
+								{agent ? (
+									<>
+										{agent.label}
+										{agentIdLabel && (
+											<span className="ml-1.5 text-[12px] text-[#737373]">
+												· {agentIdLabel}
+											</span>
+										)}
+									</>
+								) : plugin ? (
 									<>
 										{plugin.label}
 										{pluginIdLabel && (
@@ -837,11 +921,11 @@ export function SelectSpacesModal({
 
 	const renderCategoryChip = (
 		category: {
-			id: string
+			id: CategoryId
 			label: string
 			count?: number
-			iconSrc?: string
-			emoji?: string
+			iconSrc?: string | null
+			emoji?: string | null
 		},
 		isDiscover: boolean,
 	) => {

--- a/apps/web/components/space-selector.tsx
+++ b/apps/web/components/space-selector.tsx
@@ -43,6 +43,7 @@ import {
 import {
 	detectAgentSpace,
 	detectPluginSpace,
+	getAgentSpaceDisplayName,
 	pluginInitial,
 } from "@/lib/plugin-space"
 import { usePluginSpaceMeta } from "@/hooks/use-plugin-space-meta"
@@ -230,9 +231,7 @@ export function SpaceSelector({
 		const idForLabel = projectName || agent?.projectId || plugin?.projectId
 		return {
 			name: agent
-				? idForLabel
-					? `${agent.label} · ${idForLabel}`
-					: agent.label
+				? getAgentSpaceDisplayName(agent, { projectName })
 				: plugin
 					? idForLabel
 						? `${plugin.label} · ${idForLabel}`

--- a/apps/web/components/space-selector.tsx
+++ b/apps/web/components/space-selector.tsx
@@ -40,7 +40,11 @@ import {
 	isOwnConversationSpace,
 	spaceSelectorDisplayName,
 } from "@/lib/ingest-auto-space"
-import { detectPluginSpace, pluginInitial } from "@/lib/plugin-space"
+import {
+	detectAgentSpace,
+	detectPluginSpace,
+	pluginInitial,
+} from "@/lib/plugin-space"
 import { usePluginSpaceMeta } from "@/hooks/use-plugin-space-meta"
 import NovaOrb from "@/components/nova/nova-orb"
 import { AutoSpaceIcon } from "@/components/nova/auto-space-icon"
@@ -190,6 +194,7 @@ export function SpaceSelector({
 	const displayInfo = useMemo<{
 		name: string
 		emoji: string | null
+		agent: ReturnType<typeof detectAgentSpace>
 		plugin: ReturnType<typeof detectPluginSpace>
 		isAuto: boolean
 		isOwnSpace: boolean
@@ -199,6 +204,7 @@ export function SpaceSelector({
 			return {
 				name: "Auto",
 				emoji: null,
+				agent: null,
 				plugin: null,
 				isAuto: true,
 				isOwnSpace: false,
@@ -208,6 +214,7 @@ export function SpaceSelector({
 			return {
 				name: "My Space",
 				emoji: "📁",
+				agent: null,
 				plugin: null,
 				isAuto: false,
 				isOwnSpace: false,
@@ -216,19 +223,25 @@ export function SpaceSelector({
 		const found = allProjects.find(
 			(p: ContainerTagListType) => p.containerTag === containerTag,
 		)
-		const plugin = detectPluginSpace(containerTag)
+		const agent = detectAgentSpace(containerTag)
+		const plugin = agent ? null : detectPluginSpace(containerTag)
 		const isOwnSpace = isOwnConversationSpace({ containerTag }, user?.id)
 		const projectName = pluginMetaMap.get(containerTag)?.projectName
-		const idForLabel = projectName || plugin?.projectId
+		const idForLabel = projectName || agent?.projectId || plugin?.projectId
 		return {
-			name: plugin
+			name: agent
 				? idForLabel
-					? `${plugin.label} · ${idForLabel}`
-					: plugin.label
-				: spaceSelectorDisplayName(found, containerTag, {
-						currentUserId: user?.id,
-					}),
+					? `${agent.label} · ${idForLabel}`
+					: agent.label
+				: plugin
+					? idForLabel
+						? `${plugin.label} · ${idForLabel}`
+						: plugin.label
+					: spaceSelectorDisplayName(found, containerTag, {
+							currentUserId: user?.id,
+						}),
 			emoji: found?.emoji || "📁",
+			agent,
 			plugin,
 			isAuto: false,
 			isOwnSpace,
@@ -238,6 +251,7 @@ export function SpaceSelector({
 	const canEditCurrent =
 		enableEdit &&
 		!displayInfo.isAuto &&
+		!displayInfo.agent &&
 		!displayInfo.plugin &&
 		!displayInfo.isOwnSpace
 
@@ -414,6 +428,18 @@ export function SpaceSelector({
 									<NovaOrb
 										size={compact ? 14 : 16}
 										className="shrink-0 blur-[0.45px]!"
+									/>
+								) : displayInfo.agent ? (
+									<Image
+										src={displayInfo.agent.iconSrc}
+										alt=""
+										width={16}
+										height={16}
+										className={cn(
+											"shrink-0 rounded-[3px]",
+											compact ? "size-3.5" : "size-4",
+										)}
+										aria-hidden
 									/>
 								) : displayInfo.plugin ? (
 									displayInfo.plugin.iconSrc ? (

--- a/apps/web/lib/plugin-space.ts
+++ b/apps/web/lib/plugin-space.ts
@@ -7,12 +7,51 @@ export type PluginSpaceInfo = {
 	projectId?: string
 }
 
+export const AGENT_SPACE_CATEGORY_LABEL = "Agent Spaces"
+
 export type AgentSpaceInfo = {
-	label: "Agents" | "Claude Code" | "Codex"
+	label: typeof AGENT_SPACE_CATEGORY_LABEL | "Claude Code" | "Codex"
 	iconSrc: string
 	projectId?: string
 	sourceIds: Array<"claude-code" | "codex">
 	isSharedRepo: boolean
+}
+
+export function getAgentSpacePlaceName(
+	agent: AgentSpaceInfo,
+	projectName?: string | null,
+): string {
+	return projectName?.trim() || agent.projectId?.trim() || agent.label
+}
+
+/** Primary row/trigger label for an agent-scoped space. */
+export function getAgentSpaceDisplayName(
+	agent: AgentSpaceInfo,
+	options?: {
+		projectName?: string | null
+		inAgentCategory?: boolean
+	},
+): string {
+	const placeName = getAgentSpacePlaceName(agent, options?.projectName)
+
+	if (agent.isSharedRepo) {
+		return placeName
+	}
+
+	const idLabel = options?.projectName || agent.projectId
+	if (idLabel) return `${agent.label} · ${idLabel}`
+	return agent.label
+}
+
+/** Secondary hint when agent spaces appear outside the Agent Spaces filter. */
+export function getAgentSpaceSecondaryLabel(
+	agent: AgentSpaceInfo,
+	options: { inAllSpaces?: boolean },
+): string | null {
+	if (agent.isSharedRepo && options.inAllSpaces) {
+		return "Agent space"
+	}
+	return null
 }
 
 type PluginDef = {
@@ -243,7 +282,7 @@ export function detectAgentSpace(containerTag: string): AgentSpaceInfo | null {
 
 	if (containerTag.startsWith("repo_")) {
 		return {
-			label: "Agents",
+			label: AGENT_SPACE_CATEGORY_LABEL,
 			iconSrc: AGENTS_ICON_SRC,
 			projectId: parseRepoProjectId(containerTag),
 			sourceIds: ["claude-code", "codex"],

--- a/apps/web/lib/plugin-space.ts
+++ b/apps/web/lib/plugin-space.ts
@@ -7,6 +7,14 @@ export type PluginSpaceInfo = {
 	projectId?: string
 }
 
+export type AgentSpaceInfo = {
+	label: "Agents" | "Claude Code" | "Codex"
+	iconSrc: string
+	projectId?: string
+	sourceIds: Array<"claude-code" | "codex">
+	isSharedRepo: boolean
+}
+
 type PluginDef = {
 	id: PluginSpaceInfo["pluginId"]
 	label: string
@@ -52,6 +60,19 @@ const PLUGINS: PluginDef[] = [
 		prefixes: ["hermes"],
 	},
 ]
+
+const AGENTS_ICON_SRC = "/images/logo.png"
+const AGENT_PLUGIN_IDS = new Set<PluginSpaceInfo["pluginId"]>([
+	"claude-code",
+	"codex",
+])
+
+function parseRepoProjectId(containerTag: string): string | undefined {
+	if (!containerTag.startsWith("repo_")) return undefined
+	const repoName = containerTag.slice("repo_".length)
+	if (!repoName) return undefined
+	return repoName.replace(/_/g, "-").slice(0, 32)
+}
 
 function parsePluginRest(rest: string): { projectId?: string } {
 	if (!rest || rest === "default" || rest === "global") {
@@ -215,4 +236,29 @@ export function detectPluginSpace(
 	}
 
 	return null
+}
+
+export function detectAgentSpace(containerTag: string): AgentSpaceInfo | null {
+	if (!containerTag) return null
+
+	if (containerTag.startsWith("repo_")) {
+		return {
+			label: "Agents",
+			iconSrc: AGENTS_ICON_SRC,
+			projectId: parseRepoProjectId(containerTag),
+			sourceIds: ["claude-code", "codex"],
+			isSharedRepo: true,
+		}
+	}
+
+	const plugin = detectPluginSpace(containerTag)
+	if (!plugin || !AGENT_PLUGIN_IDS.has(plugin.pluginId)) return null
+
+	return {
+		label: plugin.label as "Claude Code" | "Codex",
+		iconSrc: plugin.iconSrc ?? AGENTS_ICON_SRC,
+		projectId: plugin.projectId,
+		sourceIds: [plugin.pluginId as "claude-code" | "codex"],
+		isSharedRepo: false,
+	}
 }

--- a/apps/web/lib/search-params.ts
+++ b/apps/web/lib/search-params.ts
@@ -58,4 +58,7 @@ export type IntegrationParamValue =
 export const categoriesParam = parseAsArrayOf(parseAsString, ",").withDefault(
 	[],
 )
+const agentSourceLiterals = ["claude-code", "codex"] as const
+export type AgentSourceParamValue = (typeof agentSourceLiterals)[number]
+export const agentSourceParam = parseAsStringLiteral(agentSourceLiterals)
 export const projectParam = parseAsArrayOf(parseAsString, ",").withDefault([])


### PR DESCRIPTION
## Summary
- Add an Agents section to the space selector.
- Group shared repo-based Claude Code/Codex memories under Agents.
- Hide duplicate Claude Code rows when an equivalent shared Agents row exists.
- Keep Codex legacy spaces visible for migration.
- Add Memories filters for Claude Code and Codex within Agents.
- Use the Supermemory logo for the Agents icon.
