### PR TITLE
fix(chat): show memory source fallbacks

### DIFF
--- a/apps/web/components/chat/message/agent-message.tsx
+++ b/apps/web/components/chat/message/agent-message.tsx
@@ -32,7 +32,9 @@ import {
 	extractMemoryToolOutputs,
 } from "@/lib/chat-memory-tools"
 import {
+	hasRenderableSourceAnnotations,
 	parseSourceAnnotatedMarkdown,
+	sourceAnnotatedTextRun,
 	stripSourceMarkup,
 } from "@/lib/source-annotations"
 import { modelNames, type ModelId } from "@/lib/models"
@@ -778,12 +780,8 @@ export function AgentMessage({
 		[webSources, citationIndex, documentByKnownId],
 	)
 	const hasInlineSourceAnnotations = useMemo(
-		() =>
-			parseSourceAnnotatedMarkdown(
-				messageText,
-				allowedSourceIds,
-			).markdown.includes("#sm-source:"),
-		[messageText, allowedSourceIds],
+		() => hasRenderableSourceAnnotations(message.parts, allowedSourceIds),
+		[message.parts, allowedSourceIds],
 	)
 	const showMemorySourcesFallback =
 		citationIndex.size > 0 && !hasInlineSourceAnnotations
@@ -831,22 +829,10 @@ export function AgentMessage({
 							)
 						}
 						if (part.type === "text") {
-							// Skip fragments mid-run — source-url citations split one answer into
-							// many text parts; rendering each separately tears markdown (lists etc.).
-							let prev = partIndex - 1
-							while (prev >= 0 && message.parts[prev]?.type === "source-url") {
-								prev--
-							}
-							if (prev >= 0 && message.parts[prev]?.type === "text") {
-								return null
-							}
-							let runText = ""
-							for (let j = partIndex; j < message.parts.length; j++) {
-								const p = message.parts[j]
-								if (p?.type === "text") runText += p.text
-								else if (p?.type === "source-url") continue
-								else break
-							}
+							// source-url citations split one answer into many text parts;
+							// render each contiguous text/source-url run as one markdown block.
+							const runText = sourceAnnotatedTextRun(message.parts, partIndex)
+							if (runText === null) return null
 							return (
 								<div
 									key={`${message.id}-${partIndex}`}

--- a/apps/web/components/chat/message/agent-message.tsx
+++ b/apps/web/components/chat/message/agent-message.tsx
@@ -23,6 +23,7 @@ import { isWebSearchToolName } from "@/lib/chat-web-search-tools"
 import {
 	buildCitationIndex,
 	fetchDocumentsByIds,
+	getCitationDisplay,
 	getDocumentSourceUrl,
 	isMemoryToolOutputReady,
 	mapDocumentsByKnownIds,
@@ -190,37 +191,64 @@ function CitationLink({
 	)
 }
 
-function sourceTitle(
+function documentForCitationTarget(
 	target: CitationTarget,
-	document?: DocumentWithMemories,
-): string {
+	documentByKnownId: Map<string, DocumentWithMemories>,
+): DocumentWithMemories | undefined {
 	return (
-		document?.title?.trim() ||
-		target.title?.trim() ||
-		document?.customId ||
-		target.customId ||
-		target.documentId ||
-		target.sourceId
+		(target.documentId
+			? documentByKnownId.get(target.documentId)
+			: undefined) ??
+		(target.customId ? documentByKnownId.get(target.customId) : undefined)
 	)
 }
 
-function sourceSummary(
-	target: CitationTarget,
-	document?: DocumentWithMemories,
-): string | null {
-	const summary =
-		document?.summary ||
-		target.summary ||
-		(document as { content?: string } | undefined)?.content ||
-		null
-	return summary ? summary.trim() : null
-}
+function MemorySourcesFallback({
+	citationIndex,
+	documentByKnownId,
+}: {
+	citationIndex: Map<string, CitationTarget>
+	documentByKnownId: Map<string, DocumentWithMemories>
+}) {
+	const sources = Array.from(citationIndex.values()).slice(0, 6)
+	if (sources.length === 0) return null
 
-function sourceKind(
-	target: CitationTarget,
-	document?: DocumentWithMemories,
-): string {
-	return (document?.type || target.type || "memory").replaceAll("_", " ")
+	return (
+		<div className="mt-3 flex flex-wrap gap-1.5 text-xs text-white/45">
+			<span className="mr-0.5 self-center text-white/35">Sources</span>
+			{sources.map((target) => {
+				const document = documentForCitationTarget(target, documentByKnownId)
+				const display = getCitationDisplay(target, document)
+				const url = safeExternalUrl(
+					document ? getDocumentSourceUrl(document) : target.url,
+				)
+				const label = `${target.sourceId}: ${display.title}`
+				const className =
+					"max-w-56 truncate rounded-full border border-white/10 bg-white/[0.035] px-2 py-1 text-white/55 transition-colors hover:bg-white/[0.06] hover:text-white/75"
+
+				return url ? (
+					<a
+						key={target.sourceId}
+						href={url}
+						target="_blank"
+						rel="noopener noreferrer"
+						className={className}
+						title={display.summary ?? label}
+					>
+						{label}
+					</a>
+				) : (
+					<span
+						key={target.sourceId}
+						className={className}
+						title={display.summary ?? label}
+					>
+						{label}
+					</span>
+				)
+			})}
+		</div>
+	)
 }
 
 function SourceCitationLink({
@@ -237,16 +265,11 @@ function SourceCitationLink({
 	const target = citationIndex.get(sourceId)
 	if (!target) return <>{children}</>
 
-	const document =
-		(target.documentId
-			? documentByKnownId.get(target.documentId)
-			: undefined) ??
-		(target.customId ? documentByKnownId.get(target.customId) : undefined)
+	const document = documentForCitationTarget(target, documentByKnownId)
 	const url = safeExternalUrl(
 		document ? getDocumentSourceUrl(document) : target.url,
 	)
-	const title = sourceTitle(target, document)
-	const summary = sourceSummary(target, document)
+	const display = getCitationDisplay(target, document)
 
 	return (
 		<span className="group/source relative inline rounded-[3px] border-b border-dotted border-white/20 bg-white/[0.025] px-px text-white/90 transition-colors hover:border-white/35 hover:bg-white/[0.045] focus-within:border-white/35 focus-within:bg-white/[0.045]">
@@ -274,15 +297,15 @@ function SourceCitationLink({
 				<span className="pointer-events-auto block rounded-xl border border-white/10 bg-[#0B0F16]/95 p-3 text-left shadow-[0_16px_44px_rgba(0,0,0,0.48)] backdrop-blur-xl">
 					<span className="mb-1 flex items-center justify-between gap-2">
 						<span className="truncate text-xs font-medium text-white/85">
-							{title}
+							{display.title}
 						</span>
 						<span className="shrink-0 rounded-full bg-white/5 px-2 py-0.5 text-[10px] capitalize text-white/40">
-							{sourceKind(target, document)}
+							{display.kind}
 						</span>
 					</span>
-					{summary ? (
+					{display.summary ? (
 						<span className="line-clamp-3 text-xs leading-snug text-white/55">
-							{summary}
+							{display.summary}
 						</span>
 					) : null}
 					{url ? (
@@ -754,6 +777,16 @@ export function AgentMessage({
 		() => makeMarkdownComponents(webSources, citationIndex, documentByKnownId),
 		[webSources, citationIndex, documentByKnownId],
 	)
+	const hasInlineSourceAnnotations = useMemo(
+		() =>
+			parseSourceAnnotatedMarkdown(
+				messageText,
+				allowedSourceIds,
+			).markdown.includes("#sm-source:"),
+		[messageText, allowedSourceIds],
+	)
+	const showMemorySourcesFallback =
+		citationIndex.size > 0 && !hasInlineSourceAnnotations
 	const responseModelLabel = responseModel
 		? `${modelNames[responseModel].name} ${modelNames[responseModel].version}`
 		: null
@@ -865,6 +898,12 @@ export function AgentMessage({
 						}
 						return null
 					})}
+					{showMemorySourcesFallback && (
+						<MemorySourcesFallback
+							citationIndex={citationIndex}
+							documentByKnownId={documentByKnownId}
+						/>
+					)}
 				</div>
 			</div>
 			{hasAssistantText && (

--- a/apps/web/lib/chat-memory-tools.test.ts
+++ b/apps/web/lib/chat-memory-tools.test.ts
@@ -4,6 +4,7 @@ import {
 	buildCitationIndex,
 	extractDocumentIdsFromMemoryOutput,
 	extractMemoryToolOutputs,
+	getCitationDisplay,
 	getDocumentSourceUrl,
 	mapDocumentsByKnownIds,
 } from "./chat-memory-tools"
@@ -76,7 +77,99 @@ describe("chat memory tool citation mapping", () => {
 
 		expect(index.get("S1")?.documentId).toBe("docA")
 		expect(index.get("S1")?.customId).toBe("customA")
+		expect(index.get("S1")?.content).toBe("memo")
 		expect(index.has("ignored")).toBe(false)
+	})
+
+	it("maps source ids to matching result ids when citation ids are absent", () => {
+		const outputs = extractMemoryToolOutputs({
+			parts: [
+				{
+					type: "tool-searchMemories",
+					state: "output-available",
+					output: {
+						sourceIds: ["memory_no_citation"],
+						results: [
+							{
+								id: "memory_no_citation",
+								kind: "memory",
+								content: "Fallback source text.",
+							},
+						],
+					},
+				},
+			],
+		})
+
+		expect(buildCitationIndex(outputs).get("memory_no_citation")).toMatchObject(
+			{
+				sourceId: "memory_no_citation",
+				memoryId: "memory_no_citation",
+				content: "Fallback source text.",
+			},
+		)
+	})
+
+	it("keeps memory text for citations without source documents", () => {
+		const outputs = extractMemoryToolOutputs({
+			parts: [
+				{
+					type: "tool-recallContext",
+					state: "output-available",
+					output: {
+						sourceIds: ["memory_1"],
+						results: [
+							{
+								id: "memory_1",
+								citationId: "memory_1",
+								kind: "memory",
+								content: "User prefers concise answers.",
+							},
+						],
+					},
+				},
+			],
+		})
+
+		expect(buildCitationIndex(outputs).get("memory_1")).toMatchObject({
+			sourceId: "memory_1",
+			memoryId: "memory_1",
+			kind: "memory",
+			content: "User prefers concise answers.",
+		})
+	})
+
+	it("uses memory display only for citations without document metadata", () => {
+		expect(
+			getCitationDisplay({
+				sourceId: "memory_1",
+				memoryId: "memory_1",
+				kind: "memory",
+				content: "User prefers concise answers.",
+			}),
+		).toEqual({
+			title: "Memory",
+			kind: "memory",
+			summary: "User prefers concise answers.",
+		})
+	})
+
+	it("prefers tool-provided document metadata over generic memory display", () => {
+		expect(
+			getCitationDisplay({
+				sourceId: "S1",
+				memoryId: "memory_1",
+				content: "Memory text",
+				documentId: "doc_1",
+				customId: "custom_1",
+				title: "Project Plan",
+				type: "google_doc",
+			}),
+		).toMatchObject({
+			title: "Project Plan",
+			kind: "google doc",
+			summary: "Memory text",
+		})
 	})
 
 	it("extracts graph highlight document ids from memory outputs", () => {

--- a/apps/web/lib/chat-memory-tools.ts
+++ b/apps/web/lib/chat-memory-tools.ts
@@ -55,12 +55,21 @@ export type MemoryToolOutput = {
 }
 export type CitationTarget = {
 	sourceId: string
+	memoryId?: string | undefined
+	kind?: string | undefined
+	content?: string | undefined
 	documentId?: string | undefined
 	customId?: string | null | undefined
 	title?: string | null | undefined
 	type?: string | null | undefined
 	summary?: string | null | undefined
 	url?: string | null | undefined
+}
+
+export type CitationDisplay = {
+	title: string
+	summary: string | null
+	kind: string
 }
 
 export type DocumentWithMemories = z.infer<
@@ -156,10 +165,15 @@ function citationTargetForResult(
 		doc?.id ??
 		result.documentIds?.find(Boolean) ??
 		result.documentId
-	const target = documentTarget(sourceId, doc)
-	target.documentId = target.documentId ?? docId
-	target.customId = target.customId ?? result.customId
-	return target
+	const docTarget = documentTarget(sourceId, doc)
+	return {
+		...docTarget,
+		memoryId: result.id,
+		kind: result.kind,
+		content: result.content,
+		documentId: docTarget.documentId ?? docId,
+		customId: docTarget.customId ?? result.customId,
+	}
 }
 
 function documentTarget(
@@ -247,7 +261,7 @@ export function buildCitationIndex(
 		for (const sourceId of output.sourceIds ?? []) {
 			if (index.has(sourceId)) continue
 			const matchingResult = (output.results ?? []).find(
-				(result) => result.citationId === sourceId,
+				(result) => result.citationId === sourceId || result.id === sourceId,
 			)
 			if (matchingResult)
 				addTarget(
@@ -342,6 +356,46 @@ export function mapDocumentsByKnownIds(
 		if (doc.customId) map.set(doc.customId, doc)
 	}
 	return map
+}
+
+function hasDisplayMetadata(target: CitationTarget): boolean {
+	return !!(
+		target.title?.trim() ||
+		target.documentId ||
+		target.customId ||
+		target.url ||
+		target.type ||
+		target.summary?.trim()
+	)
+}
+
+export function getCitationDisplay(
+	target: CitationTarget,
+	document?: DocumentWithMemories,
+): CitationDisplay {
+	const memoryOnly = !document && !hasDisplayMetadata(target)
+	const summary =
+		document?.summary ||
+		target.summary ||
+		target.content ||
+		(document as { content?: string } | undefined)?.content ||
+		null
+
+	return {
+		title: memoryOnly
+			? "Memory"
+			: document?.title?.trim() ||
+				target.title?.trim() ||
+				document?.customId ||
+				target.customId ||
+				target.documentId ||
+				target.sourceId,
+		summary: summary ? summary.trim() : null,
+		kind: (document?.type || target.type || target.kind || "memory").replaceAll(
+			"_",
+			" ",
+		),
+	}
 }
 
 export function getDocumentSourceUrl(

--- a/apps/web/lib/source-annotations.test.ts
+++ b/apps/web/lib/source-annotations.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "bun:test"
 import {
+	hasRenderableSourceAnnotations,
 	isSafeSourceId,
 	parseSourceAnnotatedMarkdown,
+	sourceAnnotatedTextRun,
 	stripSourceMarkup,
 } from "./source-annotations"
 
@@ -76,6 +78,31 @@ describe("source annotation parsing", () => {
 		expect(parseSourceAnnotatedMarkdown(input, new Set(["S1"])).markdown).toBe(
 			input,
 		)
+	})
+
+	it("checks inline annotations against rendered text runs", () => {
+		const allowedSourceIds = new Set(["S1"])
+		expect(
+			hasRenderableSourceAnnotations(
+				[
+					{ type: "text", text: 'Lead <response source="S1">supported' },
+					{ type: "tool-recallContext" },
+					{ type: "text", text: " claim</response>" },
+				],
+				allowedSourceIds,
+			),
+		).toBe(false)
+
+		const parts = [
+			{ type: "text", text: 'Lead <response source="S1">supported' },
+			{ type: "source-url", sourceId: "web", url: "https://example.com" },
+			{ type: "text", text: " claim</response>" },
+		]
+		expect(sourceAnnotatedTextRun(parts, 0)).toBe(
+			'Lead <response source="S1">supported claim</response>',
+		)
+		expect(sourceAnnotatedTextRun(parts, 2)).toBeNull()
+		expect(hasRenderableSourceAnnotations(parts, allowedSourceIds)).toBe(true)
 	})
 
 	it("strips source markup for copy text", () => {

--- a/apps/web/lib/source-annotations.ts
+++ b/apps/web/lib/source-annotations.ts
@@ -169,6 +169,48 @@ export function parseSourceAnnotatedMarkdown(
 	return { markdown: output.join("") }
 }
 
+export type SourceAnnotationMessagePart = {
+	type: string
+	text?: string | undefined
+}
+
+export function sourceAnnotatedTextRun(
+	parts: readonly SourceAnnotationMessagePart[],
+	partIndex: number,
+): string | null {
+	const part = parts[partIndex]
+	if (part?.type !== "text") return null
+
+	let prev = partIndex - 1
+	while (prev >= 0 && parts[prev]?.type === "source-url") prev--
+	if (prev >= 0 && parts[prev]?.type === "text") return null
+
+	let runText = ""
+	for (let index = partIndex; index < parts.length; index++) {
+		const current = parts[index]
+		if (current?.type === "text") runText += current.text ?? ""
+		else if (current?.type === "source-url") continue
+		else break
+	}
+
+	return runText
+}
+
+export function hasRenderableSourceAnnotations(
+	parts: readonly SourceAnnotationMessagePart[],
+	allowedSourceIds: ReadonlySet<string>,
+): boolean {
+	return parts.some((part, index) => {
+		if (part.type !== "text") return false
+		const runText = sourceAnnotatedTextRun(parts, index)
+		if (!runText) return false
+		return parseSourceAnnotatedMarkdown(
+			runText,
+			allowedSourceIds,
+		).markdown.includes("#sm-source:")
+	})
+}
+
 export function stripSourceMarkup(text: string): string {
 	let output = ""
 	let i = 0


### PR DESCRIPTION
Chat answers now show deterministic memory/document source attribution when visible memory tool results exist, even if the model skips inline `<response source="...">` markup. Inline citations still render when present, and the fallback gate now checks the exact same contiguous rendered text/source-url runs as `AgentMessage`, so split markup across tool boundaries cannot accidentally suppress fallback sources.

## Changes

- Preserve memory-only citation metadata (`memoryId`, `kind`, `content`) from structured memory tool outputs.
- Resolve citation targets when `sourceIds` match `results[].id` even if `results[].citationId` is omitted.
- Add a shared citation display helper so memory-only citations render as `Memory`, while document-backed citations with metadata do not temporarily show the generic `Memory` label.
- Render subtle message-level `Sources` chips when memory tool outputs provide citation targets and the answer has no valid inline source annotations.
- Suppress fallback chips when valid inline citation markup renders, avoiding duplicate attribution.
- Centralize contiguous `text` / `source-url` run assembly in source annotation helpers and reuse it for both rendering and fallback suppression.
- Add a regression test for Cursor Bugbot’s split-across-tool-boundary case.

## Testing

- PASS: `cd /code/supermemoryai/supermemory && PATH="$HOME/.bun/bin:$PATH" bun test apps/web/lib/chat-memory-tools.test.ts apps/web/lib/source-annotations.test.ts`
  - 19/19 tests passed after the Bugbot follow-up.
- PASS: `cd /code/supermemoryai/supermemory && ./node_modules/.bin/biome ci apps/web/lib/chat-memory-tools.ts apps/web/lib/chat-memory-tools.test.ts apps/web/lib/source-annotations.ts apps/web/lib/source-annotations.test.ts apps/web/components/chat/message/agent-message.tsx`
- PASS: `cd /code/supermemoryai/supermemory && ./node_modules/.bin/biome ci apps/web/lib/chat-memory-tools.ts apps/web/lib/chat-memory-tools.test.ts apps/web/components/chat/message/agent-message.tsx`
- PASS: `cd /code/supermemoryai/supermemory && git diff --check`
- PASS: `cd /code/supermemoryai/supermemory && ./node_modules/.bin/biome ci --changed --since=origin/main`
- PASS with warning: `cd /code/supermemoryai/supermemory/apps/web && NODE_ENV=production PATH="$HOME/.bun/bin:$PATH" bun run build`
  - Production build passed. Next build reports “Skipping validation of types,” so this is build evidence, not type-check evidence.
- BLOCKED/PRE-EXISTING: `cd /code/supermemoryai/supermemory/apps/web && PATH="$HOME/.bun/bin:$PATH" bunx tsc --noEmit --project tsconfig.json`
  - Failed with existing app-wide errors outside changed files; no errors referenced `components/chat/message/agent-message.tsx`, `lib/chat-memory-tools.ts`, `lib/chat-memory-tools.test.ts`, or `lib/source-annotations.ts`.

Backend-shaped memory tool output was generated with the real backend mapper and rendered through the real frontend `AgentMessage` component:

Bugbot follow-up browser/UI verification used a local mock chat backend and the real Next.js app route:

Audit-only earlier UI attempts, not pass evidence:

Authenticated live chat E2E is still blocked because no saved browser session exists; the app and preview load to login instead:

## Caveats

- This does not implement the separate simple-button confirmation flow for `forgetMemory`; current strict typed confirmation is unchanged.

---
**Attached Images and Videos**

*[supermemory-bugbot-source-run-test.log]*

*[supermemory-memory-source-cards-bun-test.log]*

*[supermemory-chat-source-related-bun-tests-after-backend-mapped.log]*

*[supermemory-bugbot-source-run-biome.log]*

*[supermemory-memory-source-cards-biome.log]*

*[supermemory-explicit-files-biome-ci-after-backend-mapped.log]*

*[supermemory-bugbot-postcommit-biome-changed.log]*

*[supermemory-postcommit-biome-changed.log]*

*[supermemory-bugbot-source-run-build.log]*

*[supermemory-web-build-production.log]*

*[supermemory-web-tsc.log]*

*[supermemory-web-tsc-noemit.log]*

*[backend-mapped-memory-tool-output.json]*

![Image available at https://supermemory.us1.vorflux.com/agent-sessions/9f5b822f-2d8b-4aba-a375-c0f0fa54560a](https://api.us1.vorflux.com/assets/artifacts/c3VwZXJtZW1vcnk6ZjozNzAy.l4yu_-dbTrH7JM-X5SbKG9BGFMnCrzGYVQiHuN5Yld4.png)

![Image available at https://supermemory.us1.vorflux.com/agent-sessions/9f5b822f-2d8b-4aba-a375-c0f0fa54560a](https://api.us1.vorflux.com/assets/artifacts/c3VwZXJtZW1vcnk6ZjozNzAz.YphhpH0iC0DQw3MEhJ70rDphKa59Bt8ytQ5-5tH3oPI.png)

![Image available at https://supermemory.us1.vorflux.com/agent-sessions/9f5b822f-2d8b-4aba-a375-c0f0fa54560a](https://api.us1.vorflux.com/assets/artifacts/c3VwZXJtZW1vcnk6ZjozNzA0.F4xh9go5LfQ0xdcFDpqzUYv3DVtm40tTzB_jKqxY7rM.png)

🎥 [View recording: supermemory-chat-backend-mapped-source-flow.webm](https://api.us1.vorflux.com/assets/artifacts/c3VwZXJtZW1vcnk6ZjozNzA1.njT0p_5SbawRUII3d268zQIyDHKLmbdfzbiHJz5_bNM.webm)

*[agent-browser-backend-mapped-snapshot.log]*

![Image available at https://supermemory.us1.vorflux.com/agent-sessions/9f5b822f-2d8b-4aba-a375-c0f0fa54560a](https://api.us1.vorflux.com/assets/artifacts/c3VwZXJtZW1vcnk6ZjozNzA3.Lwv8c0kV3gHCf6bKbHrTxcLovNhmCBr89WuGF5yZ4Ho.png)

![Image available at https://supermemory.us1.vorflux.com/agent-sessions/9f5b822f-2d8b-4aba-a375-c0f0fa54560a](https://api.us1.vorflux.com/assets/artifacts/c3VwZXJtZW1vcnk6ZjozNzA4.UpEbuBa9ttDLsTmbcQHSAd9CIlvQrzCX-CjL2HSjZos.png)

![Image available at https://supermemory.us1.vorflux.com/agent-sessions/9f5b822f-2d8b-4aba-a375-c0f0fa54560a](https://api.us1.vorflux.com/assets/artifacts/c3VwZXJtZW1vcnk6ZjozNzA5.wtYWh8EooIUlSF6McZMfpq3yIpUCe4X7dNJT1jWtWYw.png)

🎥 [View recording: source-annotation-agent-message-local-backend.webm](https://api.us1.vorflux.com/assets/artifacts/c3VwZXJtZW1vcnk6ZjozNzEw.nevYeCquzo9OeO3fuuNr46-rw8HJjrlgaaKYqJi_LDw.webm)

![Image available at https://supermemory.us1.vorflux.com/agent-sessions/9f5b822f-2d8b-4aba-a375-c0f0fa54560a](https://api.us1.vorflux.com/assets/artifacts/c3VwZXJtZW1vcnk6ZjozNzEx.8c4FwIBUIgAoBHenntU-Aj1hoQ_qtbsNHHjZ_P4gaZU.png)

![Image available at https://supermemory.us1.vorflux.com/agent-sessions/9f5b822f-2d8b-4aba-a375-c0f0fa54560a](https://api.us1.vorflux.com/assets/artifacts/c3VwZXJtZW1vcnk6ZjozNzEy.2gZXj9_1rOCnPWE_bZf-W_JainWxsY9mwDxgTS1ZsIM.png)

🎥 [View recording: source-annotation-agent-message-history-load.webm](https://api.us1.vorflux.com/assets/artifacts/c3VwZXJtZW1vcnk6ZjozNzEz.AKEA_ivggNxsVX5X-tnfKIS1T55DM7_PZEHKhpV2w2I.webm)

![Image available at https://supermemory.us1.vorflux.com/agent-sessions/9f5b822f-2d8b-4aba-a375-c0f0fa54560a](https://api.us1.vorflux.com/assets/artifacts/c3VwZXJtZW1vcnk6ZjozNzE0.CsC6prO1ssUWS02RhAf33vlRIwIEBYeZMpzzj2_aHA0.png)

![Image available at https://supermemory.us1.vorflux.com/agent-sessions/9f5b822f-2d8b-4aba-a375-c0f0fa54560a](https://api.us1.vorflux.com/assets/artifacts/c3VwZXJtZW1vcnk6ZjozNzE1.3A5A2H0-b_zlBzM20M-SUHEsJkrm-p2616DqoWZjRec.png)

🎥 [View recording: supermemory-chat-auth-blocked.webm](https://api.us1.vorflux.com/assets/artifacts/c3VwZXJtZW1vcnk6ZjozNzE2.0Kng5-4vYGha0zXd0gzFA3UIR_elTU18k2f7XnKckcI.webm)

*Media may expire after 12 hours. [View in Vorflux Session](https://supermemory.us1.vorflux.com/agent-sessions/9f5b822f-2d8b-4aba-a375-c0f0fa54560a) for permanent access.*

---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/9f5b822f-2d8b-4aba-a375-c0f0fa54560a)
- Requested by: Dhravya Shah (dhravya@supermemory.com)
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
