### PR TITLE
perf(lib): hoist customAlphabet factory in generateId

### DIFF
--- a/packages/lib/generate-id.ts
+++ b/packages/lib/generate-id.ts
@@ -1,6 +1,7 @@
 import { customAlphabet } from "nanoid"
 
-export const generateId = () =>
-	customAlphabet("123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz")(
-		22,
-	)
+const generate = customAlphabet(
+	"123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz",
+)
+
+export const generateId = () => generate(22)


### PR DESCRIPTION
## What & why

`generateId` calls `customAlphabet(alphabet)` on every invocation, which rebuilds
the nanoid generator (re-parsing the alphabet and recomputing its internal
mask/step) on each call. The factory only needs to be created once.

This hoists the `customAlphabet(...)` call to module scope so the generator is
built a single time and reused. Purely an optimization.

## Behavior

No behavioral change. The alphabet and ID length (22) are identical, so generated
IDs keep the exact same format and distribution.

## Before
​```ts
export const generateId = () =>
  customAlphabet("...")(22)
​```

## After
​```ts
const generate = customAlphabet("...")
export const generateId = () => generate(22)
​```

## Testing

`bun run format-lint` and `bun run check-types` pass for `packages/lib`
(pre-existing type errors in `@supermemory/tools` are unrelated to this change).

---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/a2f0c806-707b-4646-a629-0afe27d6dbaa)
- Requested by: Unknown
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
