### PR TITLE
fix(cartesia-sdk): treat empty profile as no memories, not a retrieval error

### DIFF
--- a/packages/cartesia-sdk-python/src/supermemory_cartesia/agent.py
+++ b/packages/cartesia-sdk-python/src/supermemory_cartesia/agent.py
@@ -166,20 +166,26 @@ class SupermemoryCartesiaAgent:
                 timeout=10.0
             )
 
-            static_count = len(response.profile.static) if response.profile.static else 0
-            dynamic_count = len(response.profile.dynamic) if response.profile.dynamic else 0
-            search_count = len(response.search_results.results) if response.search_results and response.search_results.results else 0
-
-            logger.info(f"[Supermemory] Retrieved memories - static: {static_count}, dynamic: {dynamic_count}, search: {search_count}")
+            # A user with no stored memories yet gets a null profile back, which
+            # is a normal case, not an error. Guard against it so we return an
+            # empty profile instead of raising AttributeError on response.profile.
+            profile = getattr(response, "profile", None)
+            profile_static = profile.static if profile is not None and profile.static else []
+            profile_dynamic = profile.dynamic if profile is not None and profile.dynamic else []
 
             search_results = []
             if response.search_results and response.search_results.results:
                 search_results = response.search_results.results
 
+            logger.info(
+                f"[Supermemory] Retrieved memories - static: {len(profile_static)}, "
+                f"dynamic: {len(profile_dynamic)}, search: {len(search_results)}"
+            )
+
             return {
                 "profile": {
-                    "static": response.profile.static or [],
-                    "dynamic": response.profile.dynamic or [],
+                    "static": profile_static,
+                    "dynamic": profile_dynamic,
                 },
                 "search_results": search_results,
             }

--- a/packages/cartesia-sdk-python/tests/test_empty_profile.py
+++ b/packages/cartesia-sdk-python/tests/test_empty_profile.py
@@ -1,0 +1,77 @@
+from __future__ import annotations
+
+import sys
+import types
+import unittest
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+
+def _install_test_stubs() -> None:
+    if "loguru" not in sys.modules:
+        loguru_module = types.ModuleType("loguru")
+
+        class _Logger:
+            def info(self, *_args, **_kwargs):
+                return None
+
+            def warning(self, *_args, **_kwargs):
+                return None
+
+            def error(self, *_args, **_kwargs):
+                return None
+
+        loguru_module.logger = _Logger()
+        sys.modules["loguru"] = loguru_module
+
+    if "pydantic" not in sys.modules:
+        pydantic_module = types.ModuleType("pydantic")
+
+        class BaseModel:
+            def __init__(self, **kwargs):
+                for key, value in kwargs.items():
+                    setattr(self, key, value)
+
+        def Field(*, default=None, **_kwargs):
+            return default
+
+        pydantic_module.BaseModel = BaseModel
+        pydantic_module.Field = Field
+        sys.modules["pydantic"] = pydantic_module
+
+
+_install_test_stubs()
+
+from supermemory_cartesia.agent import SupermemoryCartesiaAgent
+
+
+class _MockSupermemoryClient:
+    def __init__(self, response):
+        self.profile = AsyncMock(return_value=response)
+
+
+class TestSupermemoryCartesiaNullProfile(unittest.IsolatedAsyncioTestCase):
+    async def test_retrieve_memories_handles_null_profile(self) -> None:
+        agent = SupermemoryCartesiaAgent(
+            agent=SimpleNamespace(),
+            api_key="mock_key",
+            container_tag="user-123",
+            custom_id="conversation-456",
+        )
+
+        response = SimpleNamespace(profile=None, search_results=None)
+        agent._supermemory_client = _MockSupermemoryClient(response)
+
+        result = await agent._retrieve_memories("Hello world")
+
+        self.assertEqual(
+            result,
+            {
+                "profile": {"static": [], "dynamic": []},
+                "search_results": [],
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
A user with no stored memories gets profile=None from the API. _retrieve_memories
reads response.profile.static/.dynamic without a None check, so it raises
AttributeError for those users. The surrounding try/except turns that into
MemoryRetrievalError, which the caller logs as "Memory retrieval failed" and then
skips memory injection.

So every new or empty-profile user triggers a false error log each turn, and the
empty case is treated as a failure instead of "no memories yet". It also makes
real retrieval failures (timeouts, API errors) indistinguishable from the normal
empty case in logs.

The pipecat SDK already handles this after #1027/#1033 by treating a None profile
as empty memories. The cartesia SDK has the same unguarded access and was missed.

Changes:
- return empty static/dynamic when profile is None instead of dereferencing it
- search results handling and logging unchanged
- add a regression test for the None-profile response, modeled on pipecat's
  test_empty_profile.py

Tested:
PYTHONPATH=src python -m unittest tests.test_empty_profile
(passes; fails on the original code with 'NoneType' object has no attribute 'static')