### PR TITLE
fix(openai-sdk): cap supermemory to <3.5 so a fresh install imports

### DIFF
--- a/packages/openai-sdk-python/pyproject.toml
+++ b/packages/openai-sdk-python/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 requires-python = ">=3.8.1"
 dependencies = [
     "openai>=1.102.0",
-    "supermemory>=3.1.0",
+    "supermemory>=3.1.0,<3.5.0",
     "typing-extensions>=4.0.0",
     "requests>=2.25.0",
 ]

--- a/packages/openai-sdk-python/pyproject.toml
+++ b/packages/openai-sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "supermemory-openai-sdk"
-version = "1.0.4"
+version = "1.0.5"
 description = "Memory tools for OpenAI function calling with supermemory"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Fixes #1235

A fresh pip install supermemory-openai-sdk pulls the latest supermemory (3.50) and the package fails to import, because supermemory 3.5+ renamed the types it imports (MemoryAddResponse etc) and moved memories.add off client.memories.

The package's uv.lock already pins supermemory 3.4.0, which is what it actually works against, so this just caps the declared dependency to the same 3.4.x line. Confirmed a fresh install with the cap imports fine.

This is the minimal fix to unbreak installs. Happy to instead do the full migration to the newer 3.x API (client.add, AddResponse, etc.) if you'd rather go that route, just say the word