### PR TITLE
fix: scope MCP document reads to the default project instead of every project

### DIFF
--- a/apps/mcp/src/client.test.ts
+++ b/apps/mcp/src/client.test.ts
@@ -1,0 +1,71 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { SupermemoryClient } from "./client"
+
+const TOKEN = "sm_test_token"
+const API_URL = "https://api.supermemory.ai"
+
+/** Stubs the documents endpoint and records the request body. */
+function mockDocumentsFetch() {
+	const fetchMock = vi.fn().mockResolvedValue({
+		ok: true,
+		json: async () => ({
+			documents: [],
+			pagination: { currentPage: 1, limit: 10, totalItems: 0, totalPages: 0 },
+		}),
+	})
+	vi.stubGlobal("fetch", fetchMock)
+	return fetchMock
+}
+
+function requestBody(fetchMock: ReturnType<typeof mockDocumentsFetch>) {
+	const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+	return JSON.parse(init.body as string) as { containerTags?: string[] }
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+})
+
+describe("SupermemoryClient.getDocuments container scoping", () => {
+	// listMemories, memory-graph and fetch-graph-data all pass `undefined` when no
+	// container tag is supplied. Omitting containerTags reads across every project,
+	// while createMemory/search stay scoped to the default project — so listings
+	// would surface documents that recall can never return.
+	it("falls back to the default project when no container tag is given", async () => {
+		const fetchMock = mockDocumentsFetch()
+		const client = new SupermemoryClient(TOKEN, undefined, API_URL)
+
+		await client.getDocuments(undefined, 1, 10)
+
+		expect(requestBody(fetchMock).containerTags).toEqual(["sm_project_default"])
+	})
+
+	it("falls back to the client's container tag when no container tag is given", async () => {
+		const fetchMock = mockDocumentsFetch()
+		const client = new SupermemoryClient(TOKEN, "sm_project_work", API_URL)
+
+		await client.getDocuments(undefined, 1, 10)
+
+		expect(requestBody(fetchMock).containerTags).toEqual(["sm_project_work"])
+	})
+
+	it("uses explicitly supplied container tags", async () => {
+		const fetchMock = mockDocumentsFetch()
+		const client = new SupermemoryClient(TOKEN, "sm_project_work", API_URL)
+
+		await client.getDocuments(["sm_project_other"], 1, 10)
+
+		expect(requestBody(fetchMock).containerTags).toEqual(["sm_project_other"])
+	})
+
+	it("scopes documents to the same project that search reads from", async () => {
+		const fetchMock = mockDocumentsFetch()
+		const client = new SupermemoryClient(TOKEN, undefined, API_URL)
+
+		await client.getDocuments(undefined, 1, 10)
+
+		// search() passes `containerTag: this.containerTag`, which defaults to
+		// sm_project_default — document listings must agree with it.
+		expect(requestBody(fetchMock).containerTags).toEqual(["sm_project_default"])
+	})
+})

--- a/apps/mcp/src/client.ts
+++ b/apps/mcp/src/client.ts
@@ -358,7 +358,11 @@ export class SupermemoryClient {
 		}
 	}
 
-	// Fetch documents with their memory entries
+	// Fetch documents with their memory entries.
+	// Falls back to this client's container tag when none is given: omitting
+	// containerTags entirely would read across every project, while createMemory
+	// and search stay scoped, so listings would surface documents that recall
+	// can never return.
 	async getDocuments(
 		containerTags?: string[],
 		page = 1,
@@ -378,7 +382,7 @@ export class SupermemoryClient {
 					limit,
 					sort: "createdAt",
 					order: "desc",
-					containerTags,
+					containerTags: containerTags ?? [this.containerTag],
 				}),
 				signal,
 			})


### PR DESCRIPTION
## Summary

Fixes #1246.

The MCP tools disagreed about what they were operating on.

`memory` and `recall` go through `createMemory()` / `search()`, which pass `containerTag: this.containerTag`—and the client constructor defaults that to `sm_project_default` (`client.ts:148`).

But `listMemories`, `memory-graph`, and `fetch-graph-data` build their tags in the handler and pass `undefined` when none is supplied:

```ts
// server.ts:773-777
const result = await client.getDocuments(
  effectiveContainerTag ? [effectiveContainerTag] : undefined,
  page,
  limit,
)
```

Since `containerTags: undefined` is omitted from the request body, the API returned documents across **all projects**.

`listMemories`—whose tool description tells the model to use it "to audit what is on file"—was therefore enumerating documents that `recall` can never surface and that `memory` never writes to, and `memory-graph` was rendering them.

The fix defaults the tag at the single point all three tools route through, `SupermemoryClient.getDocuments`:

```ts
containerTags: containerTags ?? [this.containerTag],
```

I put it there rather than in the three handlers deliberately.

It closes the gap for all of them at once, prevents a fourth handler from reintroducing it, and makes the client internally consistent—`createMemory`, `search`, and `getProfile` already scope to `this.containerTag`, and now document reads do too.

Explicitly supplied tags are still honoured unchanged.

## Testing

Added:

- `apps/mcp/src/client.test.ts` (4 tests)

The tests stub `fetch`, so no network is required.

I also verified that the tests reproduce the original bug.

Against the unfixed code, three of the four tests fail with the reported defect:

```text
× falls back to the default project when no container tag is given
  → expected undefined to deeply equal [ 'sm_project_default' ]
```

That `undefined` is the omitted `containerTags` request body that caused the API to return every project.

The fourth test—explicitly supplied container tags are respected—passes both before and after the change, confirming the already-scoped path remains unchanged.

## Checks

- ✅ `vitest` (`apps/mcp/src/`) — 12 passing (4 new + the 8 existing in `format.test.ts`)
- ✅ `tsc --noEmit` — 0 errors
- ✅ `vite build`
- ✅ Biome — clean

I scoped test runs to `src/`; the `e2e/**` suite in `vitest.config.ts` requires live credentials.

## Breaking changes

None for correctly scoped callers.

Behavior does change for the previously unscoped path, which is the purpose of this fix: when no container tag is supplied, `listMemories`, `memory-graph`, and `fetch-graph-data` now return documents from `sm_project_default` instead of across every project.

Anyone relying on the previous cross-project listing was relying on results that `recall` and `memory` could not actually act upon.