### PR TITLE
fix(extension): scope related memory search

### DIFF
--- a/apps/browser-extension/entrypoints/background.ts
+++ b/apps/browser-extension/entrypoints/background.ts
@@ -148,7 +148,17 @@ export default defineBackground(() => {
 		eventSource: string,
 	): Promise<{ success: boolean; data?: unknown; error?: string }> => {
 		try {
-			const responseData = await searchMemories(data)
+			let containerTag: string = CONTAINER_TAGS.DEFAULT_PROJECT
+			try {
+				const defaultProject = await getDefaultProject()
+				if (defaultProject?.containerTag) {
+					containerTag = defaultProject.containerTag
+				}
+			} catch (error) {
+				console.warn("Failed to get default project, using fallback:", error)
+			}
+
+			const responseData = await searchMemories(data, containerTag)
 			const response = responseData as {
 				results?: Array<{ memory?: string }>
 			}

--- a/apps/browser-extension/tsconfig.json
+++ b/apps/browser-extension/tsconfig.json
@@ -4,5 +4,6 @@
 		"allowImportingTsExtensions": true,
 		"jsx": "react-jsx",
 		"types": ["chrome"]
-	}
+	},
+	"exclude": ["**/*.test.ts"]
 }

--- a/apps/browser-extension/utils/api.ts
+++ b/apps/browser-extension/utils/api.ts
@@ -3,6 +3,7 @@
  */
 import { API_ENDPOINTS } from "./constants"
 import { bearerToken, defaultProject, userData } from "./storage"
+import { buildSearchMemoriesBody } from "./search-request"
 import {
 	AuthenticationError,
 	type MemoryPayload,
@@ -145,14 +146,14 @@ export async function saveMemory(payload: MemoryPayload): Promise<unknown> {
 /**
  * Search memories using Supermemory API
  */
-export async function searchMemories(query: string): Promise<unknown> {
+export async function searchMemories(
+	query: string,
+	containerTag?: string,
+): Promise<unknown> {
 	try {
 		const response = await makeAuthenticatedRequest<unknown>("/v4/search", {
 			method: "POST",
-			body: JSON.stringify({
-				q: query,
-				include: { relatedMemories: true },
-			}),
+			body: JSON.stringify(buildSearchMemoriesBody(query, containerTag)),
 		})
 		return response
 	} catch (error) {

--- a/apps/browser-extension/utils/search-request.test.ts
+++ b/apps/browser-extension/utils/search-request.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "bun:test"
+import { buildSearchMemoriesBody } from "./search-request"
+
+describe("buildSearchMemoriesBody", () => {
+	it("builds the default related-memory search body", () => {
+		expect(buildSearchMemoriesBody("deploy notes")).toEqual({
+			q: "deploy notes",
+			include: { relatedMemories: true },
+		})
+	})
+
+	it("includes the container tag when provided", () => {
+		expect(buildSearchMemoriesBody("deploy notes", "sm_project_docs")).toEqual({
+			q: "deploy notes",
+			include: { relatedMemories: true },
+			containerTag: "sm_project_docs",
+		})
+	})
+})

--- a/apps/browser-extension/utils/search-request.ts
+++ b/apps/browser-extension/utils/search-request.ts
@@ -1,0 +1,14 @@
+export function buildSearchMemoriesBody(
+	query: string,
+	containerTag?: string,
+): {
+	q: string
+	include: { relatedMemories: boolean }
+	containerTag?: string
+} {
+	return {
+		q: query,
+		include: { relatedMemories: true },
+		...(containerTag ? { containerTag } : {}),
+	}
+}


### PR DESCRIPTION
## Description

  This PR scopes the browser extension’s related-memory search to the user’s selected/default
  project.

  The extension already saves memories into the configured default project, but the related-
  memory search flow did not use that same project scope. As a result, when users clicked the
  extension memory button inside supported AI tools, the extension searched across all memories
  instead of only the selected/default project.

  ## Problem

  Memory saves already use the stored default project:

  const defaultProject = await getDefaultProject()
  containerTag = defaultProject?.containerTag ?? "sm_project_default"

  But related-memory search called:

  searchMemories(data)

  which sent a /v4/search request without containerTag.

  That could return unrelated memories from other spaces/projects, even when the user had
  selected a default project in the extension.

  ## Changes

  - Scope related-memory search in entrypoints/background.ts
      - Reads the stored default project
      - Uses its containerTag
      - Falls back to sm_project_default if no project is available

  - Update searchMemories() to accept an optional containerTag
  - Add a small pure helper to build the /v4/search request body
  - Add focused tests for scoped and unscoped request bodies
  - Exclude *.test.ts files from the browser extension production TypeScript compile

  ## Why This Matters

  This makes search behavior consistent with save behavior.

  If a user configures the extension to save memories into a specific project, related-memory
  retrieval should use that same scope. Otherwise, injected memories can come from unrelated
  projects and reduce relevance or expose context the user did not expect in that workflow.

  ## Files Changed

  - apps/browser-extension/entrypoints/background.ts
  - apps/browser-extension/utils/api.ts
  - apps/browser-extension/utils/search-request.ts
  - apps/browser-extension/utils/search-request.test.ts
  - apps/browser-extension/tsconfig.json

  ## Testing

  Passed:

  bun test apps/browser-extension/utils/search-request.test.ts
  bunx biome check apps/browser-extension/utils/api.ts apps/browser-extension/utils/search-
  request.ts apps/browser-extension/utils/search-request.test.ts apps/browser-extension/
  entrypoints/background.ts apps/browser-extension/tsconfig.json
  bun run --cwd apps/browser-extension compile
