### PR TITLE
ci: add timeout-minutes to all workflow jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ jobs:
   quality-checks:
     name: Quality Checks
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@v4

--- a/.github/workflows/claude-auto-fix-ci.yml
+++ b/.github/workflows/claude-auto-fix-ci.yml
@@ -19,6 +19,7 @@ jobs:
       github.event.workflow_run.conclusion == 'failure' &&
       github.event.workflow_run.pull_requests[0]
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - name: Checkout code
         uses: actions/checkout@v5

--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,7 @@ jobs:
       github.actor != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -18,6 +18,7 @@ jobs:
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
       (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/publish-agent-framework-python.yml
+++ b/.github/workflows/publish-agent-framework-python.yml
@@ -10,6 +10,7 @@ on:
 jobs:
     publish:
         runs-on: ubuntu-latest
+        timeout-minutes: 15
         permissions:
             contents: read
             id-token: write

--- a/.github/workflows/publish-ai-sdk.yml
+++ b/.github/workflows/publish-ai-sdk.yml
@@ -10,6 +10,7 @@ on:
 jobs:
     publish:
         runs-on: ubuntu-latest
+        timeout-minutes: 15
         permissions: 
             contents: read
             id-token: write

--- a/.github/workflows/publish-cartesia-sdk-python.yml
+++ b/.github/workflows/publish-cartesia-sdk-python.yml
@@ -10,6 +10,7 @@ on:
 jobs:
     publish:
         runs-on: ubuntu-latest
+        timeout-minutes: 15
         permissions:
             contents: read
             id-token: write

--- a/.github/workflows/publish-memory-graph.yml
+++ b/.github/workflows/publish-memory-graph.yml
@@ -10,6 +10,7 @@ on:
 jobs:
     publish:
         runs-on: ubuntu-latest
+        timeout-minutes: 15
         permissions: 
             contents: read
             id-token: write

--- a/.github/workflows/publish-openai-sdk-python.yml
+++ b/.github/workflows/publish-openai-sdk-python.yml
@@ -10,6 +10,7 @@ on:
 jobs:
     publish:
         runs-on: ubuntu-latest
+        timeout-minutes: 15
         permissions:
             contents: read
             id-token: write

--- a/.github/workflows/publish-pipecat-sdk-python.yml
+++ b/.github/workflows/publish-pipecat-sdk-python.yml
@@ -10,6 +10,7 @@ on:
 jobs:
     publish:
         runs-on: ubuntu-latest
+        timeout-minutes: 15
         permissions:
             contents: read
             id-token: write

--- a/.github/workflows/publish-tools.yml
+++ b/.github/workflows/publish-tools.yml
@@ -10,6 +10,7 @@ on:
 jobs:
     publish:
         runs-on: ubuntu-latest
+        timeout-minutes: 15
         permissions: 
             contents: read
             id-token: write


### PR DESCRIPTION
## Problem

None of the jobs in `.github/workflows/` set `timeout-minutes`, so every job inherits GitHub's 6 hour default. If a step hangs (for example a stuck dependency install, or the Claude jobs that run with `--max-turns 15/20`), the runner stays busy until GitHub kills it at the 6 hour mark, which wastes runner capacity.

## Solution

Add an explicit `timeout-minutes` to the single job in each of the 11 workflow files:

- `ci.yml`: 15
- `publish-*.yml` (7 files): 15
- `claude.yml`, `claude-code-review.yml`, `claude-auto-fix-ci.yml`: 30

The values sit comfortably above normal run times, so they only trip on a real hang. This is a config only change and does not alter job behavior otherwise.

## Testing

- Confirmed each workflow has exactly one `timeout-minutes` entry (11 total).
- Validated all 11 workflow files parse as valid YAML.

Closes #1224


---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/6c0ddecd-e4ad-46c7-a426-3fd2c185ca46)
- Requested by: Unknown
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
