### PR TITLE
docs: document pinned install for supermemory-server

### DIFF
--- a/apps/docs/self-hosting/quickstart.mdx
+++ b/apps/docs/self-hosting/quickstart.mdx
@@ -27,6 +27,24 @@ bunx supermemory local
 
 The installer detects your OS and architecture, downloads the right binary, verifies it, and (when run interactively) prompts you for an LLM API key. Supported platforms: macOS (Apple Silicon & Intel), Linux (x64 & arm64).
 
+### Pin or change versions
+
+Pass an explicit version to install (or roll back to) a specific release instead of `latest`:
+
+```bash
+curl -fsSL https://supermemory.ai/install | bash -s -- 0.0.3
+```
+
+Release tags are `server-v<version>` on [GitHub Releases](https://github.com/supermemoryai/supermemory/releases) (for example [`server-v0.0.3`](https://github.com/supermemoryai/supermemory/releases/tag/server-v0.0.3)).
+
+To move to the newest release later:
+
+```bash
+supermemory-server upgrade
+```
+
+The binary may also print an “update available” nag on startup. If you intentionally pinned an older version (for example while debugging a regression), you can ignore that message until you are ready to upgrade.
+
 ## Run
 
 ```bash

--- a/apps/docs/self-hosting/quickstart.mdx
+++ b/apps/docs/self-hosting/quickstart.mdx
@@ -35,6 +35,10 @@ Pass an explicit version to install (or roll back to) a specific release instead
 curl -fsSL https://supermemory.ai/install | bash -s -- 0.0.3
 ```
 
+<Warning>
+Before rolling back, back up your [data directory](#where-things-live). The installer replaces the binary, but an older server may not understand data or schema changes made by a newer release.
+</Warning>
+
 Release tags are `server-v<version>` on [GitHub Releases](https://github.com/supermemoryai/supermemory/releases) (for example [`server-v0.0.3`](https://github.com/supermemoryai/supermemory/releases/tag/server-v0.0.3)).
 
 To move to the newest release later:
@@ -43,7 +47,7 @@ To move to the newest release later:
 supermemory-server upgrade
 ```
 
-The binary may also print an “update available” nag on startup. If you intentionally pinned an older version (for example while debugging a regression), you can ignore that message until you are ready to upgrade.
+The binary may also print an “update available” notification on startup. If you intentionally pinned an older version (for example while debugging a regression), you can ignore that message until you are ready to upgrade.
 
 ## Run
 


### PR DESCRIPTION
## What

Documents the self-hosted installer's existing version-pin argument in the Quickstart.

## Why

`install.sh` already accepts an explicit version (`$1`, e.g. `0.0.3`), but the Quickstart only showed `curl … | bash` (latest). After hitting a v0.0.5 auth regression (#1237), the pin/rollback path was the recovery route — it should be discoverable from the docs. The binary also nags “update available” on startup; when you intentionally pin, that message is safe to ignore.

## Changes

- New “Pin or change versions” subsection under Install in `apps/docs/self-hosting/quickstart.mdx`
- Example: `curl -fsSL https://supermemory.ai/install | bash -s -- 0.0.3`
- Link to GitHub release tags (`server-v<version>`)
- Note `supermemory-server upgrade` and the startup update nag

## Breaking changes

None.

## Related

- Closes nothing (docs only)
- Context: #1237

## Test plan

- [ ] Preview Self-Hosting → Quickstart; confirm “Pin or change versions” renders
- [ ] Confirm example matches `install.sh` (`TARGET="${1:-latest}"`)