### PR TITLE
fix(web): bypass auth proxy for local dev

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,16 +36,7 @@ Before you begin, ensure you have the following installed:
    # You'll need to add your API keys and database URLs
    ```
 
-4. **Change proxy for local development**
-
-   Add this in your `proxy.ts`(apps/web) before retrieving the cookie (`getSessionCookie(request)`):
-
-   ```ts
-   if (url.hostname === "localhost") {
-     return NextResponse.next();
-   }
-
-5. **Start the Development Server**
+4. **Start the Development Server**
 
    ```bash
    bun run dev:local

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -2,6 +2,8 @@ import { getSessionCookie } from "better-auth/cookies"
 import { NextResponse } from "next/server"
 import { getPublicRequestUrl } from "@/lib/url-helpers"
 
+const LOCAL_DEV_HOSTS = new Set(["localhost", "127.0.0.1", "::1"])
+
 function getAuthSessionCookie(request: Request): string | null {
 	return (
 		getSessionCookie(request) ??
@@ -15,6 +17,11 @@ export default async function proxy(request: Request) {
 
 	console.debug("[PROXY] Path:", url.pathname)
 	console.debug("[PROXY] Method:", request.method)
+
+	if (LOCAL_DEV_HOSTS.has(url.hostname)) {
+		console.debug("[PROXY] Local dev host, allowing access")
+		return NextResponse.next()
+	}
 
 	const sessionCookie = getAuthSessionCookie(request)
 	console.debug("[PROXY] Session cookie exists:", !!sessionCookie)

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -18,7 +18,14 @@ export default async function proxy(request: Request) {
 	console.debug("[PROXY] Path:", url.pathname)
 	console.debug("[PROXY] Method:", request.method)
 
-	if (LOCAL_DEV_HOSTS.has(url.hostname)) {
+	// Development builds only: getPublicRequestUrl trusts x-forwarded-host, so
+	// a hostname check alone could be spoofed in production to skip the /api
+	// 401 gate below. NODE_ENV is inlined at build time, making this dead code
+	// in production bundles.
+	if (
+		process.env.NODE_ENV === "development" &&
+		LOCAL_DEV_HOSTS.has(url.hostname)
+	) {
 		console.debug("[PROXY] Local dev host, allowing access")
 		return NextResponse.next()
 	}


### PR DESCRIPTION
Description
  This removes a manual setup step for OSS contributors by making the web middleware
  automatically allow plain localhost development.

  Previously, CONTRIBUTING.md instructed contributors to manually edit the web proxy/middleware
  before running bun run dev:local. Without that edit, local requests could be redirected
  through the auth proxy instead of reaching the local app directly.

  Changes

  - Add a local-dev host bypass in apps/web/middleware.ts
      - localhost
      - 127.0.0.1
      - ::1

  - Run the bypass before reading Better Auth session cookies
  - Remove the obsolete manual proxy-edit step from CONTRIBUTING.md

  Why
  bun run dev:local should work without contributors modifying tracked source files. This keeps
  local setup simpler and avoids accidental dirty worktrees.

  Testing

  - bunx biome check CONTRIBUTING.md apps/web/middleware.ts

---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/325a3f70-5370-43ea-830f-c05a917a5c7f)
- Requested by: Unknown
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
