### PR TITLE
test(web): cover helper edge cases

### DIFF
--- a/apps/web/lib/chat-memory-tools.test.ts
+++ b/apps/web/lib/chat-memory-tools.test.ts
@@ -5,6 +5,7 @@ import {
 	extractDocumentIdsFromMemoryOutput,
 	extractMemoryToolOutputs,
 	getDocumentSourceUrl,
+	MAX_INLINE_GRAPH_DOCUMENT_IDS,
 	mapDocumentsByKnownIds,
 } from "./chat-memory-tools"
 
@@ -79,6 +80,23 @@ describe("chat memory tool citation mapping", () => {
 		expect(index.has("ignored")).toBe(false)
 	})
 
+	it("ignores unsafe citation ids when building citation links", () => {
+		const index = buildCitationIndex([
+			{
+				output: {
+					results: [
+						{
+							citationId: "bad/id",
+							document: { id: "docA" },
+						},
+					],
+				},
+			},
+		])
+
+		expect(index.has("bad/id")).toBe(false)
+	})
+
 	it("extracts graph highlight document ids from memory outputs", () => {
 		const [output] = extractMemoryToolOutputs(assistantMessage)
 
@@ -88,6 +106,20 @@ describe("chat memory tool citation mapping", () => {
 		expect(
 			extractHighlightDocumentIdsFromMessages([assistantMessage as never]),
 		).toEqual(["topDoc", "docA", "customA"])
+	})
+
+	it("dedupes and caps graph highlight document ids", () => {
+		const documentIds = Array.from(
+			{ length: MAX_INLINE_GRAPH_DOCUMENT_IDS + 5 },
+			(_, index) => `doc-${index}`,
+		)
+
+		expect(
+			extractDocumentIdsFromMemoryOutput({
+				documentIds: ["doc-0", ...documentIds],
+				results: [{ id: "doc-1", documentIds: ["doc-2"] }],
+			}),
+		).toEqual(documentIds.slice(0, MAX_INLINE_GRAPH_DOCUMENT_IDS))
 	})
 
 	it("keeps graph highlights for legacy memory tool states and ids", () => {

--- a/apps/web/lib/url-helpers.test.ts
+++ b/apps/web/lib/url-helpers.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from "bun:test"
+import {
+	collectValidUrls,
+	extractUrls,
+	getPublicRequestUrl,
+	resolveAuthRedirectUrl,
+} from "./url-helpers"
+
+describe("url helpers", () => {
+	it("reconstructs public request URLs from forwarded headers", () => {
+		const request = new Request("http://localhost:3000/settings?tab=billing", {
+			headers: {
+				"x-forwarded-host": "app.dev.supermemory.ai",
+				"x-forwarded-proto": "https",
+			},
+		})
+
+		expect(getPublicRequestUrl(request).toString()).toBe(
+			"https://app.dev.supermemory.ai/settings?tab=billing",
+		)
+	})
+
+	it("maps localhost auth redirects back to the current public origin", () => {
+		const resolved = resolveAuthRedirectUrl(
+			"http://localhost:3000/settings?tab=billing",
+			"https://app.dev.supermemory.ai",
+		)
+
+		expect(resolved.toString()).toBe(
+			"https://app.dev.supermemory.ai/settings?tab=billing",
+		)
+	})
+
+	it("extracts distinct URLs from markdown, angle links, and bare links", () => {
+		const result = extractUrls(
+			"Read [docs](https://example.com/docs), <https://example.com/docs>, and example.org/path.",
+		)
+
+		expect(result.urls).toEqual([
+			"https://example.com/docs",
+			"https://example.org/path",
+		])
+		expect(result.duplicates).toBe(1)
+	})
+
+	it("keeps LinkedIn profile URLs and excludes X/Twitter links", () => {
+		expect(
+			collectValidUrls("linkedin.com/in/sam", [
+				"https://x.com/sam",
+				"example.com",
+			]),
+		).toEqual(["https://linkedin.com/in/sam", "https://example.com"])
+	})
+})


### PR DESCRIPTION
## Description

  This PR adds focused unit coverage for existing web helper behavior.

  The covered helpers are used in auth redirect handling, URL extraction, source citation
  mapping, and inline memory graph highlighting. These paths are small but important because
  they handle user-provided URLs, forwarded request metadata, and model/tool-generated citation
  IDs.

  No production code is changed in this PR.

  ## What This Covers

  ### URL helpers

  Adds tests for apps/web/lib/url-helpers.ts:

  - Reconstructing public request URLs from forwarded proxy headers
  - Mapping localhost auth redirects back to the current public origin
  - Extracting distinct URLs from markdown links, angle-wrapped links, and bare links
  - Counting duplicate URLs
  - Keeping valid LinkedIn profile URLs
  - Excluding X/Twitter links from collected profile/link URLs

  ### Chat memory tool helpers

  Adds coverage for apps/web/lib/chat-memory-tools.ts:

  - Unsafe citation IDs are ignored when building citation link targets
  - Graph highlight document IDs are deduped
  - Graph highlight document IDs are capped at MAX_INLINE_GRAPH_DOCUMENT_IDS

  ## Why This Matters

  These helpers sit on user-facing flows:

  - Login/auth redirect behavior
  - Onboarding/profile URL handling
  - Nova source citations
  - Inline memory graph highlights from chat tool results

  The added tests make these behaviors safer to change later and reduce the chance of
  regressions in edge cases involving forwarded URLs, malformed source IDs, duplicated document
  IDs, or oversized graph highlight payloads.

  ## Files Changed

  - apps/web/lib/url-helpers.test.ts
  - apps/web/lib/chat-memory-tools.test.ts

  ## Testing

  Passed:

  bun test apps/web/lib/url-helpers.test.ts apps/web/lib/chat-memory-tools.test.ts apps/web/lib/
  source-annotations.test.ts
  bunx biome check apps/web/lib/url-helpers.test.ts apps/web/lib/chat-memory-tools.test.ts

  ## Notes

  This is a test-only change. No runtime behavior is modified.

---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/a9996585-edea-4b13-8a95-c9123daadab9)
- Requested by: Unknown
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
