### PR TITLE
docs: correct addMemory default in OpenAI middleware JSDoc

### DIFF
--- a/packages/tools/src/openai/middleware.ts
+++ b/packages/tools/src/openai/middleware.ts
@@ -399,7 +399,7 @@ const addMemoryTool = async (
  * @param options.customId - Optional conversation ID to group messages for contextual memory generation
  * @param options.verbose - Enable detailed logging of memory operations (default: false)
  * @param options.mode - Memory search mode: "profile" (all memories), "query" (search-based), or "full" (both) (default: "profile")
- * @param options.addMemory - Automatic memory storage mode: "always" or "never" (default: "never")
+ * @param options.addMemory - Automatic memory storage mode: "always" or "never" (default: "always")
  * @returns Object with `wrapClient` and `createClient` methods
  * @throws {Error} When SUPERMEMORY_API_KEY environment variable is not set
  *


### PR DESCRIPTION
## What & why

`createOpenAIMiddleware`'s JSDoc documents `addMemory` as defaulting to `"never"`, but the implementation has defaulted to `"always"` since v2:

```ts
// packages/tools/src/openai/middleware.ts
const addMemory = options?.addMemory ?? "always"
```

This appears to be a leftover from the v2 migration, which changed the default across all four integrations. The migration guide already documents the new behavior:

> Across all four integrations, `addMemory` now defaults to `"always"`.

(`apps/docs/migration/tools-v2-upgrade.mdx`)

Every other surface was updated to match:

- README
- Docs site
- OpenAI entry-point JSDoc
- Vercel entry-point JSDoc
- Voltagent entry-point JSDoc

`packages/tools/src/openai/middleware.ts` was the only place that still documented the old default.

It's worth fixing because the current JSDoc implies conversations are **not** persisted unless callers explicitly opt in, when the implementation actually persists them by default. That's a misleading expectation to set around user data.

## Changes

- Update the `createOpenAIMiddleware` JSDoc to document the correct default value (`"always"`).

## Testing

Not applicable (documentation-only change).

## Breaking changes

None. This PR updates documentation only and does not change runtime behavior.