### PR TITLE
Add fetch timeout and caching to supermemory-docs-mintlify proxy worker

### DIFF
--- a/apps/docs-proxy/package.json
+++ b/apps/docs-proxy/package.json
@@ -1,0 +1,15 @@
+{
+	"name": "@repo/docs-proxy",
+	"version": "1.0.0",
+	"private": true,
+	"type": "module",
+	"scripts": {
+		"dev": "wrangler dev",
+		"deploy": "wrangler deploy --minify"
+	},
+	"devDependencies": {
+		"@cloudflare/workers-types": "^4.20250620.0",
+		"typescript": "^5.8.3",
+		"wrangler": "^4.4.0"
+	}
+}

--- a/apps/docs-proxy/src/index.ts
+++ b/apps/docs-proxy/src/index.ts
@@ -1,33 +1,36 @@
-const UPSTREAM_BASE = "https://supermemory.mintlify.dev";
-const CACHE_TTL = 300; // 5 minutes
-const FETCH_TIMEOUT_MS = 10000; // 10 seconds
+const UPSTREAM_BASE = "https://supermemory.mintlify.dev"
+const CACHE_TTL = 300 // 5 minutes
+const FETCH_TIMEOUT_MS = 10000 // 10 seconds
 
 export default {
 	async fetch(request: Request): Promise<Response> {
-		const url = new URL(request.url);
-		const proxyUrl = UPSTREAM_BASE + url.pathname + url.search;
+		const url = new URL(request.url)
+		const proxyUrl = UPSTREAM_BASE + url.pathname + url.search
 
-		const cache = caches.default;
+		const cache = caches.default
 
 		if (request.method === "GET") {
-			const cached = await cache.match(request);
-			if (cached) return cached;
+			const cached = await cache.match(request)
+			if (cached) return cached
 		}
 
-		const controller = new AbortController();
-		const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+		const controller = new AbortController()
+		const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS)
 
 		try {
-			const proxyRequest = new Request(proxyUrl, request);
-			const response = await fetch(proxyRequest, { signal: controller.signal });
+			const proxyRequest = new Request(proxyUrl, request)
+			const response = await fetch(proxyRequest, { signal: controller.signal })
 
 			if (request.method === "GET" && response.ok) {
-				const cachedResponse = new Response(response.clone().body, response);
-				cachedResponse.headers.set("Cache-Control", `public, max-age=${CACHE_TTL}`);
-				await cache.put(request, cachedResponse);
+				const cachedResponse = new Response(response.clone().body, response)
+				cachedResponse.headers.set(
+					"Cache-Control",
+					`public, max-age=${CACHE_TTL}`,
+				)
+				await cache.put(request, cachedResponse)
 			}
 
-			return response;
+			return response
 		} catch (e) {
 			if (e instanceof Error && e.name === "AbortError") {
 				return new Response(
@@ -36,11 +39,11 @@ export default {
 						status: 504,
 						headers: { "Content-Type": "text/plain; charset=utf-8" },
 					},
-				);
+				)
 			}
-			throw e;
+			throw e
 		} finally {
-			clearTimeout(timeoutId);
+			clearTimeout(timeoutId)
 		}
 	},
-};
+}

--- a/apps/docs-proxy/src/index.ts
+++ b/apps/docs-proxy/src/index.ts
@@ -1,0 +1,46 @@
+const UPSTREAM_BASE = "https://supermemory.mintlify.dev";
+const CACHE_TTL = 300; // 5 minutes
+const FETCH_TIMEOUT_MS = 10000; // 10 seconds
+
+export default {
+	async fetch(request: Request): Promise<Response> {
+		const url = new URL(request.url);
+		const proxyUrl = UPSTREAM_BASE + url.pathname + url.search;
+
+		const cache = caches.default;
+
+		if (request.method === "GET") {
+			const cached = await cache.match(request);
+			if (cached) return cached;
+		}
+
+		const controller = new AbortController();
+		const timeoutId = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+		try {
+			const proxyRequest = new Request(proxyUrl, request);
+			const response = await fetch(proxyRequest, { signal: controller.signal });
+
+			if (request.method === "GET" && response.ok) {
+				const cachedResponse = new Response(response.clone().body, response);
+				cachedResponse.headers.set("Cache-Control", `public, max-age=${CACHE_TTL}`);
+				await cache.put(request, cachedResponse);
+			}
+
+			return response;
+		} catch (e) {
+			if (e instanceof Error && e.name === "AbortError") {
+				return new Response(
+					"Documentation temporarily unavailable. Please try again in a moment.",
+					{
+						status: 504,
+						headers: { "Content-Type": "text/plain; charset=utf-8" },
+					},
+				);
+			}
+			throw e;
+		} finally {
+			clearTimeout(timeoutId);
+		}
+	},
+};

--- a/apps/docs-proxy/tsconfig.json
+++ b/apps/docs-proxy/tsconfig.json
@@ -1,0 +1,15 @@
+{
+	"compilerOptions": {
+		"target": "ESNext",
+		"module": "ESNext",
+		"moduleResolution": "Bundler",
+		"strict": true,
+		"skipLibCheck": true,
+		"lib": ["ESNext"],
+		"types": ["@cloudflare/workers-types"],
+		"outDir": "dist",
+		"rootDir": "src"
+	},
+	"include": ["src/**/*"],
+	"exclude": ["node_modules"]
+}

--- a/apps/docs-proxy/wrangler.jsonc
+++ b/apps/docs-proxy/wrangler.jsonc
@@ -1,0 +1,11 @@
+{
+	"$schema": "node_modules/wrangler/config-schema.json",
+	"name": "supermemory-docs-mintlify",
+	"main": "src/index.ts",
+	"compatibility_date": "2025-06-20",
+	"compatibility_flags": [],
+
+	"observability": {
+		"enabled": true
+	}
+}

--- a/bun.lock
+++ b/bun.lock
@@ -83,6 +83,15 @@
         "typescript": "^5.9.2",
       },
     },
+    "apps/docs-proxy": {
+      "name": "@repo/docs-proxy",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@cloudflare/workers-types": "^4.20250620.0",
+        "typescript": "^5.8.3",
+        "wrangler": "^4.4.0",
+      },
+    },
     "apps/mcp": {
       "name": "supermemory-mcp",
       "version": "4.0.0",
@@ -1447,6 +1456,8 @@
     "@remix-run/node-fetch-server": ["@remix-run/node-fetch-server@0.13.0", "", {}, "sha512-1EsNo0ZpgXu/90AWoRZf/oE3RVTUS80tiTUpt+hv5pjtAkw7icN4WskDwz/KdAw5ARbJLMhZBrO1NqThmy/McA=="],
 
     "@repo/docs": ["@repo/docs@workspace:apps/docs"],
+
+    "@repo/docs-proxy": ["@repo/docs-proxy@workspace:apps/docs-proxy"],
 
     "@repo/hooks": ["@repo/hooks@workspace:packages/hooks"],
 
@@ -5441,6 +5452,8 @@
     "@react-router/dev/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "@repo/docs/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "@repo/docs-proxy/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
 
     "@repo/lib/better-auth": ["better-auth@1.3.3", "", { "dependencies": { "@better-auth/utils": "0.2.5", "@better-fetch/fetch": "^1.1.18", "@noble/ciphers": "^0.6.0", "@noble/hashes": "^1.8.0", "@simplewebauthn/browser": "^13.0.0", "@simplewebauthn/server": "^13.0.0", "better-call": "^1.0.12", "defu": "^6.1.4", "jose": "^5.9.6", "kysely": "^0.28.1", "nanostores": "^0.11.3", "zod": "^4.0.5" }, "peerDependencies": { "react": "^18.0.0 || ^19.0.0", "react-dom": "^18.0.0 || ^19.0.0" }, "optionalPeers": ["react", "react-dom"] }, "sha512-q1aD2nNpGfEI2ckYu+pBjN+23CIRctOpmREkWyJDJdoYW1q9EPs1Xdb+KhFztg2rMmsoUN8I9Xm5mUWMxiWuLw=="],
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Creates a new Cloudflare Worker app at `apps/docs-proxy/` to replace the existing `supermemory-docs-mintlify` dashboard-deployed worker. The previous worker was a plain reverse proxy to `https://supermemory.mintlify.dev` with no timeout or caching, causing critical latency anomalies (P99 wall time reaching 836 seconds / ~14 minutes) when Mintlify is slow.

## Changes

**New files:**
- `apps/docs-proxy/src/index.ts` — Worker implementation
- `apps/docs-proxy/wrangler.jsonc` — Wrangler config (`name: supermemory-docs-mintlify`)
- `apps/docs-proxy/package.json` — Package manifest (`@repo/docs-proxy`)
- `apps/docs-proxy/tsconfig.json` — TypeScript config for Cloudflare Workers

## Key improvements

| Feature | Before | After |
|---|---|---|
| Fetch timeout | None (hangs indefinitely) | 10-second AbortController timeout → 504 |
| Caching | None | Cache API: GET responses cached 5 min (`max-age=300`) |
| Error UX | Upstream error propagated | User-friendly "temporarily unavailable" on timeout |

## Implementation notes

- Uses `caches.default` (Cloudflare Cache API) — only caches successful `GET` responses with `response.ok`
- `AbortController` timeout fires after 10 seconds; caught `AbortError` returns 504
- Proxies original method, headers, and body to `https://supermemory.mintlify.dev` + original path + query string
- No bindings (no KV, D1, R2, DO, or service bindings) — zero-config deploy

## Validation

- `tsc --noEmit`: passes with zero errors
- `wrangler deploy --dry-run`: "No bindings found. --dry-run: exiting now." (1.44 KiB upload)

## Deployment

This app is deployed independently — not wired into Turbo CI. To deploy:
```bash
cd apps/docs-proxy
wrangler deploy --minify
```

## Assumptions

- The existing `supermemory-docs-mintlify` worker (dashboard-deployed) should be replaced/updated to point to this worker source after deployment
- 10-second timeout and 5-minute cache TTL are reasonable defaults; can be tuned via constants at the top of `src/index.ts`
- No routes/custom domain config added to `wrangler.jsonc` — assumes the existing worker already has the route configured in the Cloudflare dashboard
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f74d878d-2e1e-4d9a-8c43-da5a1de6e8ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f74d878d-2e1e-4d9a-8c43-da5a1de6e8ec"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/7a250ce2-1668-4a91-bba0-6f37467f7f67)
- Requested by: Unknown
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
