### PR TITLE
ci: gate @claude workflow triggers by author association

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -13,10 +13,34 @@ on:
 jobs:
   claude:
     if: |
-      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
-      (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (
+        github.event_name == 'issue_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'COLLABORATOR')
+      ) ||
+      (
+        github.event_name == 'pull_request_review_comment' &&
+        contains(github.event.comment.body, '@claude') &&
+        (github.event.comment.author_association == 'OWNER' ||
+         github.event.comment.author_association == 'MEMBER' ||
+         github.event.comment.author_association == 'COLLABORATOR')
+      ) ||
+      (
+        github.event_name == 'pull_request_review' &&
+        contains(github.event.review.body, '@claude') &&
+        (github.event.review.author_association == 'OWNER' ||
+         github.event.review.author_association == 'MEMBER' ||
+         github.event.review.author_association == 'COLLABORATOR')
+      ) ||
+      (
+        github.event_name == 'issues' &&
+        (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')) &&
+        (github.event.issue.author_association == 'OWNER' ||
+         github.event.issue.author_association == 'MEMBER' ||
+         github.event.issue.author_association == 'COLLABORATOR')
+      )
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Problem

The `claude` job in `.github/workflows/claude.yml` is gated only by whether the comment, review, or issue body contains `@claude`:

```yaml
if: |
  (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
  ...
```

The `issue_comment` and `issues` events run in the context of the default branch and have access to repository secrets. Because there is no author check, any user, including outside contributors, can post `@claude` on an issue or PR and start a run that loads `SUPERMEMORY_API_KEY` into the MCP config. Permissions on the job are read-only, so this is not a write-access hole, but it does let anyone consume the API key and runner minutes.

## Solution

Add an `author_association` check alongside the existing `@claude` match, so the run only starts when the actor is an `OWNER`, `MEMBER`, or `COLLABORATOR`.

Each event is paired with its correct association field:

- `issue_comment` / `pull_request_review_comment` use `github.event.comment.author_association`
- `pull_request_review` uses `github.event.review.author_association`
- `issues` uses `github.event.issue.author_association`

This matches the gating pattern shown in the `anthropics/claude-code-action` docs and keeps the change scoped to the trigger condition. No permissions, steps, or model config are touched.

## Testing

- Validated the workflow YAML parses cleanly.
- Reviewed each branch of the `if:` expression to confirm the association field matches the event payload it reads from, so legitimate maintainer triggers on all four event types still fire while non-collaborator triggers are dropped.

Closes #1230


---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/741215fd-6fda-46a5-8e94-f493ac0d4005)
- Requested by: Unknown
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
