### PR TITLE
fix(web): stop truncating multi-line plugin transcript messages

### DIFF
--- a/apps/web/lib/plugin-document.test.ts
+++ b/apps/web/lib/plugin-document.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from "bun:test"
+import { parsePluginDocument } from "./plugin-document"
+
+type PluginDocumentInput = Parameters<typeof parsePluginDocument>[0]
+
+function makeCodexSessionDocument(content: string): PluginDocumentInput {
+	return {
+		id: "doc_1",
+		title: "Codex session",
+		content,
+		metadata: { sm_source: "codex" },
+		memoryEntries: [],
+	} as unknown as PluginDocumentInput
+}
+
+describe("parsePluginDocument — session transcripts", () => {
+	it("keeps multi-line message bodies intact", () => {
+		const parsed = parsePluginDocument(
+			makeCodexSessionDocument(
+				[
+					"[Session abc-123]",
+					"1. [user] Hello there",
+					"Here is more context on line two",
+					"2. [assistant] Sure!",
+					"Second line of the reply",
+				].join("\n"),
+			),
+		)
+
+		expect(parsed).not.toBeNull()
+		expect(parsed?.kind).toBe("codex-session")
+		expect(parsed?.messages).toHaveLength(2)
+		expect(parsed?.messages[0]?.text).toBe(
+			"Hello there\nHere is more context on line two",
+		)
+		expect(parsed?.messages[1]?.text).toBe("Sure!\nSecond line of the reply")
+	})
+
+	it("surfaces memory id artifacts from continuation lines", () => {
+		const parsed = parsePluginDocument(
+			makeCodexSessionDocument(
+				[
+					"[Session abc-123]",
+					"1. [user] Remember my editor is Neovim",
+					"memory id: mem_456",
+					"2. [assistant] Saved it.",
+				].join("\n"),
+			),
+		)
+
+		expect(parsed?.messages[0]?.text).toBe("Remember my editor is Neovim")
+		expect(parsed?.artifacts).toContainEqual({
+			label: "Memory ID",
+			value: "mem_456",
+		})
+	})
+
+	it("normalizes literal \\n escapes before splitting messages", () => {
+		const parsed = parsePluginDocument(
+			makeCodexSessionDocument(
+				"[Session abc-123]\\n1. [user] First line\\nSecond line\\n2. [assistant] Reply",
+			),
+		)
+
+		expect(parsed?.messages).toHaveLength(2)
+		expect(parsed?.messages[0]?.text).toBe("First line\nSecond line")
+		expect(parsed?.messages[1]?.text).toBe("Reply")
+	})
+
+	it("parses single-line messages as before", () => {
+		const parsed = parsePluginDocument(
+			makeCodexSessionDocument(
+				["[Session abc-123]", "1. [user] Hi", "2. [assistant] Hello!"].join(
+					"\n",
+				),
+			),
+		)
+
+		expect(parsed?.messages).toHaveLength(2)
+		expect(parsed?.messages[0]?.text).toBe("Hi")
+		expect(parsed?.messages[1]?.text).toBe("Hello!")
+		expect(parsed?.summary).toBe(
+			"1 user message and 1 assistant message captured from Codex.",
+		)
+	})
+})

--- a/apps/web/lib/plugin-document.ts
+++ b/apps/web/lib/plugin-document.ts
@@ -227,8 +227,11 @@ function parseTranscriptMessages(content: string): {
 } {
 	const messages: PluginDocumentMessage[] = []
 	const artifacts: PluginArtifact[] = []
+	// The lookahead must end the last message at the true end of input:
+	// with the m flag, a bare $ matches every line end and would cut each
+	// message body off at its first newline.
 	const regex = new RegExp(
-		`^\\s*(\\d+)\\.\\s+\\[(${TRANSCRIPT_ROLE_PATTERN})\\]\\s*([\\s\\S]*?)(?=^\\s*\\d+\\.\\s+\\[(?:${TRANSCRIPT_ROLE_PATTERN})\\]\\s*|$)`,
+		`^\\s*(\\d+)\\.\\s+\\[(${TRANSCRIPT_ROLE_PATTERN})\\]\\s*([\\s\\S]*?)(?=^\\s*\\d+\\.\\s+\\[(?:${TRANSCRIPT_ROLE_PATTERN})\\]\\s*|(?![\\s\\S]))`,
 		"gm",
 	)
 


### PR DESCRIPTION
## What

Fixes #1184

Multi-line messages in plugin transcript documents (Codex sessions, Amp threads) were being truncated to their first line in the document modal. The message-splitting regex in `parseTranscriptMessages` is built with the `m` flag, and its terminating lookahead ended with `|$` — under `m`, `$` matches at every line end, so the lazy `[\s\S]*?` body (written to span lines) stopped at the first newline.

For this input:

```
1. [user] Hello there
Here is more context on line two
memory id: mem_123
2. [assistant] Sure!
Second line of the reply
```

the parser produced messages `"Hello there"` and `"Sure!"` — the continuation lines landed in no message at all. Knock-on effects:

- `memory id:` lines inside a body were dropped before `extractArtifacts` could surface them, so the Memory ID chip never showed for multi-line turns
- previews and the user/assistant message counts in the summary were computed from truncated text

This bites on essentially every real transcript, since `normalizeContent` converts literal `\n` escapes to real newlines *before* parsing.

## How

One-token change: the `|$` alternative in the lookahead becomes `|(?![\s\S])` — a true end-of-input assertion that the `m` flag can't reinterpret. Message bodies now run until the next `N. [role]` header or the actual end of the transcript.

The neighboring `parseClaudeCodeTurns` regex also ends with `|$` but doesn't use the `m` flag, so it already behaves correctly and is left untouched.

## Testing

- New `apps/web/lib/plugin-document.test.ts` (bun:test, same setup as the other `lib/*.test.ts` files), exercised through the public `parsePluginDocument`: multi-line bodies preserved, memory-id artifacts extracted from continuation lines, literal `\n` normalization, and single-line messages unchanged.
- Verified the tests catch the bug: against the previous regex the three multi-line cases fail, the single-line case passes (behavior-preserving).
- Full web lib suite passes (18 tests across 3 files); `biome check` clean; no new `tsc` errors in the touched files.

cc @MaheshtheDev


---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/5671ccf4-cd72-4f2f-adb7-25a138e80726)
- Requested by: Unknown
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
