### PR TITLE
Add plugin changelog page

### DIFF
--- a/apps/docs/changelog/overview.mdx
+++ b/apps/docs/changelog/overview.mdx
@@ -1,5 +1,6 @@
 ---
 title: "Changelog"
+sidebarTitle: "Supermemory"
 description: "New updates and improvements to Supermemory"
 ---
 

--- a/apps/docs/changelog/plugins.mdx
+++ b/apps/docs/changelog/plugins.mdx
@@ -1,0 +1,81 @@
+---
+title: "Plugin changelog"
+sidebarTitle: "Plugins"
+description: "Recent updates and improvements to Supermemory plugins"
+---
+
+<Update label="June 20, 2026" tags={["OpenCode", "Cursor"]}>
+
+### OpenCode entity context
+
+OpenCode now sends entity context with memory operations, so saved context can stay tied to the active project and conversation. The entity-context prompt was also moved out of the API client for cleaner reuse across capture and compaction flows.
+
+### Cursor session auth
+
+Cursor now starts the auth flow from the session hook when needed, and the OAuth success screen uses the Cursor-branded callback path.
+
+</Update>
+
+<Update label="June 18, 2026" tags={["Claude Code", "OpenCode"]}>
+
+### Claude Code update notices
+
+Claude Code now surfaces plugin update notices during sessions and includes the latest package/version metadata.
+
+### OpenCode context prompt
+
+OpenCode gained an entity-context prompt so memory recall and capture can carry more precise source context.
+
+</Update>
+
+<Update label="June 13, 2026" tags={["Claude Code", "Codex"]}>
+
+### Claude Code marketplace polish
+
+The Claude Code plugin manifest was polished for the official marketplace listing, including refreshed metadata and naming.
+
+### Codex update notices
+
+Codex now checks for plugin updates during session start and shows a user-visible notice when a newer version is available.
+
+</Update>
+
+<Update label="June 11, 2026" tags={["Claude Code", "Cursor"]}>
+
+### Claude Code rename migration
+
+Claude Code completed the rename to the `supermemory` plugin while keeping migration safe for users already on the new plugin name. Configuration also supports custom `baseUrl` values for local or self-hosted Supermemory installs.
+
+### Cursor web OAuth
+
+Cursor OAuth now routes through the Supermemory web app, keeping the plugin auth flow consistent with the rest of the integrations.
+
+</Update>
+
+<Update label="June 10, 2026" tags={["Codex", "OpenCode"]}>
+
+### Codex auth and status tooling
+
+Codex added status, logout, and web-auth flows, plus Windows-safe auth URL opening and entity context for saved memories. The installer now includes a `supermemory-status` skill so Codex can report connection, hook, config, and installed-skill health from inside a session.
+
+### OAuth status refinements
+
+Codex and OpenCode integration status now renders more clearly in the Supermemory app during OAuth connection and setup.
+
+</Update>
+
+<Update label="June 6, 2026" tags={["Claude Code", "Cursor", "OpenClaw", "Hermes"]}>
+
+### Claude Code recall reasoning
+
+Claude Code gained reasoned per-turn memory recall with auto-approve support, refreshed bundled scripts, and updated skill names for `supermemory-save` and `supermemory-search`.
+
+### Cursor session hooks
+
+Cursor session hooks now load reliably and persist real project sessions into the correct container.
+
+### OpenClaw and Hermes memory attribution
+
+Saved plugin memories now parse source attribution more accurately, and the dashboard shows the correct plugin logos and recent-memory rows for OpenClaw and Hermes.
+
+</Update>

--- a/apps/docs/docs.json
+++ b/apps/docs/docs.json
@@ -306,7 +306,7 @@
 				"anchors": [
 					{
 						"anchor": "Changelog",
-						"pages": ["changelog/overview"]
+						"pages": ["changelog/overview", "changelog/plugins"]
 					}
 				],
 				"tab": "Changelog"

--- a/apps/docs/integrations/codex.mdx
+++ b/apps/docs/integrations/codex.mdx
@@ -49,7 +49,7 @@ This command:
 - Copies hook and skill scripts to `~/.codex/supermemory/`
 - Enables `codex_hooks = true` in `~/.codex/config.toml`
 - Registers `UserPromptSubmit` (recall) and `Stop` (capture) hooks in `~/.codex/hooks.json`
-- Installs `supermemory-search`, `supermemory-save`, and `supermemory-forget` skills to `~/.codex/skills/`
+- Installs `supermemory-search`, `supermemory-save`, `supermemory-forget`, and `supermemory-status` skills to `~/.codex/skills/`
 
 Restart Codex CLI after installing.
 
@@ -81,13 +81,14 @@ Tags are generated automatically — no configuration needed. You can override t
 
 ## Explicit Memory Skills
 
-The installer includes three skills that Codex auto-discovers from `~/.codex/skills/`. They use the same `SUPERMEMORY_CODEX_API_KEY` as the hooks — no separate login needed.
+The installer includes four skills that Codex auto-discovers from `~/.codex/skills/`. They use the same `SUPERMEMORY_CODEX_API_KEY` as the hooks — no separate login needed.
 
 | Skill | Description |
 |-------|-------------|
 | `supermemory-search` | Search your memories by natural-language query |
 | `supermemory-save` | Save important project knowledge to memory |
 | `supermemory-forget` | Remove outdated or incorrect memories |
+| `supermemory-status` | Check Supermemory connection, hook, config, and skill status |
 
 These skills let you interact with memory explicitly — for example:
 
@@ -95,6 +96,7 @@ These skills let you interact with memory explicitly — for example:
 > Remember that this project uses Vitest for unit tests and Playwright for E2E.
 > What do you remember about our database schema?
 > Forget the memory about the old API endpoint.
+> Is Supermemory connected?
 ```
 
 ## Verify Installation
@@ -111,7 +113,7 @@ codex-supermemory status:
   API key:       ✓ set (SUPERMEMORY_CODEX_API_KEY)
   Hook scripts:  ✓ installed at ~/.codex/supermemory
   hooks.json:    ✓ registered (implicit memory)
-  Skills:        ✓ installed (supermemory-search, supermemory-save, supermemory-forget)
+  Skills:        ✓ installed (supermemory-search, supermemory-save, supermemory-forget, supermemory-status)
   config.toml:   ✓ exists
 
 All good! Memory is active.

--- a/apps/docs/vibe-coding.mdx
+++ b/apps/docs/vibe-coding.mdx
@@ -47,7 +47,7 @@ Replace `claude` with: `cursor`, `opencode`, or `vscode`
 After adding the MCP, paste this in your agent session:
 
 <Accordion title="Copy prompt below." icon='copy'>
-```
+````
 You are integrating Supermemory into my application. Supermemory provides user memory, semantic search, and automatic knowledge extraction for AI applications.
 
 Note: You can always reference the documentation by using the **SearchSupermemoryDocs MCP** or running a web search tool for content on **supermemory.ai/docs**.
@@ -386,7 +386,7 @@ NOW:
 3. Include installation, settings config, and full integration
 
 DOCS: https://supermemory.ai/docs
-```
+````
 </Accordion>
 
 


### PR DESCRIPTION
## Summary
- Add a dedicated plugin changelog page under the Changelog tab, with recent updates tagged by plugin.