### PR TITLE
docs(tools): correct addMemory default in OpenAI middleware JSDoc (#1241)

### DIFF
--- a/packages/tools/src/openai/middleware.ts
+++ b/packages/tools/src/openai/middleware.ts
@@ -399,7 +399,7 @@ const addMemoryTool = async (
  * @param options.customId - Optional conversation ID to group messages for contextual memory generation
  * @param options.verbose - Enable detailed logging of memory operations (default: false)
  * @param options.mode - Memory search mode: "profile" (all memories), "query" (search-based), or "full" (both) (default: "profile")
- * @param options.addMemory - Automatic memory storage mode: "always" or "never" (default: "never")
+ * @param options.addMemory - Automatic memory storage mode: "always" or "never" (default: "always")
  * @returns Object with `wrapClient` and `createClient` methods
  * @throws {Error} When SUPERMEMORY_API_KEY environment variable is not set
  *


### PR DESCRIPTION
## Summary

The JSDoc for `createOpenAIMiddleware` documented `options.addMemory` as defaulting to `"never"`, but the implementation defaults to `"always"`. Updated the doc to match.

```diff
- * @param options.addMemory - Automatic memory storage mode: "always" or "never" (default: "never")
+ * @param options.addMemory - Automatic memory storage mode: "always" or "never" (default: "always")

Why docs and not the implementation

"always" is the intended default, not a bug. Every other integration in packages/tools agrees:

┌────────────────────────────┬──────────┬───────────────────────┐
│        Integration         │ Default  │     Documented as     │
├────────────────────────────┼──────────┼───────────────────────┤
│ openai/index.ts:85         │ "always" │ "always"              │
├────────────────────────────┼──────────┼───────────────────────┤
│ openai/middleware.ts:431   │ "always" │ "never" ← the outlier │
├────────────────────────────┼──────────┼───────────────────────┤
│ vercel/index.ts:141        │ "always" │ "always"              │
├────────────────────────────┼──────────┼───────────────────────┤
│ vercel/middleware.ts:257   │ "always" │ —                     │
├────────────────────────────┼──────────┼───────────────────────┤
│ voltagent/middleware.ts:81 │ "always" │ "always"              │
├────────────────────────────┼──────────┼───────────────────────┤
│ mastra/processor.ts:72     │ "always" │ —                     │
└────────────────────────────┴──────────┴───────────────────────┘

Changing the runtime default to "never" would be a breaking change to conversation persistence across all five integrations, so this is a one-line doc fix.

Closes [#1241](https://github.com/supermemoryai/supermemory/issues/1241)