### PR TITLE
ci: add Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
## Problem

The repository has no `.github/dependabot.yml`, so GitHub Actions versions are never checked for updates automatically. Action versions drift over time and stale, sometimes vulnerable, versions linger with no signal to maintainers.

This also pairs with the SHA-pinning work in #1219: once actions are pinned to commit SHAs, Dependabot is what keeps those pins current instead of them going stale.

## Solution

Add a focused `.github/dependabot.yml` scoped to the `github-actions` ecosystem only:

- Runs weekly.
- Groups all action bumps into a single PR to keep noise low.
- Uses the `ci` commit prefix to match the existing workflow naming.

This is intentionally limited to GitHub Actions. It does not touch the npm/bun dependency graph, so it adds no day-to-day dependency churn.

## Testing performed

- Validated the file parses as YAML and matches the Dependabot v2 schema keys.
- Confirmed no `.github/dependabot.yml` currently exists on `main`.

Closes #1226


---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/bbae0a43-1c9b-4f77-adf0-bab70cf308c3)
- Requested by: Unknown
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
