### PR TITLE
fix(tools): reject conflicting container config

### DIFF
--- a/packages/tools/src/tools-shared.test.ts
+++ b/packages/tools/src/tools-shared.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest"
+import { getContainerTags } from "./tools-shared"
+
+describe("getContainerTags", () => {
+	it("uses the default project when no config is provided", () => {
+		expect(getContainerTags()).toEqual(["sm_project_default"])
+	})
+
+	it("converts projectId into a project container tag", () => {
+		expect(getContainerTags({ projectId: "abc" })).toEqual(["sm_project_abc"])
+	})
+
+	it("uses explicit container tags", () => {
+		expect(getContainerTags({ containerTags: ["tag-a", "tag-b"] })).toEqual([
+			"tag-a",
+			"tag-b",
+		])
+	})
+
+	it("rejects config with both projectId and containerTags", () => {
+		expect(() =>
+			getContainerTags({
+				projectId: "abc",
+				containerTags: ["tag-a"],
+			}),
+		).toThrow("either projectId or containerTags")
+	})
+})

--- a/packages/tools/src/tools-shared.ts
+++ b/packages/tools/src/tools-shared.ts
@@ -63,6 +63,11 @@ export function getContainerTags(config?: {
 	projectId?: string
 	containerTags?: string[]
 }): string[] {
+	if (config?.projectId !== undefined && config.containerTags !== undefined) {
+		throw new Error(
+			"Supermemory tools config accepts either projectId or containerTags, not both.",
+		)
+	}
 	if (config?.projectId) {
 		return [`${CONTAINER_TAG_CONSTANTS.projectPrefix}${config.projectId}`]
 	}


### PR DESCRIPTION
## Description

  This PR adds runtime validation for @supermemory/tools container scoping configuration.

  SupermemoryToolsConfig already documents projectId and containerTags as mutually exclusive,
  but the implementation did not enforce that. When both were provided, getContainerTags()
  silently preferred projectId and ignored containerTags.

  ## Problem

  Before this change:

  supermemoryTools(apiKey, {
    projectId: "abc",
    containerTags: ["user_123"],
  })

  silently resolved to:

  ["sm_project_abc"]

  The explicit containerTags value was ignored, which could cause memory/search operations to
  run against an unexpected scope.

  ## Changes

  - Add a runtime guard in getContainerTags()
  - Throw a clear error when both projectId and containerTags are provided
  - Add focused tests for:
      - default container tag behavior
      - projectId conversion to sm_project_${id}
      - explicit containerTags
      - conflicting projectId + containerTags

  ## Why This Matters

  This makes runtime behavior match the public config contract and prevents accidental use of
  the wrong memory container.

  ## Files Changed

  - packages/tools/src/tools-shared.ts
  - packages/tools/src/tools-shared.test.ts

  ## Testing

  Passed:

  bun run --cwd packages/tools test src/tools-shared.test.ts
  bunx biome check packages/tools/src/tools-shared.ts packages/tools/src/tools-shared.test.ts

  Also ran:

  bun run --cwd packages/tools check-types

  That command currently fails on existing unrelated package-wide TypeScript errors outside this
  change.

---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/f3645b76-2cea-411f-ba77-1bd1ccc74d32)
- Requested by: Unknown
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
