### PR TITLE
fix(mcp): return graph view message from fetch-graph-data

### DIFF
--- a/apps/mcp/src/server/agent.ts
+++ b/apps/mcp/src/server/agent.ts
@@ -8,7 +8,7 @@ import { registerContainerTagsResource } from "./resources/container-tags"
 import { registerProfileResource } from "./resources/profile"
 import { registerWidgetResource } from "./resources/widget"
 import { registerAllTools } from "./tools"
-import { errorResult } from "./tools/types"
+import { appErrorResult, errorResult } from "./tools/types"
 
 type Env = {
 	MCP_SERVER: DurableObjectNamespace
@@ -71,6 +71,7 @@ export class SupermemoryMCP extends McpAgent<Env, unknown, Props> {
 			getClientInfo: () => this.clientInfo,
 			getMcpSessionId: () => this.ctx.id.name ?? "unknown",
 			errorResult,
+			appErrorResult,
 		}
 
 		registerAllTools(deps)
@@ -103,13 +104,15 @@ export class SupermemoryMCP extends McpAgent<Env, unknown, Props> {
 		return activeTag || this.props?.containerTag
 	}
 
-	private async refreshContainerTags(): Promise<void> {
+	private async refreshContainerTags(): Promise<boolean> {
 		try {
 			const client = this.getClient()
 			const tags = await client.listContainerTags()
 			this.cachedContainerTagsList = tags.map((t) => t.containerTag)
+			return true
 		} catch (error) {
 			console.error("Failed to refresh container tags:", error)
+			return false
 		}
 	}
 }

--- a/apps/mcp/src/server/tools/fetch-graph-data.ts
+++ b/apps/mcp/src/server/tools/fetch-graph-data.ts
@@ -1,6 +1,6 @@
 import { registerAppTool } from "@modelcontextprotocol/ext-apps/server"
 import { z } from "zod"
-import { SUPERMEMORY_RESOURCE_URI } from "../../shared/types"
+import { SUPERMEMORY_RESOURCE_URI, type ViewMessage } from "../../shared/types"
 import type { ToolDeps } from "./types"
 
 export function register(deps: ToolDeps) {
@@ -44,9 +44,23 @@ export function register(deps: ToolDeps) {
 					args.limit,
 				)
 
+				// structuredContent must be a ViewMessage - the widget dispatches on
+				// `view` and renders anything else as an "unrecognized response" error.
+				const sc: ViewMessage = {
+					view: "graph",
+					containerTag: effectiveTag,
+					documents: data.documents,
+					totalCount: data.pagination.totalItems,
+				}
+
 				return {
-					content: [{ type: "text" as const, text: JSON.stringify(data) }],
-					structuredContent: data,
+					content: [
+						{
+							type: "text" as const,
+							text: `Fetched ${data.documents.length} documents (page ${data.pagination.currentPage} of ${data.pagination.totalPages}, ${data.pagination.totalItems} total)${effectiveTag ? `. Workspace: ${effectiveTag}` : ""}`,
+						},
+					],
+					structuredContent: sc,
 				}
 			} catch (error) {
 				return deps.errorResult(error)

--- a/apps/mcp/src/server/tools/fetch-graph-data.ts
+++ b/apps/mcp/src/server/tools/fetch-graph-data.ts
@@ -51,6 +51,7 @@ export function register(deps: ToolDeps) {
 					containerTag: effectiveTag,
 					documents: data.documents,
 					totalCount: data.pagination.totalItems,
+					pagination: data.pagination,
 				}
 
 				return {

--- a/apps/mcp/src/server/tools/search-memory.ts
+++ b/apps/mcp/src/server/tools/search-memory.ts
@@ -2,8 +2,9 @@ import { z } from "zod"
 import { getMemoryText } from "../client"
 import type { ToolDeps } from "./types"
 import {
-	containerTagExists,
+	containerTagValidationUnavailableError,
 	unknownContainerTagError,
+	validateContainerTag,
 } from "./validate-container-tag"
 
 export function register(deps: ToolDeps) {
@@ -47,13 +48,21 @@ export function register(deps: ToolDeps) {
 						),
 					)
 				}
-				if (
-					args.containerTag &&
-					!(await containerTagExists(deps, args.containerTag))
-				) {
-					return deps.errorResult(unknownContainerTagError(args.containerTag))
-				}
 				const effectiveTag = await deps.resolveContainerTag(args.containerTag)
+				if (effectiveTag && !deps.rbac.canRead(effectiveTag)) {
+					return deps.errorResult(
+						new Error(`No read access to container tag '${effectiveTag}'.`),
+					)
+				}
+				if (effectiveTag) {
+					const validation = await validateContainerTag(deps, effectiveTag)
+					if (validation === "missing") {
+						return deps.errorResult(unknownContainerTagError(effectiveTag))
+					}
+					if (validation === "unavailable") {
+						return deps.errorResult(containerTagValidationUnavailableError())
+					}
+				}
 				const client = deps.getClient(effectiveTag)
 
 				const parts: string[] = []

--- a/apps/mcp/src/server/tools/set-active-tag.ts
+++ b/apps/mcp/src/server/tools/set-active-tag.ts
@@ -3,8 +3,9 @@ import { z } from "zod"
 import { SUPERMEMORY_RESOURCE_URI, type ViewMessage } from "../../shared/types"
 import type { ToolDeps } from "./types"
 import {
-	containerTagExists,
+	containerTagValidationUnavailableError,
 	unknownContainerTagError,
+	validateContainerTag,
 } from "./validate-container-tag"
 
 export function register(deps: ToolDeps) {
@@ -26,16 +27,26 @@ export function register(deps: ToolDeps) {
 		async (args) => {
 			const containerTag = (args as { containerTag: string }).containerTag
 			if (!deps.rbac.canRead(containerTag)) {
-				return deps.errorResult(
-					new Error(`No access to container tag '${containerTag}'.`),
+				return deps.appErrorResult(
+					new Error(
+						`You don't have access to '${containerTag}'. Choose a workspace from listSpaces.`,
+					),
+					{ kind: "user", title: "No access to this workspace" },
 				)
 			}
 			try {
-				if (!(await containerTagExists(deps, containerTag))) {
-					return deps.errorResult(unknownContainerTagError(containerTag))
+				const validation = await validateContainerTag(deps, containerTag)
+				if (validation === "missing") {
+					return deps.appErrorResult(unknownContainerTagError(containerTag), {
+						kind: "user",
+						title: "Workspace not found",
+					})
+				}
+				if (validation === "unavailable") {
+					return deps.appErrorResult(containerTagValidationUnavailableError())
 				}
 			} catch (error) {
-				return deps.errorResult(error)
+				return deps.appErrorResult(error)
 			}
 			await deps.storage.put("activeContainerTag", containerTag)
 			const sc: ViewMessage = {

--- a/apps/mcp/src/server/tools/types.ts
+++ b/apps/mcp/src/server/tools/types.ts
@@ -1,5 +1,6 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import type { Props } from "../../shared/types"
+import type { ViewMessage } from "../../shared/types"
 import type { RbacContext } from "../auth/rbac"
 import type { SupermemoryClient } from "../client"
 
@@ -16,13 +17,11 @@ export interface ToolDeps {
 		put: <T>(key: string, value: T) => Promise<void>
 	}
 	cachedContainerTags: () => string[]
-	refreshContainerTags: () => Promise<void>
+	refreshContainerTags: () => Promise<boolean>
 	getClientInfo: () => { name: string; version?: string } | null
 	getMcpSessionId: () => string
-	errorResult: (error: unknown) => {
-		content: { type: "text"; text: string }[]
-		isError: true
-	}
+	errorResult: typeof errorResult
+	appErrorResult: typeof appErrorResult
 }
 
 export function errorResult(error: unknown) {
@@ -31,5 +30,27 @@ export function errorResult(error: unknown) {
 	return {
 		content: [{ type: "text" as const, text: `Error: ${message}` }],
 		isError: true as const,
+	}
+}
+
+/** Like errorResult, but includes structuredContent so app widgets render the message. */
+export function appErrorResult(
+	error: unknown,
+	options?: { kind?: "user" | "system"; title?: string },
+) {
+	const message =
+		error instanceof Error ? error.message : "An unexpected error occurred"
+	const kind = options?.kind ?? "system"
+	const text = `Error: ${message}`
+	const structuredContent: ViewMessage = {
+		view: "error",
+		message,
+		kind,
+		title: options?.title,
+	}
+	return {
+		content: [{ type: "text" as const, text }],
+		isError: true as const,
+		structuredContent,
 	}
 }

--- a/apps/mcp/src/server/tools/validate-container-tag.ts
+++ b/apps/mcp/src/server/tools/validate-container-tag.ts
@@ -1,21 +1,28 @@
 import type { ToolDeps } from "./types"
 
+export type ContainerTagValidation = "exists" | "missing" | "unavailable"
+
 /**
  * Checks whether a container tag actually exists for this user.
  * Fast path is the cached tag list from init; on a miss we re-fetch once so
  * tags created after the session started are not falsely rejected.
  */
-export async function containerTagExists(
+export async function validateContainerTag(
 	deps: ToolDeps,
 	containerTag: string,
-): Promise<boolean> {
-	if (deps.cachedContainerTags().includes(containerTag)) return true
-	await deps.refreshContainerTags()
-	return deps.cachedContainerTags().includes(containerTag)
+): Promise<ContainerTagValidation> {
+	if (deps.cachedContainerTags().includes(containerTag)) return "exists"
+	const refreshed = await deps.refreshContainerTags()
+	if (!refreshed) return "unavailable"
+	return deps.cachedContainerTags().includes(containerTag) ? "exists" : "missing"
 }
 
 export function unknownContainerTagError(containerTag: string): Error {
 	return new Error(
 		`Container tag '${containerTag}' does not exist. Use listSpaces to see the available container tags.`,
 	)
+}
+
+export function containerTagValidationUnavailableError(): Error {
+	return new Error("Could not verify workspace. Please try again.")
 }

--- a/apps/mcp/src/server/tools/validate-container-tag.ts
+++ b/apps/mcp/src/server/tools/validate-container-tag.ts
@@ -14,7 +14,9 @@ export async function validateContainerTag(
 	if (deps.cachedContainerTags().includes(containerTag)) return "exists"
 	const refreshed = await deps.refreshContainerTags()
 	if (!refreshed) return "unavailable"
-	return deps.cachedContainerTags().includes(containerTag) ? "exists" : "missing"
+	return deps.cachedContainerTags().includes(containerTag)
+		? "exists"
+		: "missing"
 }
 
 export function unknownContainerTagError(containerTag: string): Error {

--- a/apps/mcp/src/shared/types.ts
+++ b/apps/mcp/src/shared/types.ts
@@ -91,6 +91,7 @@ export type ViewMessage =
 			documents: DocumentWithMemories[]
 			totalCount: number
 			containerTag?: string
+			pagination?: DocumentsApiResponse["pagination"]
 	  }
 	| {
 			view: "error"

--- a/apps/mcp/src/shared/types.ts
+++ b/apps/mcp/src/shared/types.ts
@@ -92,6 +92,12 @@ export type ViewMessage =
 			totalCount: number
 			containerTag?: string
 	  }
+	| {
+			view: "error"
+			message: string
+			kind?: "user" | "system"
+			title?: string
+	  }
 
 export type ViewName = ViewMessage["view"]
 

--- a/apps/mcp/src/widget/App.tsx
+++ b/apps/mcp/src/widget/App.tsx
@@ -139,6 +139,14 @@ function renderView(
 			)
 		case "confirmation":
 			return <Confirmation containerTag={msg.containerTag} />
+		case "error":
+			return (
+				<ErrorView
+					kind={msg.kind}
+					message={msg.message}
+					title={msg.title}
+				/>
+			)
 		case "save-success":
 			return <Success containerTag={msg.containerTag} id={msg.id} kind="save" />
 		case "upload-success":

--- a/apps/mcp/src/widget/App.tsx
+++ b/apps/mcp/src/widget/App.tsx
@@ -141,11 +141,7 @@ function renderView(
 			return <Confirmation containerTag={msg.containerTag} />
 		case "error":
 			return (
-				<ErrorView
-					kind={msg.kind}
-					message={msg.message}
-					title={msg.title}
-				/>
+				<ErrorView kind={msg.kind} message={msg.message} title={msg.title} />
 			)
 		case "save-success":
 			return <Success containerTag={msg.containerTag} id={msg.id} kind="save" />

--- a/apps/mcp/src/widget/hooks/useViewState.ts
+++ b/apps/mcp/src/widget/hooks/useViewState.ts
@@ -14,6 +14,11 @@ function safeLog(
 	}
 }
 
+function toolResultText(result: CallToolResult): string | null {
+	const item = result.content?.[0]
+	return item?.type === "text" ? item.text : null
+}
+
 type ViewState =
 	| { kind: "loading" }
 	| { kind: "view"; message: ViewMessage }
@@ -54,8 +59,20 @@ export function useViewState(): {
 			setState({ kind: "loading" })
 		}
 		app.ontoolresult = (result: CallToolResult) => {
+			if (result.isError) {
+				const text = toolResultText(result) ?? "Tool returned an error"
+				safeLog("error", `[host] ontoolresult: tool error: ${text}`)
+				setState({ kind: "error", message: text })
+				return
+			}
 			const sc = (result as { structuredContent?: unknown }).structuredContent
 			if (!sc || typeof sc !== "object") {
+				const text = toolResultText(result)
+				if (text) {
+					safeLog("warning", `[host] ontoolresult: text-only result: ${text}`)
+					setState({ kind: "error", message: text })
+					return
+				}
 				safeLog("warning", "[host] ontoolresult: no structuredContent")
 				setState({ kind: "raw", structuredContent: sc })
 				return

--- a/apps/mcp/src/widget/views/Error.tsx
+++ b/apps/mcp/src/widget/views/Error.tsx
@@ -3,18 +3,28 @@ import { WarningCircle } from "../lib/icons"
 
 interface Props {
 	message: string
+	kind?: "user" | "system"
+	title?: string
 }
 
-export function ErrorView({ message }: Props) {
+export function ErrorView({ message, kind = "system", title }: Props) {
+	const heading =
+		title ??
+		(kind === "user" ? "Couldn't complete that" : "Something went wrong")
+
 	return (
 		<Stack
 			align="center"
 			className="mx-(--page-header-px) my-(--space-6) rounded-[20px] bg-[#1B1F24] px-(--page-header-px) py-(--space-10) text-center shadow-[0_2.842px_14.211px_0_rgba(0,0,0,0.25),inset_0.711px_0.711px_0.711px_0_rgba(255,255,255,0.10)]"
 			gap="md"
 		>
-			<WarningCircle className="size-12 text-error" />
+			<WarningCircle
+				className={
+					kind === "user" ? "size-12 text-warning" : "size-12 text-error"
+				}
+			/>
 			<div className="text-(length:--text-sm) font-medium text-text-primary">
-				Something went wrong
+				{heading}
 			</div>
 			<p className="max-w-sm text-(length:--text-xs) leading-relaxed text-text-muted">
 				{message}

--- a/apps/mcp/src/widget/views/Upload.tsx
+++ b/apps/mcp/src/widget/views/Upload.tsx
@@ -29,14 +29,51 @@ function formatFileSize(bytes: number): string {
 
 const ACCEPT = ".txt,.pdf,.png,.jpg,.jpeg,.mp4"
 
+// The MCP transport rejects JSON-RPC bodies over 4 MiB with a bare 413
+// (MAXIMUM_MESSAGE_SIZE_BYTES in the agents SDK). The file travels base64
+// encoded (~4/3 inflation) inside that body, so cap the raw file size such
+// that the encoded payload plus the JSON-RPC envelope stays under the limit.
+const TRANSPORT_MESSAGE_LIMIT_BYTES = 4 * 1024 * 1024
+const ENVELOPE_ALLOWANCE_BYTES = 64 * 1024
+const MAX_UPLOAD_BYTES = Math.floor(
+	((TRANSPORT_MESSAGE_LIMIT_BYTES - ENVELOPE_ALLOWANCE_BYTES) * 3) / 4,
+)
+
+const FILE_TOO_LARGE_MESSAGE = (size: number) =>
+	`This file is ${formatFileSize(size)}. The maximum upload size is ${formatFileSize(MAX_UPLOAD_BYTES)} — please choose a smaller file.`
+
+// The transport-level 413 surfaces as an opaque error string; translate it
+// so the user sees the size limit instead of a generic failure.
+function friendlyUploadError(raw: string, fileSize: number): string {
+	if (/413|too large|payload/i.test(raw)) {
+		return FILE_TOO_LARGE_MESSAGE(fileSize)
+	}
+	return raw
+}
+
 export function Upload({ activeTag, writableTags, onAdvance, onError }: Props) {
 	const { callTool } = useApp()
 	const log = useLog()
 	const [file, setFile] = useState<File | null>(null)
+	const [fileError, setFileError] = useState<string | null>(null)
 	const [selectedTag, setSelectedTag] = useState<string | null>(
 		activeTag ?? writableTags[0] ?? null,
 	)
 	const [uploading, setUploading] = useState(false)
+
+	const handleFileSelect = (selected: File) => {
+		if (selected.size > MAX_UPLOAD_BYTES) {
+			log(
+				"warning",
+				`[upload] rejected oversized file: ${selected.name} (${selected.size}B > ${MAX_UPLOAD_BYTES}B)`,
+			)
+			setFileError(FILE_TOO_LARGE_MESSAGE(selected.size))
+			setFile(null)
+			return
+		}
+		setFileError(null)
+		setFile(selected)
+	}
 
 	const options = useMemo(
 		() => writableTags.map((tag) => ({ value: tag, label: tag })),
@@ -59,13 +96,17 @@ export function Upload({ activeTag, writableTags, onAdvance, onError }: Props) {
 			})
 			if (!result.ok || !result.data) {
 				log("error", `[upload] failed: ${result.error}`)
-				onError(result.error ?? "Upload failed")
+				onError(
+					result.error
+						? friendlyUploadError(result.error, file.size)
+						: "Upload failed",
+				)
 				return
 			}
 			onAdvance(result.data)
 		} catch (err) {
 			log("error", `[upload] threw: ${err}`)
-			onError(String(err))
+			onError(friendlyUploadError(String(err), file.size))
 		} finally {
 			setUploading(false)
 		}
@@ -102,11 +143,21 @@ export function Upload({ activeTag, writableTags, onAdvance, onError }: Props) {
 								/>
 							</div>
 						) : (
-							<FileUpload
-								accept={ACCEPT}
-								description="Supports TXT, PDF, PNG, JPG, MP4"
-								onFile={setFile}
-							/>
+							<Stack gap="sm">
+								<FileUpload
+									accept={ACCEPT}
+									description={`Supports TXT, PDF, PNG, JPG, MP4 · up to ${formatFileSize(MAX_UPLOAD_BYTES)}`}
+									onFile={handleFileSelect}
+								/>
+								{fileError ? (
+									<p
+										className="text-(length:--text-xs) leading-relaxed text-error"
+										role="alert"
+									>
+										{fileError}
+									</p>
+								) : null}
+							</Stack>
 						)}
 
 						{writableTags.length > 0 ? (

--- a/apps/mcp/src/widget/views/Upload.tsx
+++ b/apps/mcp/src/widget/views/Upload.tsx
@@ -39,14 +39,15 @@ const MAX_UPLOAD_BYTES = Math.floor(
 	((TRANSPORT_MESSAGE_LIMIT_BYTES - ENVELOPE_ALLOWANCE_BYTES) * 3) / 4,
 )
 
-const FILE_TOO_LARGE_MESSAGE = (size: number) =>
-	`This file is ${formatFileSize(size)}. The maximum upload size is ${formatFileSize(MAX_UPLOAD_BYTES)} — please choose a smaller file.`
+function fileTooLargeMessage(size: number): string {
+	return `This file is ${formatFileSize(size)}. The maximum upload size is ${formatFileSize(MAX_UPLOAD_BYTES)} — please choose a smaller file.`
+}
 
 // The transport-level 413 surfaces as an opaque error string; translate it
 // so the user sees the size limit instead of a generic failure.
 function friendlyUploadError(raw: string, fileSize: number): string {
 	if (/413|too large|payload/i.test(raw)) {
-		return FILE_TOO_LARGE_MESSAGE(fileSize)
+		return fileTooLargeMessage(fileSize)
 	}
 	return raw
 }
@@ -61,13 +62,13 @@ export function Upload({ activeTag, writableTags, onAdvance, onError }: Props) {
 	)
 	const [uploading, setUploading] = useState(false)
 
-	const handleFileSelect = (selected: File) => {
+	function handleFileSelect(selected: File) {
 		if (selected.size > MAX_UPLOAD_BYTES) {
 			log(
 				"warning",
 				`[upload] rejected oversized file: ${selected.name} (${selected.size}B > ${MAX_UPLOAD_BYTES}B)`,
 			)
-			setFileError(FILE_TOO_LARGE_MESSAGE(selected.size))
+			setFileError(fileTooLargeMessage(selected.size))
 			setFile(null)
 			return
 		}


### PR DESCRIPTION
## Summary
- `fetch-graph-data` succeeded but the widget showed "Received unrecognized response from server. Try again." The tool returned the raw `DocumentsApiResponse` as `structuredContent`, but the widget dispatches on the `view` discriminant of `ViewMessage` and treats anything else as unrecognized.
- The tool now returns a proper `view: "graph"` message (documents, totalCount, containerTag), so the widget renders the memory graph, matching the behavior of `memory-graph`. The text content reports page/limit pagination info.

Stacked on #1193 -> #1192 -> #1189 -> #1120.

## Test plan
- [ ] `fetch-graph-data` invoked by the model renders the graph view instead of "Received unrecognized response from server"
- [ ] `fetch-graph-data` with `page`/`limit` still returns paginated data in the text content