### PR TITLE
fix(extension): repair Included Memories popup data handling and lifecycle

### DIFF
--- a/apps/browser-extension/entrypoints/background.ts
+++ b/apps/browser-extension/entrypoints/background.ts
@@ -162,9 +162,12 @@ export default defineBackground(() => {
 			const response = responseData as {
 				results?: Array<{ memory?: string }>
 			}
+			// Return raw memory strings; consumers handle numbering/formatting.
 			const memories: string[] = []
-			response.results?.forEach((result, index) => {
-				memories.push(`${index + 1}. ${result.memory} \n`)
+			response.results?.forEach((result) => {
+				if (result.memory) {
+					memories.push(result.memory)
+				}
 			})
 			console.log("Memories:", memories)
 			await trackEvent(eventSource)

--- a/apps/browser-extension/entrypoints/content/chatgpt.ts
+++ b/apps/browser-extension/entrypoints/content/chatgpt.ts
@@ -10,6 +10,11 @@ import {
 	autoCapturePromptsEnabled,
 } from "../../utils/storage"
 import {
+	buildPromptInjection,
+	createIncludedMemoriesPopup,
+	serializeMemories,
+} from "../../utils/included-memories"
+import {
 	createChatGPTInputBarElement,
 	DOMUtils,
 } from "../../utils/ui-components"
@@ -156,16 +161,21 @@ async function getRelatedMemoriesForChatGPT(actionSource: string) {
 			timeoutPromise,
 		])
 
-		if (response?.success && response?.data) {
+		if (
+			response?.success &&
+			Array.isArray(response.data) &&
+			response.data.length > 0
+		) {
+			const memories = response.data as string[]
 			const promptElement = document.getElementById("prompt-textarea")
 			if (promptElement) {
-				promptElement.dataset.supermemories = `\n\nSupermemories of user (only for the reference): ${response.data}`
+				promptElement.dataset.supermemories = buildPromptInjection(memories)
 				console.log(
 					"Prompt element dataset:",
 					promptElement.dataset.supermemories,
 				)
 
-				iconElement.dataset.memoriesData = response.data
+				iconElement.dataset.memoriesData = serializeMemories(memories)
 
 				updateChatGPTIconFeedback("Included Memories", iconElement)
 			} else {
@@ -325,104 +335,10 @@ function updateChatGPTIconFeedback(
 	`
 
 	if (message === "Included Memories" && iconElement.dataset.memoriesData) {
-		const popup = document.createElement("div")
-		popup.style.cssText = `
-			position: fixed;
-			bottom: 80px;
-			left: 50%;
-			transform: translateX(-50%);
-			background: #1a1a1a;
-			color: white;
-			padding: 0;
-			border-radius: 12px;
-			font-size: 13px;
-			font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
-			max-width: 500px;
-			max-height: 400px;
-			box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-			z-index: 999999;
-			display: none;
-			border: 1px solid #333;
-		`
-
-		const header = document.createElement("div")
-		header.style.cssText = `
-			display: flex;
-			justify-content: space-between;
-			align-items: center;
-			padding: 8px;
-			border-bottom: 1px solid #333;
-			opacity: 0.8;
-		`
-		header.innerHTML = `
-			<span style="font-weight: 600; color: #fff;">Included Memories</span>
-		`
-
-		const content = document.createElement("div")
-		content.style.cssText = `
-			padding: 0;
-			max-height: 300px;
-			overflow-y: auto;
-		`
-
-		const memoriesText = iconElement.dataset.memoriesData || ""
-		console.log("Memories text:", memoriesText)
-		const individualMemories = memoriesText
-			.split(/[,\n]/)
-			.map((memory) => memory.trim())
-			.filter((memory) => memory.length > 0 && memory !== ",")
-		console.log("Individual memories:", individualMemories)
-
-		individualMemories.forEach((memory, index) => {
-			const memoryItem = document.createElement("div")
-			memoryItem.style.cssText = `
-				display: flex;
-				align-items: center;
-				gap: 6px;
-				padding: 10px;
-				font-size: 13px;
-				line-height: 1.4;
-			`
-
-			const memoryText = document.createElement("div")
-			memoryText.style.cssText = `
-				flex: 1;
-				color: #e5e5e5;
-			`
-			memoryText.textContent = memory.trim()
-
-			const removeBtn = document.createElement("button")
-			removeBtn.style.cssText = `
-				background: transparent;
-				color: #9ca3af;
-				border: none;
-				padding: 4px;
-				border-radius: 4px;
-				cursor: pointer;
-				flex-shrink: 0;
-				height: fit-content;
-				display: flex;
-				align-items: center;
-				justify-content: center;
-			`
-			removeBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="m15 9-6 6"/><path d="m9 9 6 6"/></svg>`
-			removeBtn.dataset.memoryIndex = index.toString()
-
-			removeBtn.addEventListener("mouseenter", () => {
-				removeBtn.style.color = "#ef4444"
-			})
-			removeBtn.addEventListener("mouseleave", () => {
-				removeBtn.style.color = "#9ca3af"
-			})
-
-			memoryItem.appendChild(memoryText)
-			memoryItem.appendChild(removeBtn)
-			content.appendChild(memoryItem)
+		const popupHandle = createIncludedMemoriesPopup({
+			iconElement,
+			getPromptElement: () => document.getElementById("prompt-textarea"),
 		})
-
-		popup.appendChild(header)
-		popup.appendChild(content)
-		document.body.appendChild(popup)
 
 		feedbackDiv.addEventListener("mouseenter", () => {
 			const textSpan = feedbackDiv.querySelector("span:last-child")
@@ -440,67 +356,8 @@ function updateChatGPTIconFeedback(
 
 		feedbackDiv.addEventListener("click", (e) => {
 			e.stopPropagation()
-			popup.style.display = "block"
+			popupHandle.show()
 		})
-
-		document.addEventListener("click", (e) => {
-			if (!popup.contains(e.target as Node)) {
-				popup.style.display = "none"
-			}
-		})
-
-		content.querySelectorAll("button[data-memory-index]").forEach((button) => {
-			const htmlButton = button as HTMLButtonElement
-			htmlButton.addEventListener("click", () => {
-				const index = Number.parseInt(htmlButton.dataset.memoryIndex || "0", 10)
-				const memoryItem = htmlButton.parentElement
-
-				if (memoryItem) {
-					content.removeChild(memoryItem)
-				}
-
-				const currentMemories = (iconElement.dataset.memoriesData || "")
-					.split(/[,\n]/)
-					.map((memory) => memory.trim())
-					.filter((memory) => memory.length > 0 && memory !== ",")
-				currentMemories.splice(index, 1)
-
-				const updatedMemories = currentMemories.join(" ,")
-
-				iconElement.dataset.memoriesData = updatedMemories
-
-				const promptElement = document.getElementById("prompt-textarea")
-				if (promptElement) {
-					promptElement.dataset.supermemories = `\n\nSupermemories of user (only for the reference): ${updatedMemories}`
-				}
-
-				content
-					.querySelectorAll("button[data-memory-index]")
-					.forEach((btn, newIndex) => {
-						const htmlBtn = btn as HTMLButtonElement
-						htmlBtn.dataset.memoryIndex = newIndex.toString()
-					})
-
-				if (currentMemories.length <= 1) {
-					if (promptElement?.dataset.supermemories) {
-						delete promptElement.dataset.supermemories
-						delete iconElement.dataset.memoriesData
-						iconElement.innerHTML = iconElement.dataset.originalHtml || ""
-						delete iconElement.dataset.originalHtml
-					}
-					popup.style.display = "none"
-					if (document.body.contains(popup)) {
-						document.body.removeChild(popup)
-					}
-				}
-			})
-		})
-
-		setTimeout(() => {
-			if (document.body.contains(popup)) {
-				document.body.removeChild(popup)
-			}
-		}, 300000)
 	}
 
 	iconElement.innerHTML = ""

--- a/apps/browser-extension/entrypoints/content/claude.ts
+++ b/apps/browser-extension/entrypoints/content/claude.ts
@@ -10,6 +10,11 @@ import {
 	autoCapturePromptsEnabled,
 } from "../../utils/storage"
 import {
+	buildPromptInjection,
+	createIncludedMemoriesPopup,
+	serializeMemories,
+} from "../../utils/included-memories"
+import {
 	createClaudeInputBarElement,
 	DOMUtils,
 } from "../../utils/ui-components"
@@ -230,19 +235,24 @@ async function getRelatedMemoriesForClaude(actionSource: string) {
 
 		console.log("Claude memories response:", response)
 
-		if (response?.success && response?.data) {
+		if (
+			response?.success &&
+			Array.isArray(response.data) &&
+			response.data.length > 0
+		) {
+			const memories = response.data as string[]
 			const textareaElement = document.querySelector(
 				'div[contenteditable="true"]',
 			) as HTMLElement
 
 			if (textareaElement) {
-				textareaElement.dataset.supermemories = `\n\nSupermemories of user (only for the reference): ${response.data}`
+				textareaElement.dataset.supermemories = buildPromptInjection(memories)
 				console.log(
 					"Text element dataset:",
 					textareaElement.dataset.supermemories,
 				)
 
-				iconElement.dataset.memoriesData = response.data
+				iconElement.dataset.memoriesData = serializeMemories(memories)
 
 				updateClaudeIconFeedback("Included Memories", iconElement)
 			} else {
@@ -484,104 +494,11 @@ function updateClaudeIconFeedback(
 	`
 
 	if (message === "Included Memories" && iconElement.dataset.memoriesData) {
-		const popup = document.createElement("div")
-		popup.style.cssText = `
-			position: fixed;
-			bottom: 80px;
-			left: 50%;
-			transform: translateX(-50%);
-			background: #1a1a1a;
-			color: white;
-			padding: 0;
-			border-radius: 12px;
-			font-size: 13px;
-			font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
-			max-width: 500px;
-			max-height: 400px;
-			box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-			z-index: 999999;
-			display: none;
-			border: 1px solid #333;
-		`
-
-		const header = document.createElement("div")
-		header.style.cssText = `
-			display: flex;
-			justify-content: space-between;
-			align-items: center;
-			padding: 8px;
-			border-bottom: 1px solid #333;
-			opacity: 0.8;
-		`
-		header.innerHTML = `
-			<span style="font-weight: 600; color: #fff;">Included Memories</span>
-		`
-
-		const content = document.createElement("div")
-		content.style.cssText = `
-			padding: 0;
-			max-height: 300px;
-			overflow-y: auto;
-		`
-
-		const memoriesText = iconElement.dataset.memoriesData || ""
-		console.log("Memories text:", memoriesText)
-		const individualMemories = memoriesText
-			.split(/[,\n]/)
-			.map((memory) => memory.trim())
-			.filter((memory) => memory.length > 0 && memory !== ",")
-		console.log("Individual memories:", individualMemories)
-
-		individualMemories.forEach((memory, index) => {
-			const memoryItem = document.createElement("div")
-			memoryItem.style.cssText = `
-				display: flex;
-				align-items: center;
-				gap: 6px;
-				padding: 10px;
-				font-size: 13px;
-				line-height: 1.4;
-			`
-
-			const memoryText = document.createElement("div")
-			memoryText.style.cssText = `
-				flex: 1;
-				color: #e5e5e5;
-			`
-			memoryText.textContent = memory.trim()
-
-			const removeBtn = document.createElement("button")
-			removeBtn.style.cssText = `
-				background: transparent;
-				color: #9ca3af;
-				border: none;
-				padding: 4px;
-				border-radius: 4px;
-				cursor: pointer;
-				flex-shrink: 0;
-				height: fit-content;
-				display: flex;
-				align-items: center;
-				justify-content: center;
-			`
-			removeBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="m15 9-6 6"/><path d="m9 9 6 6"/></svg>`
-			removeBtn.dataset.memoryIndex = index.toString()
-
-			removeBtn.addEventListener("mouseenter", () => {
-				removeBtn.style.color = "#ef4444"
-			})
-			removeBtn.addEventListener("mouseleave", () => {
-				removeBtn.style.color = "#9ca3af"
-			})
-
-			memoryItem.appendChild(memoryText)
-			memoryItem.appendChild(removeBtn)
-			content.appendChild(memoryItem)
+		const popupHandle = createIncludedMemoriesPopup({
+			iconElement,
+			getPromptElement: () =>
+				document.querySelector('div[contenteditable="true"]'),
 		})
-
-		popup.appendChild(header)
-		popup.appendChild(content)
-		document.body.appendChild(popup)
 
 		feedbackDiv.addEventListener("mouseenter", () => {
 			const textSpan = feedbackDiv.querySelector("span:last-child")
@@ -599,69 +516,8 @@ function updateClaudeIconFeedback(
 
 		feedbackDiv.addEventListener("click", (e) => {
 			e.stopPropagation()
-			popup.style.display = "block"
+			popupHandle.show()
 		})
-
-		document.addEventListener("click", (e) => {
-			if (!popup.contains(e.target as Node)) {
-				popup.style.display = "none"
-			}
-		})
-
-		content.querySelectorAll("button[data-memory-index]").forEach((button) => {
-			const htmlButton = button as HTMLButtonElement
-			htmlButton.addEventListener("click", () => {
-				const index = Number.parseInt(htmlButton.dataset.memoryIndex || "0", 10)
-				const memoryItem = htmlButton.parentElement
-
-				if (memoryItem) {
-					content.removeChild(memoryItem)
-				}
-
-				const currentMemories = (iconElement.dataset.memoriesData || "")
-					.split(/[,\n]/)
-					.map((memory) => memory.trim())
-					.filter((memory) => memory.length > 0 && memory !== ",")
-				currentMemories.splice(index, 1)
-
-				const updatedMemories = currentMemories.join(" ,")
-
-				iconElement.dataset.memoriesData = updatedMemories
-
-				const textareaElement = document.querySelector(
-					'div[contenteditable="true"]',
-				) as HTMLElement
-				if (textareaElement) {
-					textareaElement.dataset.supermemories = `\n\nSupermemories of user (only for the reference): ${updatedMemories}`
-				}
-
-				content
-					.querySelectorAll("button[data-memory-index]")
-					.forEach((btn, newIndex) => {
-						const htmlBtn = btn as HTMLButtonElement
-						htmlBtn.dataset.memoryIndex = newIndex.toString()
-					})
-
-				if (currentMemories.length <= 1) {
-					if (textareaElement?.dataset.supermemories) {
-						delete textareaElement.dataset.supermemories
-						delete iconElement.dataset.memoriesData
-						iconElement.innerHTML = iconElement.dataset.originalHtml || ""
-						delete iconElement.dataset.originalHtml
-					}
-					popup.style.display = "none"
-					if (document.body.contains(popup)) {
-						document.body.removeChild(popup)
-					}
-				}
-			})
-		})
-
-		setTimeout(() => {
-			if (document.body.contains(popup)) {
-				document.body.removeChild(popup)
-			}
-		}, 300000)
 	}
 
 	iconElement.innerHTML = ""

--- a/apps/browser-extension/entrypoints/content/t3.ts
+++ b/apps/browser-extension/entrypoints/content/t3.ts
@@ -9,6 +9,11 @@ import {
 	autoSearchEnabled,
 	autoCapturePromptsEnabled,
 } from "../../utils/storage"
+import {
+	buildPromptInjection,
+	createIncludedMemoriesPopup,
+	serializeMemories,
+} from "../../utils/included-memories"
 import { createT3InputBarElement, DOMUtils } from "../../utils/ui-components"
 
 let t3DebounceTimeout: NodeJS.Timeout | null = null
@@ -219,7 +224,12 @@ async function getRelatedMemoriesForT3(actionSource: string) {
 
 		console.log("T3 memories response:", response)
 
-		if (response?.success && response?.data) {
+		if (
+			response?.success &&
+			Array.isArray(response.data) &&
+			response.data.length > 0
+		) {
+			const memories = response.data as string[]
 			let textareaElement = null
 			const supermemoryContainer = document.querySelector(
 				'[data-supermemory-icon-added="true"]',
@@ -238,9 +248,9 @@ async function getRelatedMemoriesForT3(actionSource: string) {
 			}
 
 			if (textareaElement) {
-				textareaElement.dataset.supermemories = `\n\nSupermemories of user (only for the reference): ${response.data}`
+				textareaElement.dataset.supermemories = buildPromptInjection(memories)
 
-				iconElement.dataset.memoriesData = response.data
+				iconElement.dataset.memoriesData = serializeMemories(memories)
 
 				updateT3IconFeedback("Included Memories", iconElement)
 			} else {
@@ -296,104 +306,12 @@ function updateT3IconFeedback(
 	`
 
 	if (message === "Included Memories" && iconElement.dataset.memoriesData) {
-		const popup = document.createElement("div")
-		popup.style.cssText = `
-			position: fixed;
-			bottom: 80px;
-			left: 50%;
-			transform: translateX(-50%);
-			background: #1a1a1a;
-			color: white;
-			padding: 0;
-			border-radius: 12px;
-			font-size: 13px;
-			font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
-			max-width: 500px;
-			max-height: 400px;
-			box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
-			z-index: 999999;
-			display: none;
-			border: 1px solid #333;
-		`
-
-		const header = document.createElement("div")
-		header.style.cssText = `
-			display: flex;
-			justify-content: space-between;
-			align-items: center;
-			padding: 8px;
-			border-bottom: 1px solid #333;
-			opacity: 0.8;
-		`
-		header.innerHTML = `
-			<span style="font-weight: 600; color: #fff;">Included Memories</span>
-		`
-
-		const content = document.createElement("div")
-		content.style.cssText = `
-			padding: 0;
-			max-height: 300px;
-			overflow-y: auto;
-		`
-
-		const memoriesText = iconElement.dataset.memoriesData || ""
-		console.log("Memories text:", memoriesText)
-		const individualMemories = memoriesText
-			.split(/[,\n]/)
-			.map((memory) => memory.trim())
-			.filter((memory) => memory.length > 0 && memory !== ",")
-		console.log("Individual memories:", individualMemories)
-
-		individualMemories.forEach((memory, index) => {
-			const memoryItem = document.createElement("div")
-			memoryItem.style.cssText = `
-				display: flex;
-				align-items: center;
-				gap: 6px;
-				padding: 10px;
-				font-size: 13px;
-				line-height: 1.4;
-			`
-
-			const memoryText = document.createElement("div")
-			memoryText.style.cssText = `
-				flex: 1;
-				color: #e5e5e5;
-			`
-			memoryText.textContent = memory.trim()
-
-			const removeBtn = document.createElement("button")
-			removeBtn.style.cssText = `
-				background: transparent;
-				color: #9ca3af;
-				border: none;
-				padding: 4px;
-				border-radius: 4px;
-				cursor: pointer;
-				flex-shrink: 0;
-				height: fit-content;
-				display: flex;
-				align-items: center;
-				justify-content: center;
-			`
-			removeBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="m15 9-6 6"/><path d="m9 9 6 6"/></svg>`
-			removeBtn.dataset.memoryIndex = index.toString()
-
-			removeBtn.addEventListener("mouseenter", () => {
-				removeBtn.style.color = "#ef4444"
-			})
-			removeBtn.addEventListener("mouseleave", () => {
-				removeBtn.style.color = "#9ca3af"
-			})
-
-			memoryItem.appendChild(memoryText)
-			memoryItem.appendChild(removeBtn)
-			content.appendChild(memoryItem)
+		const popupHandle = createIncludedMemoriesPopup({
+			iconElement,
+			getPromptElement: () =>
+				document.querySelector("textarea") ||
+				document.querySelector('div[contenteditable="true"]'),
 		})
-
-		popup.appendChild(header)
-		popup.appendChild(content)
-		document.body.appendChild(popup)
 
 		feedbackDiv.addEventListener("mouseenter", () => {
 			const textSpan = feedbackDiv.querySelector("span:last-child")
@@ -411,69 +329,8 @@ function updateT3IconFeedback(
 
 		feedbackDiv.addEventListener("click", (e) => {
 			e.stopPropagation()
-			popup.style.display = "block"
+			popupHandle.show()
 		})
-
-		document.addEventListener("click", (e) => {
-			if (!popup.contains(e.target as Node)) {
-				popup.style.display = "none"
-			}
-		})
-
-		content.querySelectorAll("button[data-memory-index]").forEach((button) => {
-			const htmlButton = button as HTMLButtonElement
-			htmlButton.addEventListener("click", () => {
-				const index = Number.parseInt(htmlButton.dataset.memoryIndex || "0", 10)
-				const memoryItem = htmlButton.parentElement
-
-				if (memoryItem) {
-					content.removeChild(memoryItem)
-				}
-
-				const currentMemories = (iconElement.dataset.memoriesData || "")
-					.split(/[,\n]/)
-					.map((memory) => memory.trim())
-					.filter((memory) => memory.length > 0 && memory !== ",")
-				currentMemories.splice(index, 1)
-
-				const updatedMemories = currentMemories.join(" ,")
-
-				iconElement.dataset.memoriesData = updatedMemories
-
-				const textareaElement =
-					(document.querySelector("textarea") as HTMLTextAreaElement) ||
-					(document.querySelector('div[contenteditable="true"]') as HTMLElement)
-				if (textareaElement) {
-					textareaElement.dataset.supermemories = `\n\nSupermemories of user (only for the reference): ${updatedMemories}`
-				}
-
-				content
-					.querySelectorAll("button[data-memory-index]")
-					.forEach((btn, newIndex) => {
-						const htmlBtn = btn as HTMLButtonElement
-						htmlBtn.dataset.memoryIndex = newIndex.toString()
-					})
-
-				if (currentMemories.length <= 1) {
-					if (textareaElement?.dataset.supermemories) {
-						delete textareaElement.dataset.supermemories
-						delete iconElement.dataset.memoriesData
-						iconElement.innerHTML = iconElement.dataset.originalHtml || ""
-						delete iconElement.dataset.originalHtml
-					}
-					popup.style.display = "none"
-					if (document.body.contains(popup)) {
-						document.body.removeChild(popup)
-					}
-				}
-			})
-		})
-
-		setTimeout(() => {
-			if (document.body.contains(popup)) {
-				document.body.removeChild(popup)
-			}
-		}, 300000)
 	}
 
 	iconElement.innerHTML = ""

--- a/apps/browser-extension/utils/included-memories.ts
+++ b/apps/browser-extension/utils/included-memories.ts
@@ -1,0 +1,221 @@
+/**
+ * Shared "Included Memories" pipeline for the chat-site content scripts
+ * (ChatGPT, Claude, T3).
+ *
+ * The background script returns related memories as a string array. Storing
+ * that array on a dataset attribute coerces it to a comma-joined string, and
+ * the old popup re-split it on commas — fragmenting any memory whose content
+ * itself contained a comma, and desyncing the per-row remove buttons from the
+ * real memories. The helpers here keep the array intact by serializing it as
+ * JSON and always rebuilding the injected prompt block from that single
+ * source of truth.
+ */
+
+const PROMPT_PREFIX = "\n\nSupermemories of user (only for the reference): "
+
+const POPUP_AUTO_DISMISS_MS = 300_000
+
+export function serializeMemories(memories: string[]): string {
+	return JSON.stringify(memories)
+}
+
+export function parseMemories(raw: string | undefined): string[] {
+	if (!raw) return []
+	try {
+		const parsed = JSON.parse(raw)
+		if (Array.isArray(parsed)) {
+			return parsed.filter(
+				(memory): memory is string =>
+					typeof memory === "string" && memory.trim().length > 0,
+			)
+		}
+	} catch {
+		// Not JSON — fall through and treat it as legacy newline-joined text.
+	}
+	return raw
+		.split("\n")
+		.map((memory) => memory.trim())
+		.filter((memory) => memory.length > 0)
+}
+
+export function buildPromptInjection(memories: string[]): string {
+	const numbered = memories
+		.map((memory, index) => `${index + 1}. ${memory}`)
+		.join("\n")
+	return `${PROMPT_PREFIX}${numbered}`
+}
+
+export interface IncludedMemoriesPopupOptions {
+	iconElement: HTMLElement
+	/** Site-specific lookup for the element carrying dataset.supermemories */
+	getPromptElement: () => HTMLElement | null
+}
+
+export interface IncludedMemoriesPopupHandle {
+	show: () => void
+}
+
+const activePopups = new WeakMap<HTMLElement, () => void>()
+
+export function disposeIncludedMemoriesPopup(iconElement: HTMLElement): void {
+	activePopups.get(iconElement)?.()
+}
+
+export function createIncludedMemoriesPopup({
+	iconElement,
+	getPromptElement,
+}: IncludedMemoriesPopupOptions): IncludedMemoriesPopupHandle {
+	// Replace any popup left over from a previous search so document-level
+	// listeners and popup nodes don't accumulate as auto-search re-runs.
+	disposeIncludedMemoriesPopup(iconElement)
+
+	const memories = parseMemories(iconElement.dataset.memoriesData)
+
+	const popup = document.createElement("div")
+	popup.style.cssText = `
+		position: fixed;
+		bottom: 80px;
+		left: 50%;
+		transform: translateX(-50%);
+		background: #1a1a1a;
+		color: white;
+		padding: 0;
+		border-radius: 12px;
+		font-size: 13px;
+		font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', sans-serif;
+		max-width: 500px;
+		max-height: 400px;
+		box-shadow: 0 8px 32px rgba(0, 0, 0, 0.4);
+		z-index: 999999;
+		display: none;
+		border: 1px solid #333;
+	`
+
+	const header = document.createElement("div")
+	header.style.cssText = `
+		display: flex;
+		justify-content: space-between;
+		align-items: center;
+		padding: 8px;
+		border-bottom: 1px solid #333;
+		opacity: 0.8;
+	`
+	header.innerHTML = `
+		<span style="font-weight: 600; color: #fff;">Included Memories</span>
+	`
+
+	const content = document.createElement("div")
+	content.style.cssText = `
+		padding: 0;
+		max-height: 300px;
+		overflow-y: auto;
+	`
+
+	const onDocumentClick = (e: MouseEvent) => {
+		if (!popup.contains(e.target as Node)) {
+			popup.style.display = "none"
+		}
+	}
+
+	const dismissTimer = setTimeout(() => dispose(), POPUP_AUTO_DISMISS_MS)
+
+	function dispose() {
+		clearTimeout(dismissTimer)
+		document.removeEventListener("click", onDocumentClick)
+		popup.remove()
+		activePopups.delete(iconElement)
+	}
+
+	const syncTargets = () => {
+		iconElement.dataset.memoriesData = serializeMemories(memories)
+		const promptElement = getPromptElement()
+		if (promptElement) {
+			promptElement.dataset.supermemories = buildPromptInjection(memories)
+		}
+	}
+
+	const clearAll = () => {
+		const promptElement = getPromptElement()
+		if (promptElement?.dataset.supermemories) {
+			delete promptElement.dataset.supermemories
+		}
+		delete iconElement.dataset.memoriesData
+		iconElement.innerHTML = iconElement.dataset.originalHtml || ""
+		delete iconElement.dataset.originalHtml
+		dispose()
+	}
+
+	const renderRows = () => {
+		content.innerHTML = ""
+		memories.forEach((memory, index) => {
+			const memoryItem = document.createElement("div")
+			memoryItem.style.cssText = `
+				display: flex;
+				align-items: center;
+				gap: 6px;
+				padding: 10px;
+				font-size: 13px;
+				line-height: 1.4;
+			`
+
+			const memoryText = document.createElement("div")
+			memoryText.style.cssText = `
+				flex: 1;
+				color: #e5e5e5;
+			`
+			memoryText.textContent = memory
+
+			const removeBtn = document.createElement("button")
+			removeBtn.style.cssText = `
+				background: transparent;
+				color: #9ca3af;
+				border: none;
+				padding: 4px;
+				border-radius: 4px;
+				cursor: pointer;
+				flex-shrink: 0;
+				height: fit-content;
+				display: flex;
+				align-items: center;
+				justify-content: center;
+			`
+			removeBtn.innerHTML = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="10"/><path d="m15 9-6 6"/><path d="m9 9 6 6"/></svg>`
+
+			removeBtn.addEventListener("mouseenter", () => {
+				removeBtn.style.color = "#ef4444"
+			})
+			removeBtn.addEventListener("mouseleave", () => {
+				removeBtn.style.color = "#9ca3af"
+			})
+
+			removeBtn.addEventListener("click", () => {
+				memories.splice(index, 1)
+				if (memories.length === 0) {
+					// Nothing left — remove the injected block entirely and
+					// restore the icon.
+					clearAll()
+					return
+				}
+				syncTargets()
+				renderRows()
+			})
+
+			memoryItem.appendChild(memoryText)
+			memoryItem.appendChild(removeBtn)
+			content.appendChild(memoryItem)
+		})
+	}
+
+	renderRows()
+	popup.appendChild(header)
+	popup.appendChild(content)
+	document.body.appendChild(popup)
+	document.addEventListener("click", onDocumentClick)
+	activePopups.set(iconElement, dispose)
+
+	return {
+		show: () => {
+			popup.style.display = "block"
+		},
+	}
+}


### PR DESCRIPTION
Fixes #1257

## What

The "Included Memories" popup pipeline on ChatGPT/Claude/T3 had four related defects, all rooted in the same ~180-line block duplicated across the three content scripts:

1. **Comma fragmentation.** The background script returns memories as a `string[]`; assigning that to `dataset.memoriesData` coerces it into one comma-joined string, and the popup re-split it with `.split(/[,\n]/)`. Any memory containing a comma showed up as several fake rows, and the index-based remove buttons spliced the wrong entries while rewriting a desynced prompt injection.
2. **Last-memory wipe.** The removal cleanup used `length <= 1`, so removing one of two memories also silently discarded the remaining one.
3. **Listener/DOM leak.** Every successful fetch appended a fresh popup to `<body>` and registered a new `document`-level click listener that was never removed. With auto-search firing per debounced input change, a few minutes of prompt editing accumulates dozens of orphaned global click handlers and stacked popups.
4. **Degraded prompt text.** Removals re-joined the memories with `" ,"` and the numbering baked in by the background handler went stale, leaving the injected block as `1. foo , 3. bar`.

## Fix

Since the block was byte-identical in `chatgpt.ts`, `claude.ts`, and `t3.ts` (apart from the prompt-element lookup), the popup now lives in a shared `utils/included-memories.ts`:

- memories are stored as **JSON** on the dataset, so content survives the round-trip regardless of what characters it contains
- the injected `dataset.supermemories` block is always rebuilt from that single source of truth, with numbering applied at build time so it stays correct after removals
- rows re-render from the array instead of juggling `data-memory-index` attributes
- removing entries keeps the last one until none remain (`=== 0`), and only then clears the injection and restores the icon
- each popup disposes its predecessor (node, document listener, auto-dismiss timer) before mounting, so repeated auto-searches no longer leak

The background handler now returns raw memory strings and skips empty results; each content script passes its own site-specific prompt-element lookup. Net −206 lines.

## Testing

- `bun run compile` (tsc --noEmit) — clean
- `bun run build` (wxt, chrome-mv3) — clean
- `biome check` on all touched files — clean

The extension package has no test harness, so the helper was written as pure functions (`serializeMemories`/`parseMemories`/`buildPromptInjection`) plus a self-contained popup factory to keep the behaviour easy to reason about and to unit-test later if a harness lands. Happy to add screenshots/screen recording of the popup flow if that helps review.

cc @MaheshtheDev
