### PR TITLE
fix(web): declare entityContext in bulkLinkMutation so bulk link import works

### DIFF
--- a/apps/web/hooks/use-document-mutations.ts
+++ b/apps/web/hooks/use-document-mutations.ts
@@ -390,6 +390,7 @@ export function useDocumentMutations({
 			urls: string[]
 			project: string
 		}): Promise<{ success: number; failed: number }> => {
+			const entityContext = await resolveEntityContext(project)
 			let success = 0
 			let failed = 0
 
@@ -400,7 +401,7 @@ export function useDocumentMutations({
 						documents: chunk.map((url) => ({
 							content: url,
 							containerTags: [project],
-							entityContext,
+							...(entityContext !== undefined ? { entityContext } : {}),
 							metadata: { sm_source: "consumer" },
 						})),
 					},


### PR DESCRIPTION
Fixes #1259

## What

The bulk multi-URL paste flow (added in #1109) has been throwing before sending any request: `bulkLinkMutation` uses `entityContext` when building each batched document body, but never declares it. Every bulk submit hit `ReferenceError: entityContext is not defined`, which the mutation's `onError` surfaced as the generic "Failed to add links" toast after rolling back the optimistic entries — so it looked like an API failure, not a client crash.

`tsc` does flag this as TS2304, but `apps/web` builds with `ignoreBuildErrors`, which is how it survived.

## Fix

Resolve the entity context once at the top of the `mutationFn`, exactly like the `noteMutation`/`linkMutation`/`fileMutation` siblings, and forward it with the same conditional spread so the key is omitted when the space already has its own entity context configured:

```ts
const entityContext = await resolveEntityContext(project)
...
...(entityContext !== undefined ? { entityContext } : {}),
```

## Testing

- `bun test` in `apps/web` — 37 pass
- `bun run build` in `apps/web` — clean
- `biome check` on the touched file — clean

cc @MaheshtheDev
