### PR TITLE
ci: set least-privilege GITHUB_TOKEN for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,9 @@ name: CI - Type Check, Format & Lint
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   quality-checks:
     name: Quality Checks


### PR DESCRIPTION
## Problem

`.github/workflows/ci.yml` does not declare a `permissions:` block. When a workflow omits this, the injected `GITHUB_TOKEN` falls back to the repository or organization default, which is often broad read/write. That gives the CI job far more access than it needs. If any step were compromised (for example through a malicious dependency), the token could be used to push code, tamper with releases, or move laterally within the repo.

## Solution

Add a top-level read-only default:

```yaml
permissions:
  contents: read
```

The `quality-checks` job only reads the repository: it checks out the code, installs dependencies, runs the TypeScript type checker, and runs Biome. None of these steps write to the repo, so `contents: read` is sufficient and removes the write blast radius.

This follows the same least-privilege pattern already used by the publish workflows in this repo (`contents: read` + `id-token: write`).

## Testing

- Validated the workflow YAML parses correctly.
- Confirmed the job steps only perform read operations, so no write scope is required.

Closes #1218
