### PR TITLE
ci: add concurrency groups to workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,10 @@ name: CI - Type Check, Format & Lint
 on:
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   quality-checks:
     name: Quality Checks

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, ready_for_review, reopened]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     types: [opened, synchronize, ready_for_review, reopened]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   claude-review:
     if: |

--- a/.github/workflows/publish-agent-framework-python.yml
+++ b/.github/workflows/publish-agent-framework-python.yml
@@ -7,6 +7,10 @@ on:
         paths:
             - "packages/agent-framework-python/pyproject.toml"
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: false
+
 jobs:
     publish:
         runs-on: ubuntu-latest

--- a/.github/workflows/publish-ai-sdk.yml
+++ b/.github/workflows/publish-ai-sdk.yml
@@ -7,6 +7,10 @@ on:
         paths: 
             - "packages/ai-sdk/package.json"
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: false
+
 jobs:
     publish:
         runs-on: ubuntu-latest

--- a/.github/workflows/publish-cartesia-sdk-python.yml
+++ b/.github/workflows/publish-cartesia-sdk-python.yml
@@ -7,6 +7,10 @@ on:
         paths:
             - "packages/cartesia-sdk-python/pyproject.toml"
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: false
+
 jobs:
     publish:
         runs-on: ubuntu-latest

--- a/.github/workflows/publish-memory-graph.yml
+++ b/.github/workflows/publish-memory-graph.yml
@@ -7,6 +7,10 @@ on:
         paths: 
             - "packages/memory-graph/package.json"
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: false
+
 jobs:
     publish:
         runs-on: ubuntu-latest

--- a/.github/workflows/publish-openai-sdk-python.yml
+++ b/.github/workflows/publish-openai-sdk-python.yml
@@ -7,6 +7,10 @@ on:
         paths:
             - "packages/openai-sdk-python/pyproject.toml"
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: false
+
 jobs:
     publish:
         runs-on: ubuntu-latest

--- a/.github/workflows/publish-pipecat-sdk-python.yml
+++ b/.github/workflows/publish-pipecat-sdk-python.yml
@@ -7,6 +7,10 @@ on:
         paths:
             - "packages/pipecat-sdk-python/pyproject.toml"
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: false
+
 jobs:
     publish:
         runs-on: ubuntu-latest

--- a/.github/workflows/publish-tools.yml
+++ b/.github/workflows/publish-tools.yml
@@ -7,6 +7,10 @@ on:
         paths: 
             - "packages/tools/package.json"
 
+concurrency:
+    group: ${{ github.workflow }}-${{ github.ref }}
+    cancel-in-progress: false
+
 jobs:
     publish:
         runs-on: ubuntu-latest


### PR DESCRIPTION
## Problem

None of the workflows in `.github/workflows/` define a `concurrency:` group. `ci.yml` and `claude-code-review.yml` both run on every `pull_request` event, so pushing several commits in quick succession starts a fresh run for each push and leaves the earlier runs going in parallel. Those stale runs waste runner minutes and queue capacity without adding any signal.

## Solution

Add `concurrency:` groups keyed by workflow and ref:

- `ci.yml` and `claude-code-review.yml` (PR-triggered): cancel superseded runs when a new commit is pushed to the same PR (`cancel-in-progress: true`). The group key uses `github.head_ref` with a fallback to `github.ref`.
- The six `publish-*.yml` workflows: use a group keyed on `github.ref` but keep `cancel-in-progress: false`, so an in-progress release is never interrupted while still preventing two publishes of the same package from overlapping.

Two workflows are intentionally left unchanged:

- `claude.yml` is comment and issue triggered, where the ref resolves to the default branch. A shared group there would collide across unrelated issues, so it needs a per-issue key handled separately.
- `claude-auto-fix-ci.yml` is already the subject of separate permission-hardening work in #1180, so it is left alone to avoid conflicts.

## Testing

- Validated that all 11 workflow files still parse as YAML after the change.
- Confirmed the PR workflows cancel in progress while the publish workflows do not.

Closes #1222


---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/32eebeac-7102-45b3-b18a-f2d32acb16ed)
- Requested by: Unknown
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
