### PR TITLE
Fix Claude Code plugin install command

### DIFF
--- a/apps/web/lib/plugin-catalog.ts
+++ b/apps/web/lib/plugin-catalog.ts
@@ -47,7 +47,7 @@ export const PLUGIN_CATALOG: Record<string, PluginInfo> = {
 			{
 				title: "Install the plugin",
 				description: "Run these commands inside a Claude Code session:",
-				code: "/plugin marketplace add supermemoryai/claude-supermemory\n/plugin install claude-supermemory",
+				code: "/plugin marketplace add supermemoryai/claude-supermemory\n/plugin install supermemory",
 			},
 		],
 	},


### PR DESCRIPTION
## Summary
- update the Claude Code plugin install step to use `/plugin install supermemory`
- keep the marketplace add command pointing at `supermemoryai/claude-supermemory`

## Testing
- Not run; copy-only change