### PR TITLE
ci: pin workflow actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,12 +9,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
           bun-version: 1.3.6
 

--- a/.github/workflows/claude-auto-fix-ci.yml
+++ b/.github/workflows/claude-auto-fix-ci.yml
@@ -21,14 +21,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
       - name: Install dependencies
         run: bun install
@@ -40,7 +40,7 @@ jobs:
 
       - name: Get CI failure details
         id: failure_details
-        uses: actions/github-script@v7
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
         with:
           script: |
             const run = await github.rest.actions.getWorkflowRun({
@@ -63,7 +63,7 @@ jobs:
             };
 
       - name: Fix CI failures with Claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@536f2c32a39763739000b0e1ac69ca2647d97ce9 # v1.0.170
         with:
           prompt: |
             Failed CI Run: ${{ fromJSON(steps.failure_details.outputs.result).runUrl }}

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -21,12 +21,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v5
+        uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5.0.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code Review
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@536f2c32a39763739000b0e1ac69ca2647d97ce9 # v1.0.170
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -26,13 +26,13 @@ jobs:
       actions: read
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 1
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@v1
+        uses: anthropics/claude-code-action@536f2c32a39763739000b0e1ac69ca2647d97ce9 # v1.0.170
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 

--- a/.github/workflows/publish-agent-framework-python.yml
+++ b/.github/workflows/publish-agent-framework-python.yml
@@ -18,10 +18,10 @@ jobs:
                 working-directory: ./packages/agent-framework-python
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
             - name: Setup Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
               with:
                 python-version: "3.12"
 
@@ -32,6 +32,6 @@ jobs:
               run: python -m build
 
             - name: Publish to PyPI
-              uses: pypa/gh-action-pypi-publish@release/v1
+              uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
               with:
                 packages-dir: packages/agent-framework-python/dist/

--- a/.github/workflows/publish-ai-sdk.yml
+++ b/.github/workflows/publish-ai-sdk.yml
@@ -18,10 +18,10 @@ jobs:
                 working-directory: ./packages/ai-sdk
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
             - name: Setup Node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
                 node-version: '24'
                 registry-url: 'https://registry.npmjs.org'
@@ -30,7 +30,7 @@ jobs:
               run: npm install -g npm@latest
 
             - name: Setup Bun
-              uses: oven-sh/setup-bun@v2
+              uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
             - name: Install dependencies
               run: bun install

--- a/.github/workflows/publish-cartesia-sdk-python.yml
+++ b/.github/workflows/publish-cartesia-sdk-python.yml
@@ -18,10 +18,10 @@ jobs:
                 working-directory: ./packages/cartesia-sdk-python
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
             - name: Setup Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
               with:
                 python-version: "3.12"
 
@@ -32,6 +32,6 @@ jobs:
               run: python -m build
 
             - name: Publish to PyPI
-              uses: pypa/gh-action-pypi-publish@release/v1
+              uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
               with:
                 packages-dir: packages/cartesia-sdk-python/dist/

--- a/.github/workflows/publish-memory-graph.yml
+++ b/.github/workflows/publish-memory-graph.yml
@@ -18,10 +18,10 @@ jobs:
                 working-directory: ./packages/memory-graph
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
             - name: Setup Node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
                 node-version: '24'
                 registry-url: 'https://registry.npmjs.org'
@@ -30,7 +30,7 @@ jobs:
               run: npm install -g npm@latest
 
             - name: Setup Bun
-              uses: oven-sh/setup-bun@v2
+              uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
             - name: Install dependencies
               run: bun install

--- a/.github/workflows/publish-openai-sdk-python.yml
+++ b/.github/workflows/publish-openai-sdk-python.yml
@@ -18,10 +18,10 @@ jobs:
                 working-directory: ./packages/openai-sdk-python
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
             - name: Setup Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
               with:
                 python-version: "3.12"
 
@@ -32,6 +32,6 @@ jobs:
               run: python -m build
 
             - name: Publish to PyPI
-              uses: pypa/gh-action-pypi-publish@release/v1
+              uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
               with:
                 packages-dir: packages/openai-sdk-python/dist/

--- a/.github/workflows/publish-pipecat-sdk-python.yml
+++ b/.github/workflows/publish-pipecat-sdk-python.yml
@@ -18,10 +18,10 @@ jobs:
                 working-directory: ./packages/pipecat-sdk-python
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
             - name: Setup Python
-              uses: actions/setup-python@v5
+              uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
               with:
                 python-version: "3.12"
 
@@ -32,6 +32,6 @@ jobs:
               run: python -m build
 
             - name: Publish to PyPI
-              uses: pypa/gh-action-pypi-publish@release/v1
+              uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0
               with:
                 packages-dir: packages/pipecat-sdk-python/dist/

--- a/.github/workflows/publish-tools.yml
+++ b/.github/workflows/publish-tools.yml
@@ -18,10 +18,10 @@ jobs:
                 working-directory: ./packages/tools
         steps:
             - name: Checkout
-              uses: actions/checkout@v4
+              uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
             - name: Setup Node
-              uses: actions/setup-node@v4
+              uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
                 node-version: '24'
                 registry-url: 'https://registry.npmjs.org'
@@ -30,7 +30,7 @@ jobs:
               run: npm install -g npm@latest
 
             - name: Setup Bun
-              uses: oven-sh/setup-bun@v2
+              uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
 
             - name: Install dependencies
               run: bun install


### PR DESCRIPTION
## Summary

Pins every GitHub Actions reference in `.github/workflows/` to a full 40-character commit SHA, with a trailing version comment so the intended release stays readable and Dependabot can still bump it.

## Problem

All 11 workflow files reference actions by mutable tags (`@v4`, `@v5`, `@v2`, `@v7`, `@v1`) or a moving branch (`pypa/gh-action-pypi-publish@release/v1`). A tag or branch can be repointed upstream, so a compromised or retagged release would run new code in CI with no change on our side. The highest-risk case is the PyPI publish jobs, which run with `id-token: write` for trusted publishing.

## Solution

Replace each tag or branch with the commit SHA of the current release in the same major version, so behavior is unchanged:

| Action | Pinned version |
|--------|----------------|
| `actions/checkout` | v4.3.1 / v5.0.1 |
| `actions/setup-node` | v4.4.0 |
| `actions/setup-python` | v5.6.0 |
| `oven-sh/setup-bun` | v2.2.0 |
| `pypa/gh-action-pypi-publish` | v1.14.0 |
| `actions/github-script` | v7.1.0 |
| `anthropics/claude-code-action` | v1.0.170 |

The version comment on each line keeps the SHAs greppable and lets Dependabot's `github-actions` ecosystem propose future bumps.

## Testing

- Parsed all 11 workflow files with a YAML loader; all valid.
- Confirmed the diff only touches `uses:` lines (31 lines), with no logic changes.

## Related

Closes #1220


---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/5ed5f8f4-ed5a-4d06-bb2b-0b4633b3ad20)
- Requested by: Unknown
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
