### PR TITLE
chore(tools): bump @supermemory/tools to 2.1.0

### DIFF
--- a/packages/tools/package.json
+++ b/packages/tools/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@supermemory/tools",
   "type": "module",
-  "version": "2.0.0",
+  "version": "2.1.0",
   "description": "Memory tools for AI SDK, OpenAI, Voltagent and Mastra with supermemory",
   "scripts": {
     "build": "tsdown",


### PR DESCRIPTION
Releases #1186 (SDK call mismatches that broke five tools) to npm.

Minor bump rather than patch because the public tool parameter schemas changed: `documentList` now takes `page` instead of the never-functional `offset`/`status`.

Merging this triggers `publish-tools.yml` (publishes to npm on `packages/tools/package.json` changes on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release-only version bump with no code changes in this PR; behavioral fixes and schema changes were validated in the prior PR.
> 
> **Overview**
> Bumps **`@supermemory/tools`** from **2.0.0** to **2.1.0** in `packages/tools/package.json` so the npm release can ship fixes from #1186 (SDK call mismatches that broke five tools).
> 
> The minor version reflects a **public schema change**: `documentList` now accepts **`page`** instead of the non-functional **`offset`** / **`status`** parameters. Merging to main should run **`publish-tools.yml`** and publish when this manifest changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 060c5eff4ce2d3e1bf7c7238dcc400852cf828ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->