### PR TITLE
fix(web): make the finished-processing refresh effect actually fire

### DIFF
--- a/apps/web/hooks/use-processing-documents.ts
+++ b/apps/web/hooks/use-processing-documents.ts
@@ -37,12 +37,20 @@ export function useProcessingDocuments() {
 		staleTime: 0,
 	})
 
-	const docs =
-		(
-			data as
-				| { documents?: Array<{ id?: string | null; status?: string | null }> }
-				| undefined
-		)?.documents ?? []
+	// Memoized on `data` (kept referentially stable between polls by React
+	// Query's structural sharing) so `processingMap` only changes identity
+	// when the poll payload actually changes — the effect below depends on it.
+	const docs = useMemo(
+		() =>
+			(
+				data as
+					| {
+							documents?: Array<{ id?: string | null; status?: string | null }>
+					  }
+					| undefined
+			)?.documents ?? [],
+		[data],
+	)
 
 	const processingMap = useMemo(() => {
 		const map = new Map<string, string>()
@@ -52,7 +60,6 @@ export function useProcessingDocuments() {
 			}
 		}
 		return map
-		// eslint-disable-next-line react-hooks/exhaustive-deps
 	}, [docs])
 
 	// Detect docs that just finished (present in previous poll, absent now).
@@ -80,8 +87,10 @@ export function useProcessingDocuments() {
 			clearTimeout(t1)
 			clearTimeout(t2)
 		}
-		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [processingMap.keys, queryClient.refetchQueries])
+		// `processingMap` (not `processingMap.keys` — that's the shared
+		// Map.prototype method, identical for every map, so the effect would
+		// never re-run and finished docs would never trigger a refresh).
+	}, [processingMap, queryClient])
 
 	return processingMap
 }


### PR DESCRIPTION
## What

The `useProcessingDocuments` effect that's supposed to refetch `documents-with-memories` and `dashboard-recents` when a document finishes processing never fires. Its dependency array is

```ts
}, [processingMap.keys, queryClient.refetchQueries])
```

`processingMap.keys` (uncalled) is `Map.prototype.keys` — the **same function object for every Map instance** — and `queryClient.refetchQueries` is likewise a stable method reference. Both deps are constant across renders, so the effect runs exactly once on mount, when the previous and current id sets are both empty. The prev/current diff that detects "these docs just finished" never re-executes, and the delayed refresh the comment describes is dead code. The `eslint-disable-next-line react-hooks/exhaustive-deps` on the array is what kept the lint rule from flagging it.

**Effect for users:** after adding a document, the memories grid and dashboard recents don't pick up the extracted memories when processing completes — the card stays stale until something else happens to refetch.

## How

Two changes, both needed:

1. The effect now depends on `[processingMap, queryClient]`.
2. `docs` is memoized on `data` so `processingMap` only changes identity when the poll payload actually changes. React Query's structural sharing keeps `data` referentially stable between identical polls, so this holds. Without this second change the map would get a fresh identity every render, and each effect re-run's cleanup could cancel the pending 1s/4s refresh timers before they fire — trading "never refreshes" for "sometimes loses the refresh".

With both in place: a doc disappearing from the processing poll → new `data` → new `processingMap` → effect re-runs → diff catches the finished id → delayed refetches fire. Renders caused by anything else don't re-run the effect, so the timers survive.

Both stray `eslint-disable` comments are removed — the dependency arrays are now honest.

## Testing

- `biome check` clean; no `tsc` errors in the touched file (the web app has pre-existing errors elsewhere and `ignoreBuildErrors` in its Next config — none involve this file).
- The web app has no React hook test harness, so this is verified by analysis rather than a unit test: the bug itself is a JavaScript identity fact (`new Map().keys === new Map().keys` → `true`), and the structural-sharing guarantee that makes the fix safe is React Query's documented default. Happy to add a hook test if you'd like a `@testing-library/react` setup introduced for it.

cc @MaheshtheDev


---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/57a9bde7-5f6e-4cda-8b0f-805b81d4d20e)
- Requested by: Unknown
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
