### PR TITLE
fix(web): stop extractUrls treating email addresses as URLs

### DIFF
--- a/apps/web/lib/extract-urls.test.ts
+++ b/apps/web/lib/extract-urls.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "bun:test"
+import { extractUrls } from "./url-helpers"
+
+describe("extractUrls", () => {
+	it("extracts bare, markdown, and angle-bracket links", () => {
+		const { urls } = extractUrls(
+			"see https://a.example/one, [docs](https://b.example/two) and <https://c.example/three>",
+		)
+		expect(urls).toEqual([
+			"https://a.example/one",
+			"https://b.example/two",
+			"https://c.example/three",
+		])
+	})
+
+	it("normalizes scheme-less URLs", () => {
+		const { urls } = extractUrls("check supermemory.ai for details")
+		expect(urls).toEqual(["https://supermemory.ai"])
+	})
+
+	it("does not extract URLs from email addresses", () => {
+		const result = extractUrls("email me at john.doe@example.com")
+		expect(result.urls).toEqual([])
+		expect(result.duplicates).toBe(0)
+	})
+
+	it("keeps real URLs while skipping emails in the same text", () => {
+		const { urls } = extractUrls(
+			"email john.doe@example.com or visit https://supermemory.ai",
+		)
+		expect(urls).toEqual(["https://supermemory.ai"])
+	})
+
+	it("skips multiple email addresses", () => {
+		const { urls } = extractUrls(
+			"contacts: a.person@foo.example, b.person@bar.example",
+		)
+		expect(urls).toEqual([])
+	})
+
+	it("strips trailing punctuation", () => {
+		const { urls } = extractUrls("read https://example.com/post.")
+		expect(urls).toEqual(["https://example.com/post"])
+	})
+
+	it("dedupes URLs that differ only by scheme/host case or trailing slash", () => {
+		const { urls, duplicates } = extractUrls(
+			"HTTPS://EXAMPLE.COM/docs https://example.com/docs https://example.com/docs/",
+		)
+		expect(urls).toHaveLength(1)
+		expect(duplicates).toBe(2)
+	})
+
+	it("keeps URLs whose paths differ only by case", () => {
+		const { urls, duplicates } = extractUrls(
+			"https://example.com/Page and https://example.com/page",
+		)
+		expect(urls).toEqual([
+			"https://example.com/Page",
+			"https://example.com/page",
+		])
+		expect(duplicates).toBe(0)
+	})
+
+	it("returns nothing for plain text", () => {
+		expect(extractUrls("no links here").urls).toEqual([])
+		expect(extractUrls("").urls).toEqual([])
+	})
+})

--- a/apps/web/lib/url-helpers.ts
+++ b/apps/web/lib/url-helpers.ts
@@ -96,12 +96,20 @@ export const extractUrls = (
 	const unwrapped = text
 		.replace(MARKDOWN_LINK_REGEX, " $1 ")
 		.replace(ANGLE_LINK_REGEX, " $1 ")
-	const matches = unwrapped.match(URL_TOKEN_REGEX) ?? []
 	const seen = new Set<string>()
 	const urls: string[] = []
 	let duplicates = 0
-	for (const match of matches) {
-		let trimmed = match.trim().replace(/[.,;!]+$/, "")
+	for (const match of unwrapped.matchAll(URL_TOKEN_REGEX)) {
+		const start = match.index ?? 0
+		const end = start + match[0].length
+		const before = start > 0 ? (unwrapped[start - 1] ?? "") : ""
+		const after = end < unwrapped.length ? (unwrapped[end] ?? "") : ""
+		// Skip email addresses: a domain-shaped token ending at "@" is the
+		// local part, one starting right after "@" is the mail domain. Also
+		// skip matches that begin mid-token (e.g. after "_", which the
+		// hostname charset can't include) — those aren't standalone URLs.
+		if (after === "@" || before === "@" || /[\w.-]/.test(before)) continue
+		let trimmed = match[0].trim().replace(/[.,;!]+$/, "")
 		const opens = (trimmed.match(/\(/g) ?? []).length
 		const closes = (trimmed.match(/\)/g) ?? []).length
 		if (closes > opens && trimmed.endsWith(")")) {
@@ -109,7 +117,15 @@ export const extractUrls = (
 		}
 		const normalized = normalizeUrl(trimmed)
 		if (!isValidUrl(normalized)) continue
-		const key = normalized.toLowerCase().replace(/\/+$/, "")
+		// Dedupe on the parsed URL so the scheme and host compare
+		// case-insensitively while the path/query — which are case-sensitive
+		// resources — stay distinct.
+		const parsed = new URL(normalized)
+		const key =
+			`${parsed.origin}${parsed.pathname}${parsed.search}${parsed.hash}`.replace(
+				/\/+$/,
+				"",
+			)
 		if (seen.has(key)) {
 			duplicates++
 			continue


### PR DESCRIPTION
## What

`extractUrls` in `apps/web/lib/url-helpers.ts` treats email addresses as URLs. `URL_TOKEN_REGEX` has no left boundary, so for

```
email me at john.doe@example.com
```

it extracts **two** bogus URLs: `https://john.doe` and `https://example.com`.

This is user-visible: the add-document note view (`components/add-document/note.tsx`) shows a "N links detected — save each as its own memory?" banner when 2+ URLs are detected, so a note containing a *single email address* triggers a bulk-import offer of garbage links.

There's a second defect in the same function: the dedupe key lowercases the entire URL, so `https://example.com/Page` and `https://example.com/page` — distinct, case-sensitive resources — are collapsed and one is silently dropped.

## How

- Switched from `match` to `matchAll` and inspect the characters adjacent to each candidate: a token ending at `@` is an email local part, a token starting right after `@` is the mail domain, and a token beginning mid-word (e.g. after `_`, which the hostname charset can't include) isn't a standalone URL. All are skipped.
- The dedupe key is now built from the parsed `URL` (`origin + pathname + search + hash`), so scheme and host compare case-insensitively — which the URL parser normalizes anyway — while path, query, and hash stay case-sensitive. Trailing-slash-only variants still count as duplicates, as before.

No API change: same signature, same `{urls, duplicates}` result shape.

## Testing

- New `apps/web/lib/extract-urls.test.ts` (bun:test, same setup as the other `lib/*.test.ts` files): emails alone, emails mixed with real URLs, multiple emails, markdown/angle-bracket links, scheme-less URLs, trailing punctuation, case/slash dedupe, and case-sensitive paths kept distinct.
- Verified the tests catch the bugs: 4 of 9 fail against the previous implementation; the other 5 pin existing behavior and pass on both.
- Full web lib suite passes (23 tests); `biome check` clean.

Note: the test lives in its own file rather than `url-helpers.test.ts` because #1182 (open) adds that file for the YouTube-detection fix — this way the two PRs merge cleanly in either order.

cc @MaheshtheDev


---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/af429baf-5210-412d-947d-eac23e6781b9)
- Requested by: Unknown
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
