### PR TITLE
fix(web): match YouTube URLs by hostname instead of substring

### DIFF
--- a/apps/web/components/document-icon.tsx
+++ b/apps/web/components/document-icon.tsx
@@ -17,6 +17,7 @@ import {
 } from "@ui/assets/icons"
 import { Globe, FileText, FileCode, Image } from "lucide-react"
 import { cn } from "@lib/utils"
+import { isYouTubeUrl } from "@/lib/url-helpers"
 
 function MCPIcon({ className }: { className?: string }) {
 	return (
@@ -206,7 +207,7 @@ export function DocumentIcon({
 		return <MCPIcon className={iconClassName} />
 	}
 
-	if (url?.includes("youtube.com") || url?.includes("youtu.be")) {
+	if (isYouTubeUrl(url)) {
 		return <YouTubeIcon className={iconClassName} />
 	}
 

--- a/apps/web/components/document-modal/content/index.tsx
+++ b/apps/web/components/document-modal/content/index.tsx
@@ -3,7 +3,7 @@
 import type { DocumentsWithMemoriesResponseSchema } from "@repo/validation/api"
 import type { z } from "zod"
 import dynamic from "next/dynamic"
-import { isTwitterUrl } from "@/lib/url-helpers"
+import { isTwitterUrl, isYouTubeUrl } from "@/lib/url-helpers"
 import { ImagePreview } from "./image-preview"
 import { TweetContent } from "./tweet"
 import { NotionDoc } from "./notion-doc"
@@ -67,7 +67,7 @@ function getContentType(document: DocumentWithMemories | null): ContentType {
 	if (document.type === "google_doc") return "google_doc"
 	if (document.type === "google_sheet") return "google_sheet"
 	if (document.type === "google_slide") return "google_slide"
-	if (document.url?.includes("youtube.com")) return "youtube"
+	if (isYouTubeUrl(document.url)) return "youtube"
 	if (document.type === "webpage") return "webpage"
 
 	return null

--- a/apps/web/components/timeline-view.tsx
+++ b/apps/web/components/timeline-view.tsx
@@ -6,6 +6,7 @@ import type { DocumentsWithMemoriesResponseSchema } from "@repo/validation/api"
 import type { z } from "zod"
 import { cn } from "@lib/utils"
 import { dmSansClassName } from "@/lib/fonts"
+import { isYouTubeUrl } from "@/lib/url-helpers"
 import { SyncLogoIcon } from "@ui/assets/icons"
 import { DocumentIcon } from "@/components/document-icon"
 import { CheckIcon, ChevronDownIcon } from "lucide-react"
@@ -41,7 +42,7 @@ type CategoryInfo = { label: string; singularLabel: string; key: string }
 function getDocumentTypeInfo(doc: DocumentWithMemories): CategoryInfo {
 	if (doc.source === "mcp")
 		return { label: "MCP Items", singularLabel: "MCP Item", key: "mcp" }
-	if (doc.url?.includes("youtube.com") || doc.url?.includes("youtu.be"))
+	if (isYouTubeUrl(doc.url))
 		return {
 			label: "YouTube Videos",
 			singularLabel: "YouTube Video",

--- a/apps/web/components/utils.ts
+++ b/apps/web/components/utils.ts
@@ -1,15 +1,9 @@
 "use client"
 
 import { useQuery } from "@tanstack/react-query"
+import { isYouTubeUrl } from "@/lib/url-helpers"
 
-export function isYouTubeUrl(url: string | undefined | null): boolean {
-	if (!url) return false
-	return (
-		url.includes("youtube.com") ||
-		url.includes("youtu.be") ||
-		url.includes("m.youtube.com")
-	)
-}
+export { isYouTubeUrl }
 
 export function extractYouTubeVideoId(
 	url: string | undefined | null,

--- a/apps/web/lib/url-helpers.test.ts
+++ b/apps/web/lib/url-helpers.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test"
+import { isYouTubeUrl } from "./url-helpers"
+
+describe("isYouTubeUrl", () => {
+	it("matches canonical youtube.com watch URLs", () => {
+		expect(isYouTubeUrl("https://youtube.com/watch?v=dQw4w9WgXcQ")).toBe(true)
+		expect(isYouTubeUrl("https://www.youtube.com/watch?v=dQw4w9WgXcQ")).toBe(
+			true,
+		)
+	})
+
+	it("matches real youtube subdomains", () => {
+		expect(isYouTubeUrl("https://m.youtube.com/watch?v=dQw4w9WgXcQ")).toBe(true)
+		expect(isYouTubeUrl("https://music.youtube.com/watch?v=dQw4w9WgXcQ")).toBe(
+			true,
+		)
+	})
+
+	it("matches youtu.be short links", () => {
+		expect(isYouTubeUrl("https://youtu.be/dQw4w9WgXcQ")).toBe(true)
+		expect(isYouTubeUrl("https://www.youtu.be/dQw4w9WgXcQ")).toBe(true)
+	})
+
+	it("matches embed and shorts paths", () => {
+		expect(isYouTubeUrl("https://www.youtube.com/embed/dQw4w9WgXcQ")).toBe(true)
+		expect(isYouTubeUrl("https://www.youtube.com/shorts/dQw4w9WgXcQ")).toBe(
+			true,
+		)
+	})
+
+	it("is case-insensitive for scheme and host", () => {
+		expect(isYouTubeUrl("HTTPS://youtube.com/watch?v=dQw4w9WgXcQ")).toBe(true)
+		expect(isYouTubeUrl("https://WWW.YOUTUBE.COM/watch?v=dQw4w9WgXcQ")).toBe(
+			true,
+		)
+	})
+
+	it("matches scheme-less URLs", () => {
+		expect(isYouTubeUrl("youtube.com/watch?v=dQw4w9WgXcQ")).toBe(true)
+		expect(isYouTubeUrl("www.youtube.com/watch?v=dQw4w9WgXcQ")).toBe(true)
+	})
+
+	it("rejects lookalike domains", () => {
+		expect(isYouTubeUrl("https://notyoutube.com/watch?v=dQw4w9WgXcQ")).toBe(
+			false,
+		)
+		expect(isYouTubeUrl("https://myyoutu.be/dQw4w9WgXcQ")).toBe(false)
+	})
+
+	it("rejects hosts that merely start with youtube.com", () => {
+		expect(
+			isYouTubeUrl("https://youtube.com.evil.example/watch?v=dQw4w9WgXcQ"),
+		).toBe(false)
+		expect(isYouTubeUrl("https://youtu.be.evil.example/dQw4w9WgXcQ")).toBe(
+			false,
+		)
+	})
+
+	it("rejects URLs that only contain youtube.com in the path", () => {
+		expect(
+			isYouTubeUrl("https://evil.example/youtube.com/watch?v=dQw4w9WgXcQ"),
+		).toBe(false)
+		expect(isYouTubeUrl("https://evil.example/redirect?to=youtu.be/x")).toBe(
+			false,
+		)
+	})
+
+	it("rejects empty and nullish input", () => {
+		expect(isYouTubeUrl("")).toBe(false)
+		expect(isYouTubeUrl(null)).toBe(false)
+		expect(isYouTubeUrl(undefined)).toBe(false)
+	})
+})

--- a/apps/web/lib/url-helpers.ts
+++ b/apps/web/lib/url-helpers.ts
@@ -158,6 +158,22 @@ export const isTwitterUrl = (url: string): boolean => {
 }
 
 /**
+ * Checks if a URL is a YouTube URL by matching the hostname against
+ * youtube.com / youtu.be (and their subdomains, e.g. www / m).
+ * Lookalike hosts (`notyoutube.com`, `youtube.com.evil.example`) and URLs
+ * that only contain "youtube.com" in the path do not match.
+ */
+export const isYouTubeUrl = (url: string | undefined | null): boolean => {
+	if (!url) return false
+	const parsed = parseWebUrl(url)
+	if (!parsed) return false
+	return (
+		hostnameMatches(parsed.hostname, "youtube.com") ||
+		hostnameMatches(parsed.hostname, "youtu.be")
+	)
+}
+
+/**
  * Checks if a URL is a LinkedIn profile URL (not a company page).
  */
 export const isLinkedInProfileUrl = (url: string): boolean => {


### PR DESCRIPTION
## What

Fixes #1175

YouTube detection in the web app was done with substring checks (`url.includes("youtube.com")` etc.) in four places, so any URL that merely *contains* those strings got classified as YouTube:

```ts
isYouTubeUrl("https://notyoutube.com/watch?v=dQw4w9WgXcQ")            // was true
isYouTubeUrl("https://evil.example/youtube.com/watch?v=dQw4w9WgXcQ")  // was true
isYouTubeUrl("https://youtube.com.evil.example/watch?v=dQw4w9WgXcQ")  // was true
```

Those URLs then got the YouTube icon in `document-icon.tsx`, were grouped under "YouTube Videos" in the timeline view, rendered as a YouTube preview on memory cards, and opened in the embed player in the document modal.

## How

- Added a hostname-based `isYouTubeUrl()` to `apps/web/lib/url-helpers.ts`, reusing the existing `parseWebUrl` + `hostnameMatches` helpers that `isTwitterUrl` already uses. It matches `youtube.com` / `youtu.be` and their real subdomains (`www.`, `m.`, `music.`) only.
- `components/utils.ts` now re-exports the shared helper, so existing imports (memory card previews, `useYouTubeChannelName`) are unchanged.
- Switched the three inline substring checks (`document-modal/content/index.tsx`, `document-icon.tsx`, `timeline-view.tsx`) to the shared helper.
- Side effect worth calling out: the document modal previously only checked for `youtube.com`, so `youtu.be` short links fell through to the webpage renderer. They now open in the embed player — `yt-video.tsx` already knew how to extract IDs from short links, so no change was needed there.

Uppercase schemes (`HTTPS://youtube.com/...`) and scheme-less inputs (`youtube.com/watch?v=...`) keep working since `parseWebUrl` normalizes both.

## Testing

- Added `apps/web/lib/url-helpers.test.ts` — 10 cases covering canonical/watch/embed/shorts URLs, real subdomains, short links, uppercase schemes, scheme-less input, lookalike domains, subdomain tricks, path-only matches, and nullish input. All pass with `bun test`.
- Existing web tests still pass (24 tests across 3 files).
- `biome check` clean on all touched files.
- `bun run build` for `apps/web` completes successfully.

cc @MaheshtheDev
