### PR TITLE
fix(mcp): scope MCP document reads to the default project

### DIFF
--- a/apps/mcp/src/client.ts
+++ b/apps/mcp/src/client.ts
@@ -378,7 +378,7 @@ export class SupermemoryClient {
 					limit,
 					sort: "createdAt",
 					order: "desc",
-					containerTags,
+					containerTags: containerTags ?? [this.containerTag],
 				}),
 				signal,
 			})


### PR DESCRIPTION
## Summary
`listMemories`, `memory-graph`, and `fetch-graph-data` were passing an `undefined` containerTag down to the API, causing it to return documents spanning across every single project—creating a massive scoping discrepancy against the `memory` and `recall` tools (which correctly scope to the default project).

**Changes:**
Instead of tweaking every individual handler, I centralized the fix inside `SupermemoryClient.getDocuments` (`apps/mcp/src/client.ts`). If a caller doesn't provide tags, it will securely fall back to `[this.containerTag]`.

This strictly guarantees that all downstream reads are properly scoped to the intended container, preventing any data leakage across unconnected projects.

Fixes #1246
