### PR TITLE
ci: skip Claude review on fork PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -6,8 +6,12 @@ on:
 
 jobs:
   claude-review:
+    # Fork PRs run with a read-only token and no secrets/OIDC id-token, so the
+    # Claude action can never authenticate there and the job always fails. Skip
+    # it for forks so those PRs report a clean skipped check instead of a red X.
     if: |
       github.event.pull_request.draft == false &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
       github.actor != 'graphite-app[bot]' &&
       github.actor != 'dependabot[bot]'
 


### PR DESCRIPTION
## Problem

The Claude Code Review workflow triggers on `pull_request`. For PRs opened from a fork, GitHub runs `pull_request` workflows with a read-only `GITHUB_TOKEN`, no repository secrets, and no OIDC `id-token`, regardless of the `permissions:` block. The `anthropics/claude-code-action` step needs the `CLAUDE_CODE_OAUTH_TOKEN` secret and an OIDC token, so on every fork PR the job cannot authenticate and fails with a red X.

Example failing run on a fork PR (#1221): https://github.com/supermemoryai/supermemory/actions/runs/29127250133/job/86475344910?pr=1221

## Solution

Gate the `claude-review` job on the PR head repository matching the base repository:

```yaml
github.event.pull_request.head.repo.full_name == github.repository
```

Fork PRs now report a clean skipped check instead of a failed one. Internal branches are unchanged and keep receiving reviews.

This intentionally avoids switching the trigger to `pull_request_target`, which would grant secrets and write access in the base-repo context and is a well-known security footgun when handling untrusted fork code.

## Testing

- Confirmed the workflow YAML still parses.
- Same-repo PRs: the condition is true, so the job runs exactly as before.
- Fork PRs: the condition is false, so the job is skipped and no longer posts a failing check.

Closes #1232


---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/cb3eda64-847f-4e71-b62d-c2bce163d77c)
- Requested by: Unknown
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.
