### PR TITLE
ci: pass workflow_run id to github-script via env

### DIFF
--- a/.github/workflows/claude-auto-fix-ci.yml
+++ b/.github/workflows/claude-auto-fix-ci.yml
@@ -41,18 +41,22 @@ jobs:
       - name: Get CI failure details
         id: failure_details
         uses: actions/github-script@v7
+        env:
+          RUN_ID: ${{ github.event.workflow_run.id }}
         with:
           script: |
+            const runId = Number(process.env.RUN_ID);
+
             const run = await github.rest.actions.getWorkflowRun({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              run_id: ${{ github.event.workflow_run.id }}
+              run_id: runId
             });
 
             const jobs = await github.rest.actions.listJobsForWorkflowRun({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              run_id: ${{ github.event.workflow_run.id }}
+              run_id: runId
             });
 
             const failedJobs = jobs.data.jobs.filter(job => job.conclusion === 'failure');


### PR DESCRIPTION
## Summary

The `Get CI failure details` step in `claude-auto-fix-ci.yml` interpolates `${{ github.event.workflow_run.id }}` directly into the `actions/github-script` body. This change passes the value through the step `env` and reads it with `Number(process.env.RUN_ID)` inside the script.

## Problem

Interpolating a `${{ }}` expression straight into a `github-script` body splices workflow-context data into the script source before the script runs. Here `workflow_run.id` is a GitHub-generated integer, so there is no injection risk today, but the recommended pattern is to pass values through `env` and read them from `process.env`. Following that pattern keeps the workflow consistent and avoids setting a precedent that could later be copied for values that are attacker-controlled.

## Solution

- Add `RUN_ID: ${{ github.event.workflow_run.id }}` to the step `env`.
- Read `const runId = Number(process.env.RUN_ID)` once and reuse it for both `getWorkflowRun` and `listJobsForWorkflowRun`.

Behavior is unchanged: `runId` resolves to the same numeric run id that was interpolated before.

## Testing

- Confirmed the workflow still parses as YAML:

```bash
python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude-auto-fix-ci.yml'))"
```

Closes #1228


---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/4793d549-bda8-4cd8-bcf8-71eb872c6fdb)
- Requested by: Unknown
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
