### PR TITLE
fix(middleware): update deduplication logic for profile memories in query mode

### DIFF
--- a/packages/tools/src/openai/middleware.ts
+++ b/packages/tools/src/openai/middleware.ts
@@ -1,7 +1,7 @@
 import type OpenAI from "openai"
 import Supermemory from "supermemory"
 import { addConversation } from "../conversations-client"
-import { deduplicateMemories } from "../tools-shared"
+import { deduplicateMemoriesForMode } from "../tools-shared"
 import { createLogger, type Logger } from "../vercel/logger"
 import { convertProfileToMarkdown } from "../vercel/util"
 
@@ -184,7 +184,7 @@ const addSystemPrompt = async (
 		mode,
 	})
 
-	const deduplicated = deduplicateMemories({
+	const deduplicated = deduplicateMemoriesForMode(mode, {
 		static: memoriesResponse.profile.static,
 		dynamic: memoriesResponse.profile.dynamic,
 		searchResults: memoriesResponse.searchResults?.results,
@@ -471,7 +471,7 @@ export function createOpenAIMiddleware(
 			mode,
 		})
 
-		const deduplicated = deduplicateMemories({
+		const deduplicated = deduplicateMemoriesForMode(mode, {
 			static: memoriesResponse.profile.static,
 			dynamic: memoriesResponse.profile.dynamic,
 			searchResults: memoriesResponse.searchResults?.results,

--- a/packages/tools/src/shared/memory-client.test.ts
+++ b/packages/tools/src/shared/memory-client.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { buildMemoriesText } from "./memory-client"
+import { createLogger } from "./logger"
+
+const API_KEY = "sm_test_key"
+const BASE_URL = "https://api.supermemory.ai"
+const CONTAINER_TAG = "user-123"
+
+const logger = createLogger(false)
+
+/** Stubs `/v4/profile` so the injected prompt can be asserted without network access. */
+function mockProfileResponse(body: unknown) {
+	const fetchMock = vi.fn().mockResolvedValue({
+		ok: true,
+		json: async () => body,
+	})
+	vi.stubGlobal("fetch", fetchMock)
+	return fetchMock
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+})
+
+describe("buildMemoriesText", () => {
+	// The profile is not injected in "query" mode. Deduplicating the search
+	// results against it would drop a fact present in both, leaving the model
+	// with nothing.
+	it("injects a search result that also exists in the profile in query mode", async () => {
+		mockProfileResponse({
+			profile: {
+				static: [{ memory: "User is allergic to peanuts" }],
+				dynamic: [],
+			},
+			searchResults: { results: [{ memory: "User is allergic to peanuts" }] },
+		})
+
+		const memories = await buildMemoriesText({
+			containerTag: CONTAINER_TAG,
+			queryText: "what should I avoid eating?",
+			mode: "query",
+			baseUrl: BASE_URL,
+			apiKey: API_KEY,
+			logger,
+		})
+
+		expect(memories).toContain("User is allergic to peanuts")
+	})
+
+	it("does not repeat a profile memory in the search results in full mode", async () => {
+		mockProfileResponse({
+			profile: {
+				static: [{ memory: "User is allergic to peanuts" }],
+				dynamic: [],
+			},
+			searchResults: {
+				results: [
+					{ memory: "User is allergic to peanuts" },
+					{ memory: "User prefers async/await" },
+				],
+			},
+		})
+
+		const memories = await buildMemoriesText({
+			containerTag: CONTAINER_TAG,
+			queryText: "what should I avoid eating?",
+			mode: "full",
+			baseUrl: BASE_URL,
+			apiKey: API_KEY,
+			logger,
+		})
+
+		expect(memories).toContain("## Static Profile")
+		expect(memories).toContain("User prefers async/await")
+		// Present once, under the profile — not duplicated into the search results.
+		expect(memories.match(/User is allergic to peanuts/g)).toHaveLength(1)
+	})
+})

--- a/packages/tools/src/shared/memory-client.ts
+++ b/packages/tools/src/shared/memory-client.ts
@@ -1,4 +1,4 @@
-import { deduplicateMemories } from "../tools-shared"
+import { deduplicateMemoriesForMode } from "../tools-shared"
 import type {
 	Logger,
 	MemoryMode,
@@ -119,7 +119,7 @@ export const buildMemoriesText = async (
 		mode,
 	})
 
-	const deduplicated = deduplicateMemories({
+	const deduplicated = deduplicateMemoriesForMode(mode, {
 		static: memoriesResponse.profile.static,
 		dynamic: memoriesResponse.profile.dynamic,
 		searchResults: memoriesResponse.searchResults?.results,

--- a/packages/tools/src/tools-shared.test.ts
+++ b/packages/tools/src/tools-shared.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest"
-import { getContainerTags } from "./tools-shared"
+import { deduplicateMemoriesForMode, getContainerTags } from "./tools-shared"
 
 describe("getContainerTags", () => {
 	it("uses the default project when no config is provided", () => {
@@ -24,5 +24,61 @@ describe("getContainerTags", () => {
 				containerTags: ["tag-a"],
 			}),
 		).toThrow("either projectId or containerTags")
+	})
+})
+
+describe("deduplicateMemoriesForMode", () => {
+	// The profile is not injected in "query" mode, so a memory that is both a
+	// profile fact and a search hit must survive in the search results —
+	// otherwise it is dropped from the prompt entirely.
+	it("keeps a search result that duplicates a profile memory in query mode", () => {
+		const deduplicated = deduplicateMemoriesForMode("query", {
+			static: [{ memory: "User is allergic to peanuts" }],
+			dynamic: [],
+			searchResults: [{ memory: "User is allergic to peanuts" }],
+		})
+
+		expect(deduplicated.searchResults).toEqual(["User is allergic to peanuts"])
+		expect(deduplicated.static).toEqual([])
+		expect(deduplicated.dynamic).toEqual([])
+	})
+
+	it("still deduplicates within the search results in query mode", () => {
+		const deduplicated = deduplicateMemoriesForMode("query", {
+			static: [],
+			dynamic: [],
+			searchResults: [
+				{ memory: "User likes TypeScript" },
+				"User likes TypeScript",
+			],
+		})
+
+		expect(deduplicated.searchResults).toEqual(["User likes TypeScript"])
+	})
+
+	it("deduplicates search results against the profile in full mode", () => {
+		const deduplicated = deduplicateMemoriesForMode("full", {
+			static: [{ memory: "User is allergic to peanuts" }],
+			dynamic: [{ memory: "User is shipping a release today" }],
+			searchResults: [
+				{ memory: "User is allergic to peanuts" },
+				{ memory: "User prefers async/await" },
+			],
+		})
+
+		expect(deduplicated.static).toEqual(["User is allergic to peanuts"])
+		expect(deduplicated.dynamic).toEqual(["User is shipping a release today"])
+		expect(deduplicated.searchResults).toEqual(["User prefers async/await"])
+	})
+
+	it("deduplicates search results against the profile in profile mode", () => {
+		const deduplicated = deduplicateMemoriesForMode("profile", {
+			static: [{ memory: "User is allergic to peanuts" }],
+			dynamic: [],
+			searchResults: [{ memory: "User is allergic to peanuts" }],
+		})
+
+		expect(deduplicated.static).toEqual(["User is allergic to peanuts"])
+		expect(deduplicated.searchResults).toEqual([])
 	})
 })

--- a/packages/tools/src/tools-shared.ts
+++ b/packages/tools/src/tools-shared.ts
@@ -2,6 +2,8 @@
  * Shared constants and descriptions for Supermemory tools
  */
 
+import type { MemoryMode } from "./shared/types"
+
 // Tool descriptions
 export const TOOL_DESCRIPTIONS = {
 	searchMemories:
@@ -176,4 +178,30 @@ export function deduplicateMemories(
 		dynamic: dynamicMemories,
 		searchResults: searchMemories,
 	}
+}
+
+/**
+ * Deduplicates memory items against only the sources the given mode actually
+ * injects into the prompt.
+ *
+ * `"query"` mode injects the search results but not the profile, so search
+ * results must not be deduplicated against the profile: a memory present in
+ * both would be dropped as a duplicate of something the model never sees, and
+ * would disappear from the prompt entirely.
+ *
+ * @param mode - The memory retrieval mode
+ * @param data - Profile data with memory items from different sources
+ * @returns Deduplicated memory strings for each source
+ */
+export function deduplicateMemoriesForMode(
+	mode: MemoryMode,
+	data: ProfileWithMemories,
+): DeduplicatedMemories {
+	const injectsProfile = mode !== "query"
+
+	return deduplicateMemories({
+		static: injectsProfile ? data.static : [],
+		dynamic: injectsProfile ? data.dynamic : [],
+		searchResults: data.searchResults,
+	})
 }


### PR DESCRIPTION
# Summary

Fixes #1240.

In `mode: "query"` the profile isn't injected into the prompt, but search results were still being deduplicated against it. A memory that was both a profile fact and a search hit got dropped as a duplicate of something the model never sees, so it vanished from the prompt entirely.

Worst case, if the only relevant memory was also present in the profile, the prompt contained an empty search-results section:

```text
User Supermemories:

Search results for user's recent message:
```

The memories most likely to appear in both sources are also the most relevant ones, so this disproportionately affected the best search hits.

## Fix

Deduplicate only against the memory sources that are actually injected for the selected mode.

To avoid repeating this logic in multiple places, the mode-aware behavior is centralized in a new helper:

- `deduplicateMemoriesForMode()` (`packages/tools/src/tools-shared.ts`)

The existing callers become simple one-line changes:

- `buildMemoriesText()` (`src/shared/memory-client.ts`)
  - Used by the Vercel AI SDK integration (`withSupermemory`)
  - Used by the Mastra processors
- `addSystemPrompt()` (`src/openai/middleware.ts`)
- `searchAndFormatMemories()` (`src/openai/middleware.ts`)
  - Used by both the OpenAI Chat Completions and Responses middleware

`mode: "profile"` and `mode: "full"` are unaffected since both inject the profile into the prompt, making deduplication against it correct.

## Testing

Added:

- 6 new tests in `src/tools-shared.test.ts`
- 1 new `src/shared/memory-client.test.ts` (stubs `/v4/profile`, no network)

I also verified that the regression tests actually catch the original bug rather than simply passing.

Reverting the fix causes exactly the two regression tests to fail:

```text
× buildMemoriesText > injects a search result that also exists in the profile in query mode
  → expected 'User Supermemories: \n\nSearch result…' to contain 'User is allergic to peanuts'
```

The existing `full`, `profile`, and within-search-results deduplication tests pass before and after the change, confirming the fix is narrowly scoped.

## Checks

Per `CONTRIBUTING.md`:

- ✅ `vitest` — 82 passing, 0 failing assertions
- ✅ `check-types` — 148 errors on this branch, 148 on `main` (no new errors; existing ones are in test files)
- ✅ `build`
- ✅ `format-lint` (Biome)

## Breaking changes

None.

`deduplicateMemories()` retains its existing API and behavior.

The only behavioral change is in `mode: "query"`, where memories that were previously dropped now correctly reach the prompt.