### PR TITLE
Add multi-plugin OAuth connect UI

### DIFF
--- a/apps/web/app/auth/connect/page.tsx
+++ b/apps/web/app/auth/connect/page.tsx
@@ -208,18 +208,10 @@ function PluginAccessList({
 									"flex size-6 shrink-0 items-center justify-center rounded-md border",
 									eligible
 										? "border-[#24413C] bg-[#0B1717] text-[#8BD8CB]"
-										: "border-[#2B3240] bg-[#11151C] text-[#8B8B8B]",
+										: "border-transparent bg-transparent",
 								)}
 							>
-								{eligible ? (
-									<Check className="size-3" strokeWidth={2} />
-								) : (
-									<span
-										className={dmSans125ClassName("text-[9px] font-semibold")}
-									>
-										PRO
-									</span>
-								)}
+								{eligible && <Check className="size-3" strokeWidth={2} />}
 							</div>
 							{plugin && (
 								<Image
@@ -231,13 +223,24 @@ function PluginAccessList({
 								/>
 							)}
 							<div className="min-w-0 flex-1">
-								<p
-									className={dmSans125ClassName(
-										"truncate text-[13px] text-[#FAFAFA]",
+								<div className="flex min-w-0 items-center gap-1.5">
+									<p
+										className={dmSans125ClassName(
+											"truncate text-[13px] text-[#FAFAFA]",
+										)}
+									>
+										{getPluginName(id)}
+									</p>
+									{!eligible && (
+										<span
+											className={dmSans125ClassName(
+												"shrink-0 rounded-full bg-[#4BA0FA]/15 px-1.5 py-0.5 text-[9px] font-semibold text-[#8BC6FF]",
+											)}
+										>
+											PRO
+										</span>
 									)}
-								>
-									{getPluginName(id)}
-								</p>
+								</div>
 								<p className={dmSans125ClassName("text-[12px] text-[#737373]")}>
 									{eligible
 										? "Available on your current plan"

--- a/apps/web/app/auth/connect/page.tsx
+++ b/apps/web/app/auth/connect/page.tsx
@@ -7,7 +7,7 @@ import { cn } from "@lib/utils"
 import { dmSans125ClassName } from "@/lib/fonts"
 import { isFreeTierPlugin } from "@/lib/plugin-catalog"
 import { useCustomer } from "autumn-js/react"
-import { ArrowRight, Check, Clock3, Loader, XCircle } from "lucide-react"
+import { ArrowRight, Check, Loader, XCircle } from "lucide-react"
 import Image from "next/image"
 import { useRouter, useSearchParams } from "next/navigation"
 import {
@@ -835,7 +835,7 @@ function AuthConnectContent() {
 			<div className={pageWrapperClass}>
 				<div className={cardClass}>
 					<div className="flex flex-col items-center gap-5 text-center">
-						<Clock3 className="size-10 text-[#8BC6FF]" />
+						<PluginLogoStack clients={requestedClients} />
 						<div>
 							<h2
 								className={dmSans125ClassName(
@@ -854,11 +854,11 @@ function AuthConnectContent() {
 							</p>
 						</div>
 
-						<div className="w-full rounded-lg border border-[#1E293B] bg-[#0D121A] px-4 py-3 text-left">
-							<p className={dmSans125ClassName("text-[12px] text-[#8B8B8B]")}>
-								Re-authenticate from the CLI to finish connecting.
+						<div className="w-full text-left">
+							<p className={dmSans125ClassName("text-[12px] text-[#737373]")}>
+								Re-authenticate from the CLI to finish connecting:
 							</p>
-							<code className="mt-1 block text-[12px] text-[#8BC6FF]">
+							<code className="mt-1.5 block text-[12px] text-[#FAFAFA]">
 								npx supermemory plugin login
 							</code>
 						</div>
@@ -869,8 +869,10 @@ function AuthConnectContent() {
 								onClick={retryUpgradeSync}
 								className={cn(
 									"w-full flex items-center justify-center rounded-[10px] h-11",
-									"bg-[#0D121A] border border-[#1E293B] text-[#FAFAFA]",
-									"text-[14px] font-medium cursor-pointer transition-colors hover:bg-[#1E293B]",
+									"text-[#FAFAFA] text-[14px] font-medium cursor-pointer",
+									"bg-[linear-gradient(182.37deg,#0ff0d2_-91.53%,#5bd3fb_-67.8%,#1e0ff0_95.17%)]",
+									"shadow-[1px_1px_2px_0px_#1A88FF_inset,0_2px_10px_0_rgba(5,1,0,0.20)]",
+									"transition-opacity hover:opacity-90",
 									dmSans125ClassName(),
 								)}
 							>

--- a/apps/web/app/auth/connect/page.tsx
+++ b/apps/web/app/auth/connect/page.tsx
@@ -7,10 +7,17 @@ import { cn } from "@lib/utils"
 import { dmSans125ClassName } from "@/lib/fonts"
 import { isFreeTierPlugin } from "@/lib/plugin-catalog"
 import { useCustomer } from "autumn-js/react"
-import { ArrowRight, Loader, XCircle } from "lucide-react"
+import { ArrowRight, Check, Loader, XCircle } from "lucide-react"
 import Image from "next/image"
 import { useRouter, useSearchParams } from "next/navigation"
-import { Suspense, useEffect, useState } from "react"
+import {
+	Suspense,
+	useCallback,
+	useEffect,
+	useMemo,
+	useRef,
+	useState,
+} from "react"
 
 import { PENDING_CONNECT_URL_KEY } from "@/lib/constants"
 
@@ -169,6 +176,81 @@ function PluginLogoStack({ clients }: { clients: string[] }) {
 	)
 }
 
+function PluginAccessList({
+	blockedClients,
+	eligibleClients,
+}: {
+	blockedClients: string[]
+	eligibleClients: string[]
+}) {
+	const rows = [
+		...eligibleClients.map((id) => ({ id, state: "eligible" as const })),
+		...blockedClients.map((id) => ({ id, state: "blocked" as const })),
+	]
+
+	if (rows.length === 0) return null
+
+	return (
+		<div className="w-full space-y-2">
+			<p
+				className={dmSans125ClassName("text-[12px] font-medium text-[#FAFAFA]")}
+			>
+				Connection summary
+			</p>
+			<div className="space-y-2">
+				{rows.map(({ id, state }) => {
+					const plugin = PLUGIN_INFO[id]
+					const eligible = state === "eligible"
+					return (
+						<div className="flex items-center gap-3" key={`${id}-${state}`}>
+							<div
+								className={cn(
+									"flex size-6 shrink-0 items-center justify-center rounded-md border",
+									eligible
+										? "border-[#24413C] bg-[#0B1717] text-[#8BD8CB]"
+										: "border-[#2B3240] bg-[#11151C] text-[#8B8B8B]",
+								)}
+							>
+								{eligible ? (
+									<Check className="size-3" strokeWidth={2} />
+								) : (
+									<span
+										className={dmSans125ClassName("text-[9px] font-semibold")}
+									>
+										PRO
+									</span>
+								)}
+							</div>
+							{plugin && (
+								<Image
+									alt=""
+									className="size-5 object-contain"
+									height={20}
+									src={plugin.icon}
+									width={20}
+								/>
+							)}
+							<div className="min-w-0 flex-1">
+								<p
+									className={dmSans125ClassName(
+										"truncate text-[13px] text-[#FAFAFA]",
+									)}
+								>
+									{getPluginName(id)}
+								</p>
+								<p className={dmSans125ClassName("text-[12px] text-[#737373]")}>
+									{eligible
+										? "Available on your current plan"
+										: "Upgrade required"}
+								</p>
+							</div>
+						</div>
+					)
+				})}
+			</div>
+		</div>
+	)
+}
 type Status = "loading" | "creating" | "success" | "error" | "upgrade"
 
 const pageWrapperClass =
@@ -187,31 +269,56 @@ function AuthConnectContent() {
 	const [status, setStatus] = useState<Status>("loading")
 	const [error, setError] = useState<string | null>(null)
 	const [isUpgrading, setIsUpgrading] = useState(false)
+	const hasAutoConnectedAfterUpgrade = useRef(false)
 
 	const callback = params.get("callback")
 	const client = params.get("client")
-	const clients = (params.get("clients") ?? "")
-		.split(",")
-		.map((value) => value.trim())
-		.filter((value) => value in PLUGIN_INFO)
-	const requestedClients = clients.length > 0 ? clients : client ? [client] : []
+	const clientsParam = params.get("clients")
 	const hasClientList = params.has("clients")
-	const validClient = client && client in PLUGIN_INFO ? client : null
+	const rawRequestedClients = useMemo(
+		() =>
+			(clientsParam !== null ? clientsParam.split(",") : client ? [client] : [])
+				.map((value) => value.trim())
+				.filter(Boolean),
+		[client, clientsParam],
+	)
+	const requestedClients = useMemo(
+		() =>
+			Array.from(
+				new Set(rawRequestedClients.filter((value) => value in PLUGIN_INFO)),
+			),
+		[rawRequestedClients],
+	)
+	const invalidClients = useMemo(
+		() => rawRequestedClients.filter((value) => !(value in PLUGIN_INFO)),
+		[rawRequestedClients],
+	)
+	const validClient = requestedClients[0] ?? null
 	const displayName = formatPluginNames(requestedClients)
 	const pluginInfo =
-		requestedClients.length === 1
-			? PLUGIN_INFO[requestedClients[0] ?? ""]
+		requestedClients.length === 1 && validClient
+			? PLUGIN_INFO[validClient]
 			: null
 	const hasProProduct = hasActivePlan(autumn.data?.subscriptions, "api_pro")
-	const eligibleClients = requestedClients.filter(
-		(requestedClient) => hasProProduct || isFreeTierPlugin(requestedClient),
+	const eligibleClients = useMemo(
+		() =>
+			requestedClients.filter(
+				(requestedClient) => hasProProduct || isFreeTierPlugin(requestedClient),
+			),
+		[hasProProduct, requestedClients],
 	)
-	const blockedClients = requestedClients.filter(
-		(requestedClient) => !eligibleClients.includes(requestedClient),
+	const blockedClients = useMemo(
+		() =>
+			requestedClients.filter(
+				(requestedClient) => !eligibleClients.includes(requestedClient),
+			),
+		[eligibleClients, requestedClients],
 	)
 	const needsPlanStatus = requestedClients.some(
 		(requestedClient) => !isFreeTierPlugin(requestedClient),
 	)
+	const shouldAutoConnectAfterUpgrade =
+		params.get("upgrade_complete") === "true"
 	const eligibleDisplayName = formatPluginNames(eligibleClients)
 	const blockedDisplayName = formatPluginNames(blockedClients)
 
@@ -238,7 +345,7 @@ function AuthConnectContent() {
 		router.replace("/onboarding")
 	}, [isPending, isRestoring, session, organizations, router])
 
-	async function handleConnect() {
+	const handleConnect = useCallback(async () => {
 		if (!callback) {
 			setStatus("error")
 			setError("Missing callback parameter.")
@@ -247,6 +354,16 @@ function AuthConnectContent() {
 		if (!isValidLocalhostCallback(callback)) {
 			setStatus("error")
 			setError("Invalid callback URL.")
+			return
+		}
+		if (invalidClients.length > 0) {
+			setStatus("error")
+			setError(`Unsupported plugin requested: ${invalidClients.join(", ")}.`)
+			return
+		}
+		if (requestedClients.length === 0) {
+			setStatus("error")
+			setError("Invalid or missing client.")
 			return
 		}
 		if (!session || !org) {
@@ -260,36 +377,36 @@ function AuthConnectContent() {
 		try {
 			setStatus("creating")
 			if (eligibleClients.length === 0) {
-				const redirectUrl = new URL(callback)
-				redirectUrl.searchParams.set(
-					"errors",
-					encodeBase64UrlJson(
-						Object.fromEntries(
-							blockedClients.map((blockedClient) => [
-								blockedClient,
-								pluginAccessError(blockedClient),
-							]),
-						),
-					),
+				setStatus("upgrade")
+				setError(`Upgrade to Pro to connect ${blockedDisplayName}.`)
+				return
+			}
+			if (shouldAutoConnectAfterUpgrade && blockedClients.length > 0) {
+				setStatus("upgrade")
+				setError(
+					"Your plan update is still processing. Please try again in a moment.",
 				)
-				window.location.href = redirectUrl.toString()
 				return
 			}
 
 			const fetchParams = new URLSearchParams({ callback })
-			fetchParams.set("client", eligibleClients[0] ?? validClient ?? "")
+			fetchParams.set("client", eligibleClients[0] ?? "")
 
 			const res = await fetch(`${API_URL}/v3/auth/key?${fetchParams}`, {
 				credentials: "include",
 			})
 
 			if (!res.ok) {
-				if (res.status === 403) {
-					setStatus("upgrade")
-					return
-				}
 				const errorData = (await res.json().catch(() => ({}))) as {
 					message?: string
+				}
+				if (res.status === 403) {
+					setStatus("upgrade")
+					setError(
+						errorData.message ||
+							`Upgrade to Pro to connect ${eligibleDisplayName}.`,
+					)
+					return
 				}
 				throw new Error(errorData.message || "Failed to get API key")
 			}
@@ -333,12 +450,26 @@ function AuthConnectContent() {
 			setStatus("error")
 			setError(err instanceof Error ? err.message : "Failed to get API key")
 		}
-	}
+	}, [
+		blockedClients,
+		blockedDisplayName,
+		callback,
+		eligibleClients,
+		eligibleDisplayName,
+		hasClientList,
+		invalidClients,
+		org,
+		requestedClients.length,
+		session,
+		shouldAutoConnectAfterUpgrade,
+	])
 
 	async function handleUpgrade() {
 		try {
 			setIsUpgrading(true)
-			const safeSuccessUrl = `${window.location.origin}${window.location.pathname}${window.location.search}`
+			const successParams = new URLSearchParams(params.toString())
+			successParams.set("upgrade_complete", "true")
+			const safeSuccessUrl = `${window.location.origin}${window.location.pathname}?${successParams.toString()}`
 			await autumn.attach({
 				planId: "api_pro",
 				successUrl: safeSuccessUrl,
@@ -356,6 +487,37 @@ function AuthConnectContent() {
 		isRestoring ||
 		organizations === null ||
 		(needsPlanStatus && autumn.isLoading)
+	useEffect(() => {
+		if (!shouldAutoConnectAfterUpgrade) return
+		if (hasAutoConnectedAfterUpgrade.current) return
+		if (status !== "loading") return
+		if (isAuthLoading || shouldRedirectToOnboarding || !session || !org) return
+
+		hasAutoConnectedAfterUpgrade.current = true
+		void handleConnect()
+	}, [
+		shouldAutoConnectAfterUpgrade,
+		status,
+		isAuthLoading,
+		shouldRedirectToOnboarding,
+		session,
+		org,
+		handleConnect,
+	])
+
+	useEffect(() => {
+		if (status !== "loading") return
+		if (rawRequestedClients.length === 0) {
+			setStatus("error")
+			setError("Invalid or missing client.")
+			return
+		}
+		if (invalidClients.length > 0) {
+			setStatus("error")
+			setError(`Unsupported plugin requested: ${invalidClients.join(", ")}.`)
+		}
+	}, [invalidClients, rawRequestedClients.length, status])
+
 	if (isAuthLoading || shouldRedirectToOnboarding) {
 		return (
 			<div className="flex items-center justify-center min-h-screen bg-background">
@@ -384,21 +546,22 @@ function AuthConnectContent() {
 								)}
 							>
 								{pluginInfo?.description ??
-									`Approve one Supermemory OAuth flow for ${displayName}.`}
+									(requestedClients.length > 1
+										? "Use one Supermemory account across these plugins."
+										: `Use your Supermemory account with ${displayName}.`)}
 							</p>
 						</div>
 
-						{blockedClients.length > 0 && (
-							<div className="w-full rounded-[10px] border border-[#1E293B] bg-[#080B0F] p-3">
-								<p className={dmSans125ClassName("text-[13px] text-[#8B8B8B]")}>
-									{eligibleClients.length > 0
-										? `OAuth will connect ${eligibleDisplayName}. Upgrade to Pro to connect ${blockedDisplayName}.`
-										: `Upgrade to Pro to connect ${blockedDisplayName}.`}
-								</p>
-							</div>
+						{(requestedClients.length > 1 || blockedClients.length > 0) && (
+							<PluginAccessList
+								blockedClients={blockedClients}
+								eligibleClients={eligibleClients}
+							/>
 						)}
 
-						{pluginInfo ? (
+						{requestedClients.length <= 1 &&
+						blockedClients.length === 0 &&
+						pluginInfo ? (
 							<ul className="w-full space-y-2.5">
 								{pluginInfo.features.map((feature) => (
 									<li key={feature} className="flex items-start gap-2.5">
@@ -413,7 +576,7 @@ function AuthConnectContent() {
 									</li>
 								))}
 							</ul>
-						) : (
+						) : requestedClients.length <= 1 && blockedClients.length === 0 ? (
 							<ul className="w-full space-y-2.5">
 								<li className="flex items-start gap-2.5">
 									<ArrowRight className="mt-0.5 size-3.5 shrink-0 text-[#4BA0FA]" />
@@ -443,28 +606,91 @@ function AuthConnectContent() {
 									</span>
 								</li>
 							</ul>
-						)}
+						) : null}
 
-						<button
-							type="button"
-							onClick={handleConnect}
-							className={cn(
-								"relative w-full h-11 rounded-[10px] flex items-center justify-center",
-								"text-[#FAFAFA] font-medium text-[14px] tracking-[-0.14px]",
-								"shadow-[0px_2px_10px_rgba(5,1,0,0.2)]",
-								"cursor-pointer transition-opacity hover:opacity-90",
-								dmSans125ClassName(),
+						<div className="flex w-full flex-col items-center gap-2">
+							{eligibleClients.length > 0 ? (
+								<button
+									type="button"
+									onClick={handleConnect}
+									className={cn(
+										"relative w-full h-11 rounded-[10px] flex items-center justify-center",
+										"text-[#FAFAFA] font-medium text-[14px]",
+										"shadow-[0px_2px_10px_rgba(5,1,0,0.2)]",
+										"cursor-pointer transition-opacity hover:opacity-90",
+										dmSans125ClassName(),
+									)}
+									style={{
+										background:
+											"linear-gradient(182.37deg, #0ff0d2 -91.53%, #5bd3fb -67.8%, #1e0ff0 95.17%)",
+										boxShadow:
+											"1px 1px 2px 0px #1A88FF inset, 0 2px 10px 0 rgba(5, 1, 0, 0.20)",
+									}}
+								>
+									{blockedClients.length > 0
+										? "Approve available plugins"
+										: "Approve Connection"}
+									<div className="absolute inset-0 pointer-events-none rounded-[inherit] shadow-[inset_1px_1px_2px_1px_#1A88FF]" />
+								</button>
+							) : (
+								<button
+									type="button"
+									onClick={handleUpgrade}
+									disabled={isUpgrading || autumn.isLoading}
+									className={cn(
+										"relative w-full h-11 rounded-[10px] flex items-center justify-center",
+										"text-[#FAFAFA] font-medium text-[14px] disabled:opacity-60 disabled:cursor-not-allowed",
+										"shadow-[0px_2px_10px_rgba(5,1,0,0.2)]",
+										"cursor-pointer transition-opacity hover:opacity-90",
+										dmSans125ClassName(),
+									)}
+									style={{
+										background:
+											"linear-gradient(182.37deg, #0ff0d2 -91.53%, #5bd3fb -67.8%, #1e0ff0 95.17%)",
+										boxShadow:
+											"1px 1px 2px 0px #1A88FF inset, 0 2px 10px 0 rgba(5, 1, 0, 0.20)",
+									}}
+								>
+									{isUpgrading || autumn.isLoading ? (
+										<>
+											<Loader className="size-4 animate-spin mr-2" />
+											Upgrading...
+										</>
+									) : (
+										"Upgrade to Pro"
+									)}
+									<div className="absolute inset-0 pointer-events-none rounded-[inherit] shadow-[inset_1px_1px_2px_1px_#1A88FF]" />
+								</button>
 							)}
-							style={{
-								background:
-									"linear-gradient(182.37deg, #0ff0d2 -91.53%, #5bd3fb -67.8%, #1e0ff0 95.17%)",
-								boxShadow:
-									"1px 1px 2px 0px #1A88FF inset, 0 2px 10px 0 rgba(5, 1, 0, 0.20)",
-							}}
-						>
-							Approve Connection
-							<div className="absolute inset-0 pointer-events-none rounded-[inherit] shadow-[inset_1px_1px_2px_1px_#1A88FF]" />
-						</button>
+
+							{eligibleClients.length > 0 && blockedClients.length > 0 && (
+								<button
+									type="button"
+									onClick={handleUpgrade}
+									disabled={isUpgrading || autumn.isLoading}
+									className={cn(
+										"inline-flex min-h-8 items-center justify-center gap-1.5 text-[12px] text-[#737373] hover:text-[#FAFAFA]",
+										"disabled:opacity-60 disabled:cursor-not-allowed cursor-pointer transition-colors",
+										dmSans125ClassName(),
+									)}
+								>
+									{isUpgrading || autumn.isLoading ? (
+										"Opening upgrade..."
+									) : (
+										<>
+											<Image
+												alt=""
+												className="size-3.5 rounded-[3px] object-contain opacity-90"
+												height={14}
+												src="/images/logo.png"
+												width={14}
+											/>
+											<span>{`Upgrade to include ${blockedDisplayName}`}</span>
+										</>
+									)}
+								</button>
+							)}
+						</div>
 					</div>
 				</div>
 			</div>
@@ -476,19 +702,11 @@ function AuthConnectContent() {
 			<div className={pageWrapperClass}>
 				<div className={cardClass}>
 					<div className="flex flex-col items-center gap-5">
-						<div className="flex size-10 items-center justify-center rounded-lg border border-[#1E293B] bg-[#080B0F]">
-							{pluginInfo ? (
-								<Image
-									alt={pluginInfo.name}
-									className="size-6"
-									height={24}
-									src={pluginInfo.icon}
-									width={24}
-								/>
-							) : (
-								<ArrowRight className="size-5 text-[#4BA0FA]" />
-							)}
-						</div>
+						<PluginLogoStack
+							clients={
+								blockedClients.length > 0 ? blockedClients : requestedClients
+							}
+						/>
 						<div className="text-center">
 							<h2
 								className={dmSans125ClassName(
@@ -502,7 +720,8 @@ function AuthConnectContent() {
 									"text-[13px] text-[#737373] mt-1",
 								)}
 							>
-								{pluginInfo?.description ??
+								{error ??
+									pluginInfo?.description ??
 									`A paid plan is required to use ${displayName} with Supermemory.`}
 							</p>
 						</div>

--- a/apps/web/app/auth/connect/page.tsx
+++ b/apps/web/app/auth/connect/page.tsx
@@ -7,7 +7,7 @@ import { cn } from "@lib/utils"
 import { dmSans125ClassName } from "@/lib/fonts"
 import { isFreeTierPlugin } from "@/lib/plugin-catalog"
 import { useCustomer } from "autumn-js/react"
-import { ArrowRight, Check, Loader, XCircle } from "lucide-react"
+import { ArrowRight, Check, Clock3, Loader, XCircle } from "lucide-react"
 import Image from "next/image"
 import { useRouter, useSearchParams } from "next/navigation"
 import {
@@ -23,6 +23,8 @@ import { PENDING_CONNECT_URL_KEY } from "@/lib/constants"
 
 const API_URL =
 	process.env.NEXT_PUBLIC_BACKEND_URL ?? "https://api.supermemory.ai"
+const UPGRADE_PLAN_SYNC_TIMEOUT_MS = 10 * 60 * 1000
+const UPGRADE_PLAN_SYNC_RETRY_MS = 3000
 
 function isValidLocalhostCallback(callback: string): boolean {
 	try {
@@ -249,7 +251,13 @@ function PluginAccessList({
 		</div>
 	)
 }
-type Status = "loading" | "creating" | "success" | "error" | "upgrade"
+type Status =
+	| "loading"
+	| "creating"
+	| "success"
+	| "error"
+	| "upgrade"
+	| "upgrade_timeout"
 
 const pageWrapperClass =
 	"flex items-center justify-center min-h-screen bg-background p-4"
@@ -268,6 +276,8 @@ function AuthConnectContent() {
 	const [error, setError] = useState<string | null>(null)
 	const [isUpgrading, setIsUpgrading] = useState(false)
 	const hasAutoConnectedAfterUpgrade = useRef(false)
+	const upgradeSyncStartedAt = useRef<number | null>(null)
+	const upgradeSyncRetryTimer = useRef<number | null>(null)
 
 	const callback = params.get("callback")
 	const client = params.get("client")
@@ -374,16 +384,35 @@ function AuthConnectContent() {
 
 		try {
 			setStatus("creating")
+			if (
+				shouldAutoConnectAfterUpgrade &&
+				eligibleClients.length < requestedClients.length
+			) {
+				const startedAt = upgradeSyncStartedAt.current ?? Date.now()
+				upgradeSyncStartedAt.current = startedAt
+
+				if (Date.now() - startedAt < UPGRADE_PLAN_SYNC_TIMEOUT_MS) {
+					hasAutoConnectedAfterUpgrade.current = false
+					setStatus("loading")
+					if (upgradeSyncRetryTimer.current !== null) {
+						window.clearTimeout(upgradeSyncRetryTimer.current)
+					}
+					upgradeSyncRetryTimer.current = window.setTimeout(() => {
+						upgradeSyncRetryTimer.current = null
+						void autumn.refetch?.()
+					}, UPGRADE_PLAN_SYNC_RETRY_MS)
+					return
+				}
+
+				setStatus("upgrade_timeout")
+				setError(
+					"Your upgrade completed, but Pro access is still syncing. Re-authenticate from the CLI to finish connecting.",
+				)
+				return
+			}
 			if (eligibleClients.length === 0) {
 				setStatus("upgrade")
 				setError(`Upgrade to Pro to connect ${blockedDisplayName}.`)
-				return
-			}
-			if (shouldAutoConnectAfterUpgrade && blockedClients.length > 0) {
-				setStatus("upgrade")
-				setError(
-					"Your plan update is still processing. Please try again in a moment.",
-				)
 				return
 			}
 
@@ -449,6 +478,7 @@ function AuthConnectContent() {
 			setError(err instanceof Error ? err.message : "Failed to get API key")
 		}
 	}, [
+		autumn,
 		blockedClients,
 		blockedDisplayName,
 		callback,
@@ -478,6 +508,21 @@ function AuthConnectContent() {
 		}
 	}
 
+	const retryUpgradeSync = useCallback(() => {
+		upgradeSyncStartedAt.current = Date.now()
+		hasAutoConnectedAfterUpgrade.current = false
+		setError(null)
+		setStatus("loading")
+		void autumn.refetch?.()
+	}, [autumn])
+
+	useEffect(() => {
+		return () => {
+			if (upgradeSyncRetryTimer.current !== null) {
+				window.clearTimeout(upgradeSyncRetryTimer.current)
+			}
+		}
+	}, [])
 	// Show a spinner while session/org data is loading or while we're about
 	// to redirect to onboarding (prevents a brief flash of the connect card).
 	const isAuthLoading =
@@ -785,6 +830,66 @@ function AuthConnectContent() {
 		)
 	}
 
+	if (status === "upgrade_timeout") {
+		return (
+			<div className={pageWrapperClass}>
+				<div className={cardClass}>
+					<div className="flex flex-col items-center gap-5 text-center">
+						<Clock3 className="size-10 text-[#8BC6FF]" />
+						<div>
+							<h2
+								className={dmSans125ClassName(
+									"font-semibold text-[18px] text-[#FAFAFA]",
+								)}
+							>
+								Request timed out
+							</h2>
+							<p
+								className={dmSans125ClassName(
+									"text-[13px] text-[#737373] mt-1",
+								)}
+							>
+								{error ??
+									"Your upgrade completed, but Pro access is still syncing."}
+							</p>
+						</div>
+
+						<div className="w-full rounded-lg border border-[#1E293B] bg-[#0D121A] px-4 py-3 text-left">
+							<p className={dmSans125ClassName("text-[12px] text-[#8B8B8B]")}>
+								Re-authenticate from the CLI to finish connecting.
+							</p>
+							<code className="mt-1 block text-[12px] text-[#8BC6FF]">
+								npx supermemory plugin login
+							</code>
+						</div>
+
+						<div className="flex w-full flex-col gap-2">
+							<button
+								type="button"
+								onClick={retryUpgradeSync}
+								className={cn(
+									"w-full flex items-center justify-center rounded-[10px] h-11",
+									"bg-[#0D121A] border border-[#1E293B] text-[#FAFAFA]",
+									"text-[14px] font-medium cursor-pointer transition-colors hover:bg-[#1E293B]",
+									dmSans125ClassName(),
+								)}
+							>
+								Try syncing again
+							</button>
+							<a
+								href="https://app.supermemory.ai/settings#billing"
+								className={dmSans125ClassName(
+									"text-[12px] text-[#737373] hover:text-[#FAFAFA] transition-colors",
+								)}
+							>
+								View billing
+							</a>
+						</div>
+					</div>
+				</div>
+			</div>
+		)
+	}
 	if (status === "error") {
 		return (
 			<div className={pageWrapperClass}>

--- a/apps/web/app/auth/connect/page.tsx
+++ b/apps/web/app/auth/connect/page.tsx
@@ -203,16 +203,6 @@ function PluginAccessList({
 					const eligible = state === "eligible"
 					return (
 						<div className="flex items-center gap-3" key={`${id}-${state}`}>
-							<div
-								className={cn(
-									"flex size-6 shrink-0 items-center justify-center rounded-md border",
-									eligible
-										? "border-[#24413C] bg-[#0B1717] text-[#8BD8CB]"
-										: "border-transparent bg-transparent",
-								)}
-							>
-								{eligible && <Check className="size-3" strokeWidth={2} />}
-							</div>
 							{plugin && (
 								<Image
 									alt=""
@@ -231,6 +221,11 @@ function PluginAccessList({
 									>
 										{getPluginName(id)}
 									</p>
+									{eligible && (
+										<span className="inline-flex size-5 shrink-0 items-center justify-center rounded-full border border-[#24413C] bg-[#0B1717] text-[#8BD8CB]">
+											<Check className="size-3" strokeWidth={2} />
+										</span>
+									)}
 									{!eligible && (
 										<span
 											className={dmSans125ClassName(

--- a/apps/web/app/auth/connect/page.tsx
+++ b/apps/web/app/auth/connect/page.tsx
@@ -278,6 +278,7 @@ function AuthConnectContent() {
 	const hasAutoConnectedAfterUpgrade = useRef(false)
 	const upgradeSyncStartedAt = useRef<number | null>(null)
 	const upgradeSyncRetryTimer = useRef<number | null>(null)
+	const handleConnectRef = useRef<(() => Promise<void>) | null>(null)
 
 	const callback = params.get("callback")
 	const client = params.get("client")
@@ -392,14 +393,19 @@ function AuthConnectContent() {
 				upgradeSyncStartedAt.current = startedAt
 
 				if (Date.now() - startedAt < UPGRADE_PLAN_SYNC_TIMEOUT_MS) {
-					hasAutoConnectedAfterUpgrade.current = false
 					setStatus("loading")
 					if (upgradeSyncRetryTimer.current !== null) {
 						window.clearTimeout(upgradeSyncRetryTimer.current)
 					}
 					upgradeSyncRetryTimer.current = window.setTimeout(() => {
 						upgradeSyncRetryTimer.current = null
-						void autumn.refetch?.()
+						void (async () => {
+							try {
+								await autumn.refetch?.()
+							} finally {
+								void handleConnectRef.current?.()
+							}
+						})()
 					}, UPGRADE_PLAN_SYNC_RETRY_MS)
 					return
 				}
@@ -492,6 +498,10 @@ function AuthConnectContent() {
 		shouldAutoConnectAfterUpgrade,
 	])
 
+	useEffect(() => {
+		handleConnectRef.current = handleConnect
+	}, [handleConnect])
+
 	async function handleUpgrade() {
 		try {
 			setIsUpgrading(true)
@@ -510,7 +520,6 @@ function AuthConnectContent() {
 
 	const retryUpgradeSync = useCallback(() => {
 		upgradeSyncStartedAt.current = Date.now()
-		hasAutoConnectedAfterUpgrade.current = false
 		setError(null)
 		setStatus("loading")
 		void autumn.refetch?.()

--- a/apps/web/app/auth/connect/page.tsx
+++ b/apps/web/app/auth/connect/page.tsx
@@ -522,7 +522,13 @@ function AuthConnectContent() {
 		upgradeSyncStartedAt.current = Date.now()
 		setError(null)
 		setStatus("loading")
-		void autumn.refetch?.()
+		void (async () => {
+			try {
+				await autumn.refetch?.()
+			} finally {
+				void handleConnectRef.current?.()
+			}
+		})()
 	}, [autumn])
 
 	useEffect(() => {

--- a/apps/web/app/auth/connect/page.tsx
+++ b/apps/web/app/auth/connect/page.tsx
@@ -2,29 +2,17 @@
 
 import { useAuth } from "@lib/auth-context"
 import { useSession } from "@lib/auth"
-import { hasActivePlan } from "@lib/queries"
 import { cn } from "@lib/utils"
 import { dmSans125ClassName } from "@/lib/fonts"
-import { isFreeTierPlugin } from "@/lib/plugin-catalog"
-import { useCustomer } from "autumn-js/react"
-import { ArrowRight, Check, Loader, XCircle } from "lucide-react"
+import { ArrowRight, XCircle } from "lucide-react"
 import Image from "next/image"
 import { useRouter, useSearchParams } from "next/navigation"
-import {
-	Suspense,
-	useCallback,
-	useEffect,
-	useMemo,
-	useRef,
-	useState,
-} from "react"
+import { Suspense, useEffect, useMemo, useState } from "react"
 
 import { PENDING_CONNECT_URL_KEY } from "@/lib/constants"
 
 const API_URL =
 	process.env.NEXT_PUBLIC_BACKEND_URL ?? "https://api.supermemory.ai"
-const UPGRADE_PLAN_SYNC_TIMEOUT_MS = 10 * 60 * 1000
-const UPGRADE_PLAN_SYNC_RETRY_MS = 3000
 
 function isValidLocalhostCallback(callback: string): boolean {
 	try {
@@ -99,7 +87,7 @@ const PLUGIN_INFO: Record<string, PluginInfo> = {
 			"Auto-capture of project decisions",
 			"Context-aware suggestions",
 		],
-		icon: "/images/plugins/cursor.svg",
+		icon: "/images/plugins/cursor.png",
 	},
 	codex: {
 		name: "OpenAI Codex",
@@ -112,6 +100,16 @@ const PLUGIN_INFO: Record<string, PluginInfo> = {
 		],
 		icon: "/images/plugins/codex.png",
 	},
+}
+
+const MULTI_PLUGIN_FEATURES = [
+	"Share one persistent memory layer across selected coding agents.",
+	"Recall project context, coding decisions, and prior sessions.",
+	"Connect every selected plugin with one approval.",
+]
+
+function isKnownPlugin(value: string): boolean {
+	return Object.hasOwn(PLUGIN_INFO, value)
 }
 
 function getPluginName(client: string): string {
@@ -134,10 +132,6 @@ function encodeBase64UrlJson(value: Record<string, string>): string {
 		.replace(/\+/g, "-")
 		.replace(/\//g, "_")
 		.replace(/=+$/g, "")
-}
-
-function pluginAccessError(client: string): string {
-	return `${getPluginName(client)} requires a Pro plan or higher.`
 }
 
 function PluginLogoStack({ clients }: { clients: string[] }) {
@@ -178,86 +172,7 @@ function PluginLogoStack({ clients }: { clients: string[] }) {
 	)
 }
 
-function PluginAccessList({
-	blockedClients,
-	eligibleClients,
-}: {
-	blockedClients: string[]
-	eligibleClients: string[]
-}) {
-	const rows = [
-		...eligibleClients.map((id) => ({ id, state: "eligible" as const })),
-		...blockedClients.map((id) => ({ id, state: "blocked" as const })),
-	]
-
-	if (rows.length === 0) return null
-
-	return (
-		<div className="w-full space-y-2">
-			<p
-				className={dmSans125ClassName("text-[12px] font-medium text-[#FAFAFA]")}
-			>
-				Connection summary
-			</p>
-			<div className="space-y-2">
-				{rows.map(({ id, state }) => {
-					const plugin = PLUGIN_INFO[id]
-					const eligible = state === "eligible"
-					return (
-						<div className="flex items-center gap-3" key={`${id}-${state}`}>
-							{plugin && (
-								<Image
-									alt=""
-									className="size-5 object-contain"
-									height={20}
-									src={plugin.icon}
-									width={20}
-								/>
-							)}
-							<div className="min-w-0 flex-1">
-								<div className="flex min-w-0 items-center gap-1.5">
-									<p
-										className={dmSans125ClassName(
-											"truncate text-[13px] text-[#FAFAFA]",
-										)}
-									>
-										{getPluginName(id)}
-									</p>
-									{eligible && (
-										<span className="inline-flex size-5 shrink-0 items-center justify-center rounded-full border border-[#24413C] bg-[#0B1717] text-[#8BD8CB]">
-											<Check className="size-3" strokeWidth={2} />
-										</span>
-									)}
-									{!eligible && (
-										<span
-											className={dmSans125ClassName(
-												"shrink-0 rounded-full bg-[#4BA0FA]/15 px-1.5 py-0.5 text-[9px] font-semibold text-[#8BC6FF]",
-											)}
-										>
-											PRO
-										</span>
-									)}
-								</div>
-								<p className={dmSans125ClassName("text-[12px] text-[#737373]")}>
-									{eligible
-										? "Available on your current plan"
-										: "Upgrade required"}
-								</p>
-							</div>
-						</div>
-					)
-				})}
-			</div>
-		</div>
-	)
-}
-type Status =
-	| "loading"
-	| "creating"
-	| "success"
-	| "error"
-	| "upgrade"
-	| "upgrade_timeout"
+type Status = "loading" | "creating" | "success" | "error"
 
 const pageWrapperClass =
 	"flex items-center justify-center min-h-screen bg-background p-4"
@@ -271,14 +186,8 @@ function AuthConnectContent() {
 	const router = useRouter()
 	const { data: session, isPending } = useSession()
 	const { org, organizations, isRestoring } = useAuth()
-	const autumn = useCustomer()
 	const [status, setStatus] = useState<Status>("loading")
 	const [error, setError] = useState<string | null>(null)
-	const [isUpgrading, setIsUpgrading] = useState(false)
-	const hasAutoConnectedAfterUpgrade = useRef(false)
-	const upgradeSyncStartedAt = useRef<number | null>(null)
-	const upgradeSyncRetryTimer = useRef<number | null>(null)
-	const handleConnectRef = useRef<(() => Promise<void>) | null>(null)
 
 	const callback = params.get("callback")
 	const client = params.get("client")
@@ -292,14 +201,11 @@ function AuthConnectContent() {
 		[client, clientsParam],
 	)
 	const requestedClients = useMemo(
-		() =>
-			Array.from(
-				new Set(rawRequestedClients.filter((value) => value in PLUGIN_INFO)),
-			),
+		() => Array.from(new Set(rawRequestedClients.filter(isKnownPlugin))),
 		[rawRequestedClients],
 	)
 	const invalidClients = useMemo(
-		() => rawRequestedClients.filter((value) => !(value in PLUGIN_INFO)),
+		() => rawRequestedClients.filter((value) => !isKnownPlugin(value)),
 		[rawRequestedClients],
 	)
 	const validClient = requestedClients[0] ?? null
@@ -308,28 +214,6 @@ function AuthConnectContent() {
 		requestedClients.length === 1 && validClient
 			? PLUGIN_INFO[validClient]
 			: null
-	const hasProProduct = hasActivePlan(autumn.data?.subscriptions, "api_pro")
-	const eligibleClients = useMemo(
-		() =>
-			requestedClients.filter(
-				(requestedClient) => hasProProduct || isFreeTierPlugin(requestedClient),
-			),
-		[hasProProduct, requestedClients],
-	)
-	const blockedClients = useMemo(
-		() =>
-			requestedClients.filter(
-				(requestedClient) => !eligibleClients.includes(requestedClient),
-			),
-		[eligibleClients, requestedClients],
-	)
-	const needsPlanStatus = requestedClients.some(
-		(requestedClient) => !isFreeTierPlugin(requestedClient),
-	)
-	const shouldAutoConnectAfterUpgrade =
-		params.get("upgrade_complete") === "true"
-	const eligibleDisplayName = formatPluginNames(eligibleClients)
-	const blockedDisplayName = formatPluginNames(blockedClients)
 
 	// Redirect new users (logged in but no organization) to onboarding.
 	// Store the current connect URL so onboarding can redirect back here.
@@ -354,7 +238,7 @@ function AuthConnectContent() {
 		router.replace("/onboarding")
 	}, [isPending, isRestoring, session, organizations, router])
 
-	const handleConnect = useCallback(async () => {
+	async function handleConnect() {
 		if (!callback) {
 			setStatus("error")
 			setError("Missing callback parameter.")
@@ -385,45 +269,8 @@ function AuthConnectContent() {
 
 		try {
 			setStatus("creating")
-			if (
-				shouldAutoConnectAfterUpgrade &&
-				eligibleClients.length < requestedClients.length
-			) {
-				const startedAt = upgradeSyncStartedAt.current ?? Date.now()
-				upgradeSyncStartedAt.current = startedAt
-
-				if (Date.now() - startedAt < UPGRADE_PLAN_SYNC_TIMEOUT_MS) {
-					setStatus("loading")
-					if (upgradeSyncRetryTimer.current !== null) {
-						window.clearTimeout(upgradeSyncRetryTimer.current)
-					}
-					upgradeSyncRetryTimer.current = window.setTimeout(() => {
-						upgradeSyncRetryTimer.current = null
-						void (async () => {
-							try {
-								await autumn.refetch?.()
-							} finally {
-								void handleConnectRef.current?.()
-							}
-						})()
-					}, UPGRADE_PLAN_SYNC_RETRY_MS)
-					return
-				}
-
-				setStatus("upgrade_timeout")
-				setError(
-					"Your upgrade completed, but Pro access is still syncing. Re-authenticate from the CLI to finish connecting.",
-				)
-				return
-			}
-			if (eligibleClients.length === 0) {
-				setStatus("upgrade")
-				setError(`Upgrade to Pro to connect ${blockedDisplayName}.`)
-				return
-			}
-
 			const fetchParams = new URLSearchParams({ callback })
-			fetchParams.set("client", eligibleClients[0] ?? "")
+			fetchParams.set("client", requestedClients[0] ?? "")
 
 			const res = await fetch(`${API_URL}/v3/auth/key?${fetchParams}`, {
 				credentials: "include",
@@ -432,14 +279,6 @@ function AuthConnectContent() {
 			if (!res.ok) {
 				const errorData = (await res.json().catch(() => ({}))) as {
 					message?: string
-				}
-				if (res.status === 403) {
-					setStatus("upgrade")
-					setError(
-						errorData.message ||
-							`Upgrade to Pro to connect ${eligibleDisplayName}.`,
-					)
-					return
 				}
 				throw new Error(errorData.message || "Failed to get API key")
 			}
@@ -453,26 +292,13 @@ function AuthConnectContent() {
 					"keys",
 					encodeBase64UrlJson(
 						Object.fromEntries(
-							eligibleClients.map((eligibleClient) => [
-								eligibleClient,
+							requestedClients.map((requestedClient) => [
+								requestedClient,
 								data.key,
 							]),
 						),
 					),
 				)
-				if (blockedClients.length > 0) {
-					redirectUrl.searchParams.set(
-						"errors",
-						encodeBase64UrlJson(
-							Object.fromEntries(
-								blockedClients.map((blockedClient) => [
-									blockedClient,
-									pluginAccessError(blockedClient),
-								]),
-							),
-						),
-					)
-				}
 			} else {
 				redirectUrl.searchParams.set("apikey", data.key)
 			}
@@ -483,85 +309,11 @@ function AuthConnectContent() {
 			setStatus("error")
 			setError(err instanceof Error ? err.message : "Failed to get API key")
 		}
-	}, [
-		autumn,
-		blockedClients,
-		blockedDisplayName,
-		callback,
-		eligibleClients,
-		eligibleDisplayName,
-		hasClientList,
-		invalidClients,
-		org,
-		requestedClients.length,
-		session,
-		shouldAutoConnectAfterUpgrade,
-	])
-
-	useEffect(() => {
-		handleConnectRef.current = handleConnect
-	}, [handleConnect])
-
-	async function handleUpgrade() {
-		try {
-			setIsUpgrading(true)
-			const successParams = new URLSearchParams(params.toString())
-			successParams.set("upgrade_complete", "true")
-			const safeSuccessUrl = `${window.location.origin}${window.location.pathname}?${successParams.toString()}`
-			await autumn.attach({
-				planId: "api_pro",
-				successUrl: safeSuccessUrl,
-			})
-		} catch (err) {
-			console.error("Upgrade failed:", err)
-			setIsUpgrading(false)
-		}
 	}
 
-	const retryUpgradeSync = useCallback(() => {
-		upgradeSyncStartedAt.current = Date.now()
-		setError(null)
-		setStatus("loading")
-		void (async () => {
-			try {
-				await autumn.refetch?.()
-			} finally {
-				void handleConnectRef.current?.()
-			}
-		})()
-	}, [autumn])
-
-	useEffect(() => {
-		return () => {
-			if (upgradeSyncRetryTimer.current !== null) {
-				window.clearTimeout(upgradeSyncRetryTimer.current)
-			}
-		}
-	}, [])
 	// Show a spinner while session/org data is loading or while we're about
 	// to redirect to onboarding (prevents a brief flash of the connect card).
-	const isAuthLoading =
-		isPending ||
-		isRestoring ||
-		organizations === null ||
-		(needsPlanStatus && autumn.isLoading)
-	useEffect(() => {
-		if (!shouldAutoConnectAfterUpgrade) return
-		if (hasAutoConnectedAfterUpgrade.current) return
-		if (status !== "loading") return
-		if (isAuthLoading || shouldRedirectToOnboarding || !session || !org) return
-
-		hasAutoConnectedAfterUpgrade.current = true
-		void handleConnect()
-	}, [
-		shouldAutoConnectAfterUpgrade,
-		status,
-		isAuthLoading,
-		shouldRedirectToOnboarding,
-		session,
-		org,
-		handleConnect,
-	])
+	const isAuthLoading = isPending || isRestoring || organizations === null
 
 	useEffect(() => {
 		if (status !== "loading") return
@@ -610,18 +362,9 @@ function AuthConnectContent() {
 							</p>
 						</div>
 
-						{(requestedClients.length > 1 || blockedClients.length > 0) && (
-							<PluginAccessList
-								blockedClients={blockedClients}
-								eligibleClients={eligibleClients}
-							/>
-						)}
-
-						{requestedClients.length <= 1 &&
-						blockedClients.length === 0 &&
-						pluginInfo ? (
-							<ul className="w-full space-y-2.5">
-								{pluginInfo.features.map((feature) => (
+						<ul className="w-full space-y-2.5">
+							{(pluginInfo?.features ?? MULTI_PLUGIN_FEATURES).map(
+								(feature) => (
 									<li key={feature} className="flex items-start gap-2.5">
 										<ArrowRight className="mt-0.5 size-3.5 shrink-0 text-[#4BA0FA]" />
 										<span
@@ -632,184 +375,17 @@ function AuthConnectContent() {
 											{feature}
 										</span>
 									</li>
-								))}
-							</ul>
-						) : requestedClients.length <= 1 && blockedClients.length === 0 ? (
-							<ul className="w-full space-y-2.5">
-								<li className="flex items-start gap-2.5">
-									<ArrowRight className="mt-0.5 size-3.5 shrink-0 text-[#4BA0FA]" />
-									<span
-										className={dmSans125ClassName("text-[13px] text-[#8B8B8B]")}
-									>
-										Share one persistent memory layer across selected coding
-										agents.
-									</span>
-								</li>
-								<li className="flex items-start gap-2.5">
-									<ArrowRight className="mt-0.5 size-3.5 shrink-0 text-[#4BA0FA]" />
-									<span
-										className={dmSans125ClassName("text-[13px] text-[#8B8B8B]")}
-									>
-										Recall project context, coding decisions, and prior
-										sessions.
-									</span>
-								</li>
-								<li className="flex items-start gap-2.5">
-									<ArrowRight className="mt-0.5 size-3.5 shrink-0 text-[#4BA0FA]" />
-									<span
-										className={dmSans125ClassName("text-[13px] text-[#8B8B8B]")}
-									>
-										Keep each connected plugin ready without separate auth
-										steps.
-									</span>
-								</li>
-							</ul>
-						) : null}
-
-						<div className="flex w-full flex-col items-center gap-2">
-							{eligibleClients.length > 0 ? (
-								<button
-									type="button"
-									onClick={handleConnect}
-									className={cn(
-										"relative w-full h-11 rounded-[10px] flex items-center justify-center",
-										"text-[#FAFAFA] font-medium text-[14px]",
-										"shadow-[0px_2px_10px_rgba(5,1,0,0.2)]",
-										"cursor-pointer transition-opacity hover:opacity-90",
-										dmSans125ClassName(),
-									)}
-									style={{
-										background:
-											"linear-gradient(182.37deg, #0ff0d2 -91.53%, #5bd3fb -67.8%, #1e0ff0 95.17%)",
-										boxShadow:
-											"1px 1px 2px 0px #1A88FF inset, 0 2px 10px 0 rgba(5, 1, 0, 0.20)",
-									}}
-								>
-									{blockedClients.length > 0
-										? "Approve available plugins"
-										: "Approve Connection"}
-									<div className="absolute inset-0 pointer-events-none rounded-[inherit] shadow-[inset_1px_1px_2px_1px_#1A88FF]" />
-								</button>
-							) : (
-								<button
-									type="button"
-									onClick={handleUpgrade}
-									disabled={isUpgrading || autumn.isLoading}
-									className={cn(
-										"relative w-full h-11 rounded-[10px] flex items-center justify-center",
-										"text-[#FAFAFA] font-medium text-[14px] disabled:opacity-60 disabled:cursor-not-allowed",
-										"shadow-[0px_2px_10px_rgba(5,1,0,0.2)]",
-										"cursor-pointer transition-opacity hover:opacity-90",
-										dmSans125ClassName(),
-									)}
-									style={{
-										background:
-											"linear-gradient(182.37deg, #0ff0d2 -91.53%, #5bd3fb -67.8%, #1e0ff0 95.17%)",
-										boxShadow:
-											"1px 1px 2px 0px #1A88FF inset, 0 2px 10px 0 rgba(5, 1, 0, 0.20)",
-									}}
-								>
-									{isUpgrading || autumn.isLoading ? (
-										<>
-											<Loader className="size-4 animate-spin mr-2" />
-											Upgrading...
-										</>
-									) : (
-										"Upgrade to Pro"
-									)}
-									<div className="absolute inset-0 pointer-events-none rounded-[inherit] shadow-[inset_1px_1px_2px_1px_#1A88FF]" />
-								</button>
+								),
 							)}
-
-							{eligibleClients.length > 0 && blockedClients.length > 0 && (
-								<button
-									type="button"
-									onClick={handleUpgrade}
-									disabled={isUpgrading || autumn.isLoading}
-									className={cn(
-										"inline-flex min-h-8 items-center justify-center gap-1.5 text-[12px] text-[#737373] hover:text-[#FAFAFA]",
-										"disabled:opacity-60 disabled:cursor-not-allowed cursor-pointer transition-colors",
-										dmSans125ClassName(),
-									)}
-								>
-									{isUpgrading || autumn.isLoading ? (
-										"Opening upgrade..."
-									) : (
-										<>
-											<Image
-												alt=""
-												className="size-3.5 rounded-[3px] object-contain opacity-90"
-												height={14}
-												src="/images/logo.png"
-												width={14}
-											/>
-											<span>{`Upgrade to include ${blockedDisplayName}`}</span>
-										</>
-									)}
-								</button>
-							)}
-						</div>
-					</div>
-				</div>
-			</div>
-		)
-	}
-
-	if (status === "upgrade") {
-		return (
-			<div className={pageWrapperClass}>
-				<div className={cardClass}>
-					<div className="flex flex-col items-center gap-5">
-						<PluginLogoStack
-							clients={
-								blockedClients.length > 0 ? blockedClients : requestedClients
-							}
-						/>
-						<div className="text-center">
-							<h2
-								className={dmSans125ClassName(
-									"font-semibold text-[18px] text-[#FAFAFA]",
-								)}
-							>
-								{pluginInfo?.name ?? displayName}
-							</h2>
-							<p
-								className={dmSans125ClassName(
-									"text-[13px] text-[#737373] mt-1",
-								)}
-							>
-								{error ??
-									pluginInfo?.description ??
-									`A paid plan is required to use ${displayName} with Supermemory.`}
-							</p>
-						</div>
-
-						{pluginInfo && (
-							<ul className="w-full space-y-2.5">
-								{pluginInfo.features.map((feature) => (
-									<li key={feature} className="flex items-start gap-2.5">
-										<ArrowRight className="mt-0.5 size-3.5 shrink-0 text-[#4BA0FA]" />
-										<span
-											className={dmSans125ClassName(
-												"text-[13px] text-[#8B8B8B]",
-											)}
-										>
-											{feature}
-										</span>
-									</li>
-								))}
-							</ul>
-						)}
+						</ul>
 
 						<button
 							type="button"
-							onClick={handleUpgrade}
-							disabled={isUpgrading || autumn.isLoading}
+							onClick={handleConnect}
 							className={cn(
 								"relative w-full h-11 rounded-[10px] flex items-center justify-center",
-								"text-[#FAFAFA] font-medium text-[14px] tracking-[-0.14px]",
+								"text-[#FAFAFA] font-medium text-[14px]",
 								"shadow-[0px_2px_10px_rgba(5,1,0,0.2)]",
-								"disabled:opacity-60 disabled:cursor-not-allowed",
 								"cursor-pointer transition-opacity hover:opacity-90",
 								dmSans125ClassName(),
 							)}
@@ -820,88 +396,9 @@ function AuthConnectContent() {
 									"1px 1px 2px 0px #1A88FF inset, 0 2px 10px 0 rgba(5, 1, 0, 0.20)",
 							}}
 						>
-							{isUpgrading || autumn.isLoading ? (
-								<>
-									<Loader className="size-4 animate-spin mr-2" />
-									Upgrading…
-								</>
-							) : (
-								"Upgrade to Pro \u2014 $19/month"
-							)}
+							Approve Connection
 							<div className="absolute inset-0 pointer-events-none rounded-[inherit] shadow-[inset_1px_1px_2px_1px_#1A88FF]" />
 						</button>
-
-						<a
-							href="https://app.supermemory.ai/settings#billing"
-							className={dmSans125ClassName(
-								"text-[12px] text-[#737373] hover:text-[#FAFAFA] transition-colors",
-							)}
-						>
-							View all plans
-						</a>
-					</div>
-				</div>
-			</div>
-		)
-	}
-
-	if (status === "upgrade_timeout") {
-		return (
-			<div className={pageWrapperClass}>
-				<div className={cardClass}>
-					<div className="flex flex-col items-center gap-5 text-center">
-						<PluginLogoStack clients={requestedClients} />
-						<div>
-							<h2
-								className={dmSans125ClassName(
-									"font-semibold text-[18px] text-[#FAFAFA]",
-								)}
-							>
-								Request timed out
-							</h2>
-							<p
-								className={dmSans125ClassName(
-									"text-[13px] text-[#737373] mt-1",
-								)}
-							>
-								{error ??
-									"Your upgrade completed, but Pro access is still syncing."}
-							</p>
-						</div>
-
-						<div className="w-full text-left">
-							<p className={dmSans125ClassName("text-[12px] text-[#737373]")}>
-								Re-authenticate from the CLI to finish connecting:
-							</p>
-							<code className="mt-1.5 block text-[12px] text-[#FAFAFA]">
-								npx supermemory plugin login
-							</code>
-						</div>
-
-						<div className="flex w-full flex-col gap-2">
-							<button
-								type="button"
-								onClick={retryUpgradeSync}
-								className={cn(
-									"w-full flex items-center justify-center rounded-[10px] h-11",
-									"text-[#FAFAFA] text-[14px] font-medium cursor-pointer",
-									"bg-[linear-gradient(182.37deg,#0ff0d2_-91.53%,#5bd3fb_-67.8%,#1e0ff0_95.17%)]",
-									"shadow-[1px_1px_2px_0px_#1A88FF_inset,0_2px_10px_0_rgba(5,1,0,0.20)]",
-									"transition-opacity hover:opacity-90",
-									dmSans125ClassName(),
-								)}
-							>
-								Try syncing again
-							</button>
-							<a
-								href="https://app.supermemory.ai/settings#billing"
-								className={dmSans125ClassName(
-									"text-[12px] text-[#737373] hover:text-[#FAFAFA] transition-colors",
-								)}
-							>
-								View billing
-							</a>
-						</div>
 					</div>
 				</div>
 			</div>
@@ -933,7 +430,7 @@ function AuthConnectContent() {
 						<div className="flex flex-col gap-2 w-full">
 							<button
 								type="button"
-								onClick={() => window.location.reload()}
+								onClick={() => void handleConnect()}
 								className={cn(
 									"w-full flex items-center justify-center gap-2 rounded-full h-10 px-4",
 									"bg-[#0D121A] border border-[#1E293B] text-[#FAFAFA]",

--- a/apps/web/app/auth/connect/page.tsx
+++ b/apps/web/app/auth/connect/page.tsx
@@ -2,9 +2,12 @@
 
 import { useAuth } from "@lib/auth-context"
 import { useSession } from "@lib/auth"
+import { hasActivePlan } from "@lib/queries"
 import { cn } from "@lib/utils"
 import { dmSans125ClassName } from "@/lib/fonts"
-import { ArrowRight, XCircle } from "lucide-react"
+import { isFreeTierPlugin } from "@/lib/plugin-catalog"
+import { useCustomer } from "autumn-js/react"
+import { ArrowRight, Loader, XCircle } from "lucide-react"
 import Image from "next/image"
 import { useRouter, useSearchParams } from "next/navigation"
 import { Suspense, useEffect, useState } from "react"
@@ -106,7 +109,67 @@ function getPluginName(client: string): string {
 	return PLUGIN_INFO[client]?.name ?? "External Tool"
 }
 
-type Status = "loading" | "creating" | "success" | "error"
+function formatPluginNames(clients: string[]): string {
+	const names = clients.map((id) => getPluginName(id))
+	if (names.length === 0) return "External Tool"
+	if (names.length === 1) return names[0] ?? "External Tool"
+	if (names.length === 2) {
+		return `${names[0] ?? "External Tool"} and ${names[1] ?? "External Tool"}`
+	}
+
+	return `${names.slice(0, -1).join(", ")}, and ${names.at(-1) ?? "External Tool"}`
+}
+
+function encodeBase64UrlJson(value: Record<string, string>): string {
+	return btoa(JSON.stringify(value))
+		.replace(/\+/g, "-")
+		.replace(/\//g, "_")
+		.replace(/=+$/g, "")
+}
+
+function pluginAccessError(client: string): string {
+	return `${getPluginName(client)} requires a Pro plan or higher.`
+}
+
+function PluginLogoStack({ clients }: { clients: string[] }) {
+	if (clients.length === 0) {
+		return (
+			<div className="flex size-10 items-center justify-center rounded-lg border border-[#1E293B] bg-[#080B0F]">
+				<ArrowRight className="size-5 text-[#4BA0FA]" />
+			</div>
+		)
+	}
+
+	return (
+		<div className="flex items-center justify-center">
+			{clients.map((id, index) => {
+				const plugin = PLUGIN_INFO[id]
+				return (
+					<div
+						className="-ml-2 flex size-10 items-center justify-center rounded-lg border border-[#1E293B] bg-[#080B0F] p-2 first:ml-0"
+						key={`${id}-${index}`}
+						style={{ zIndex: clients.length - index }}
+						title={plugin?.name ?? id}
+					>
+						{plugin ? (
+							<Image
+								alt={plugin.name}
+								className="size-6 object-contain"
+								height={24}
+								src={plugin.icon}
+								width={24}
+							/>
+						) : (
+							<ArrowRight className="size-5 text-[#4BA0FA]" />
+						)}
+					</div>
+				)
+			})}
+		</div>
+	)
+}
+
+type Status = "loading" | "creating" | "success" | "error" | "upgrade"
 
 const pageWrapperClass =
 	"flex items-center justify-center min-h-screen bg-background p-4"
@@ -120,14 +183,37 @@ function AuthConnectContent() {
 	const router = useRouter()
 	const { data: session, isPending } = useSession()
 	const { org, organizations, isRestoring } = useAuth()
+	const autumn = useCustomer()
 	const [status, setStatus] = useState<Status>("loading")
 	const [error, setError] = useState<string | null>(null)
+	const [isUpgrading, setIsUpgrading] = useState(false)
 
 	const callback = params.get("callback")
 	const client = params.get("client")
+	const clients = (params.get("clients") ?? "")
+		.split(",")
+		.map((value) => value.trim())
+		.filter((value) => value in PLUGIN_INFO)
+	const requestedClients = clients.length > 0 ? clients : client ? [client] : []
+	const hasClientList = params.has("clients")
 	const validClient = client && client in PLUGIN_INFO ? client : null
-	const displayName = validClient ? getPluginName(validClient) : "External Tool"
-	const pluginInfo = validClient ? PLUGIN_INFO[validClient] : null
+	const displayName = formatPluginNames(requestedClients)
+	const pluginInfo =
+		requestedClients.length === 1
+			? PLUGIN_INFO[requestedClients[0] ?? ""]
+			: null
+	const hasProProduct = hasActivePlan(autumn.data?.subscriptions, "api_pro")
+	const eligibleClients = requestedClients.filter(
+		(requestedClient) => hasProProduct || isFreeTierPlugin(requestedClient),
+	)
+	const blockedClients = requestedClients.filter(
+		(requestedClient) => !eligibleClients.includes(requestedClient),
+	)
+	const needsPlanStatus = requestedClients.some(
+		(requestedClient) => !isFreeTierPlugin(requestedClient),
+	)
+	const eligibleDisplayName = formatPluginNames(eligibleClients)
+	const blockedDisplayName = formatPluginNames(blockedClients)
 
 	// Redirect new users (logged in but no organization) to onboarding.
 	// Store the current connect URL so onboarding can redirect back here.
@@ -173,14 +259,35 @@ function AuthConnectContent() {
 
 		try {
 			setStatus("creating")
+			if (eligibleClients.length === 0) {
+				const redirectUrl = new URL(callback)
+				redirectUrl.searchParams.set(
+					"errors",
+					encodeBase64UrlJson(
+						Object.fromEntries(
+							blockedClients.map((blockedClient) => [
+								blockedClient,
+								pluginAccessError(blockedClient),
+							]),
+						),
+					),
+				)
+				window.location.href = redirectUrl.toString()
+				return
+			}
+
 			const fetchParams = new URLSearchParams({ callback })
-			if (validClient) fetchParams.set("client", validClient)
+			fetchParams.set("client", eligibleClients[0] ?? validClient ?? "")
 
 			const res = await fetch(`${API_URL}/v3/auth/key?${fetchParams}`, {
 				credentials: "include",
 			})
 
 			if (!res.ok) {
+				if (res.status === 403) {
+					setStatus("upgrade")
+					return
+				}
 				const errorData = (await res.json().catch(() => ({}))) as {
 					message?: string
 				}
@@ -191,7 +298,34 @@ function AuthConnectContent() {
 			setStatus("success")
 
 			const redirectUrl = new URL(callback)
-			redirectUrl.searchParams.set("apikey", data.key)
+			if (hasClientList) {
+				redirectUrl.searchParams.set(
+					"keys",
+					encodeBase64UrlJson(
+						Object.fromEntries(
+							eligibleClients.map((eligibleClient) => [
+								eligibleClient,
+								data.key,
+							]),
+						),
+					),
+				)
+				if (blockedClients.length > 0) {
+					redirectUrl.searchParams.set(
+						"errors",
+						encodeBase64UrlJson(
+							Object.fromEntries(
+								blockedClients.map((blockedClient) => [
+									blockedClient,
+									pluginAccessError(blockedClient),
+								]),
+							),
+						),
+					)
+				}
+			} else {
+				redirectUrl.searchParams.set("apikey", data.key)
+			}
 			redirectUrl.searchParams.set("api_url", API_URL)
 			window.location.href = redirectUrl.toString()
 		} catch (err) {
@@ -201,9 +335,27 @@ function AuthConnectContent() {
 		}
 	}
 
+	async function handleUpgrade() {
+		try {
+			setIsUpgrading(true)
+			const safeSuccessUrl = `${window.location.origin}${window.location.pathname}${window.location.search}`
+			await autumn.attach({
+				planId: "api_pro",
+				successUrl: safeSuccessUrl,
+			})
+		} catch (err) {
+			console.error("Upgrade failed:", err)
+			setIsUpgrading(false)
+		}
+	}
+
 	// Show a spinner while session/org data is loading or while we're about
 	// to redirect to onboarding (prevents a brief flash of the connect card).
-	const isAuthLoading = isPending || isRestoring || organizations === null
+	const isAuthLoading =
+		isPending ||
+		isRestoring ||
+		organizations === null ||
+		(needsPlanStatus && autumn.isLoading)
 	if (isAuthLoading || shouldRedirectToOnboarding) {
 		return (
 			<div className="flex items-center justify-center min-h-screen bg-background">
@@ -217,19 +369,7 @@ function AuthConnectContent() {
 			<div className={pageWrapperClass}>
 				<div className={cardClass}>
 					<div className="flex flex-col items-center gap-5">
-						<div className="flex size-10 items-center justify-center rounded-lg border border-[#1E293B] bg-[#080B0F]">
-							{pluginInfo ? (
-								<Image
-									alt={pluginInfo.name}
-									className="size-6"
-									height={24}
-									src={pluginInfo.icon}
-									width={24}
-								/>
-							) : (
-								<ArrowRight className="size-5 text-[#4BA0FA]" />
-							)}
-						</div>
+						<PluginLogoStack clients={requestedClients} />
 						<div className="text-center">
 							<h2
 								className={dmSans125ClassName(
@@ -244,11 +384,21 @@ function AuthConnectContent() {
 								)}
 							>
 								{pluginInfo?.description ??
-									`Allow ${displayName} to access your Supermemory account.`}
+									`Approve one Supermemory OAuth flow for ${displayName}.`}
 							</p>
 						</div>
 
-						{pluginInfo && (
+						{blockedClients.length > 0 && (
+							<div className="w-full rounded-[10px] border border-[#1E293B] bg-[#080B0F] p-3">
+								<p className={dmSans125ClassName("text-[13px] text-[#8B8B8B]")}>
+									{eligibleClients.length > 0
+										? `OAuth will connect ${eligibleDisplayName}. Upgrade to Pro to connect ${blockedDisplayName}.`
+										: `Upgrade to Pro to connect ${blockedDisplayName}.`}
+								</p>
+							</div>
+						)}
+
+						{pluginInfo ? (
 							<ul className="w-full space-y-2.5">
 								{pluginInfo.features.map((feature) => (
 									<li key={feature} className="flex items-start gap-2.5">
@@ -262,6 +412,36 @@ function AuthConnectContent() {
 										</span>
 									</li>
 								))}
+							</ul>
+						) : (
+							<ul className="w-full space-y-2.5">
+								<li className="flex items-start gap-2.5">
+									<ArrowRight className="mt-0.5 size-3.5 shrink-0 text-[#4BA0FA]" />
+									<span
+										className={dmSans125ClassName("text-[13px] text-[#8B8B8B]")}
+									>
+										Share one persistent memory layer across selected coding
+										agents.
+									</span>
+								</li>
+								<li className="flex items-start gap-2.5">
+									<ArrowRight className="mt-0.5 size-3.5 shrink-0 text-[#4BA0FA]" />
+									<span
+										className={dmSans125ClassName("text-[13px] text-[#8B8B8B]")}
+									>
+										Recall project context, coding decisions, and prior
+										sessions.
+									</span>
+								</li>
+								<li className="flex items-start gap-2.5">
+									<ArrowRight className="mt-0.5 size-3.5 shrink-0 text-[#4BA0FA]" />
+									<span
+										className={dmSans125ClassName("text-[13px] text-[#8B8B8B]")}
+									>
+										Keep each connected plugin ready without separate auth
+										steps.
+									</span>
+								</li>
 							</ul>
 						)}
 
@@ -285,6 +465,103 @@ function AuthConnectContent() {
 							Approve Connection
 							<div className="absolute inset-0 pointer-events-none rounded-[inherit] shadow-[inset_1px_1px_2px_1px_#1A88FF]" />
 						</button>
+					</div>
+				</div>
+			</div>
+		)
+	}
+
+	if (status === "upgrade") {
+		return (
+			<div className={pageWrapperClass}>
+				<div className={cardClass}>
+					<div className="flex flex-col items-center gap-5">
+						<div className="flex size-10 items-center justify-center rounded-lg border border-[#1E293B] bg-[#080B0F]">
+							{pluginInfo ? (
+								<Image
+									alt={pluginInfo.name}
+									className="size-6"
+									height={24}
+									src={pluginInfo.icon}
+									width={24}
+								/>
+							) : (
+								<ArrowRight className="size-5 text-[#4BA0FA]" />
+							)}
+						</div>
+						<div className="text-center">
+							<h2
+								className={dmSans125ClassName(
+									"font-semibold text-[18px] text-[#FAFAFA]",
+								)}
+							>
+								{pluginInfo?.name ?? displayName}
+							</h2>
+							<p
+								className={dmSans125ClassName(
+									"text-[13px] text-[#737373] mt-1",
+								)}
+							>
+								{pluginInfo?.description ??
+									`A paid plan is required to use ${displayName} with Supermemory.`}
+							</p>
+						</div>
+
+						{pluginInfo && (
+							<ul className="w-full space-y-2.5">
+								{pluginInfo.features.map((feature) => (
+									<li key={feature} className="flex items-start gap-2.5">
+										<ArrowRight className="mt-0.5 size-3.5 shrink-0 text-[#4BA0FA]" />
+										<span
+											className={dmSans125ClassName(
+												"text-[13px] text-[#8B8B8B]",
+											)}
+										>
+											{feature}
+										</span>
+									</li>
+								))}
+							</ul>
+						)}
+
+						<button
+							type="button"
+							onClick={handleUpgrade}
+							disabled={isUpgrading || autumn.isLoading}
+							className={cn(
+								"relative w-full h-11 rounded-[10px] flex items-center justify-center",
+								"text-[#FAFAFA] font-medium text-[14px] tracking-[-0.14px]",
+								"shadow-[0px_2px_10px_rgba(5,1,0,0.2)]",
+								"disabled:opacity-60 disabled:cursor-not-allowed",
+								"cursor-pointer transition-opacity hover:opacity-90",
+								dmSans125ClassName(),
+							)}
+							style={{
+								background:
+									"linear-gradient(182.37deg, #0ff0d2 -91.53%, #5bd3fb -67.8%, #1e0ff0 95.17%)",
+								boxShadow:
+									"1px 1px 2px 0px #1A88FF inset, 0 2px 10px 0 rgba(5, 1, 0, 0.20)",
+							}}
+						>
+							{isUpgrading || autumn.isLoading ? (
+								<>
+									<Loader className="size-4 animate-spin mr-2" />
+									Upgrading…
+								</>
+							) : (
+								"Upgrade to Pro \u2014 $19/month"
+							)}
+							<div className="absolute inset-0 pointer-events-none rounded-[inherit] shadow-[inset_1px_1px_2px_1px_#1A88FF]" />
+						</button>
+
+						<a
+							href="https://app.supermemory.ai/settings#billing"
+							className={dmSans125ClassName(
+								"text-[12px] text-[#737373] hover:text-[#FAFAFA] transition-colors",
+							)}
+						>
+							View all plans
+						</a>
 					</div>
 				</div>
 			</div>


### PR DESCRIPTION

<img width="1280" height="614" alt="image" src="https://github.com/user-attachments/assets/666bb853-8d4c-4bdc-a353-c5e97a2f2722" />



## Summary
- Adds multi-client handling to the `/auth/connect` UI for plugin OAuth requests with `clients=...`.
- Shows stacked plugin logos and shared benefit copy for multi-plugin approvals.
- Gates non-free plugins by plan while preserving one shared API key flow for eligible clients.
- Returns `keys` for eligible clients and `errors` for plan-gated clients to the CLI callback.