### PR TITLE
fix(memory-graph): keep node selection when pagination changes the node count

### DIFF
--- a/packages/memory-graph/src/components/memory-graph.tsx
+++ b/packages/memory-graph/src/components/memory-graph.tsx
@@ -609,14 +609,23 @@ export function MemoryGraph({
 	const onSlideshowNodeChangeRef = useRef(onSlideshowNodeChange)
 	onSlideshowNodeChangeRef.current = onSlideshowNodeChange
 
+	// Track the previous slideshow state so deactivation can be distinguished
+	// from unrelated re-runs (e.g. nodes.length changing when pagination
+	// appends documents). Only a true active -> inactive transition should
+	// clear the user's selection.
+	const wasSlideshowActiveRef = useRef(false)
+
 	useEffect(() => {
-		if (!isSlideshowActive || nodes.length === 0) {
-			if (!isSlideshowActive) {
+		if (!isSlideshowActive) {
+			if (wasSlideshowActiveRef.current) {
+				wasSlideshowActiveRef.current = false
 				setSelectedNode(null)
 				simulationRef.current?.coolDown()
 			}
 			return
 		}
+		wasSlideshowActiveRef.current = true
+		if (nodes.length === 0) return
 
 		let lastIdx = -1
 		let coolDownTimer: ReturnType<typeof setTimeout> | null = null


### PR DESCRIPTION
## What

Pin a node's popover in the memory graph, zoom out far enough for the load-more trigger to fetch the next page, and the popover vanishes mid-read.

The slideshow effect in `memory-graph.tsx` depends on `nodes.length`, and its inactive branch unconditionally cleared the selected node:

```ts
useEffect(() => {
    if (!isSlideshowActive || nodes.length === 0) {
        if (!isSlideshowActive) {
            setSelectedNode(null)   // runs on every node-count change
            ...
```

With the slideshow off (the default for every consumer), any change in node count re-ran the effect and wiped the user's selection — pagination appending documents being the common trigger. It also fired a stray `coolDown()` on the simulation each time.

## Fix

Track the previous slideshow state in a ref and only clear the selection on a genuine active → inactive transition. Re-runs caused by `nodes.length` changing while the slideshow was never active are now no-ops.

## Testing

- `bun run test` in `packages/memory-graph` — 188 pass
- `bun run check-types` — clean

Behaviour notes for review: the active → inactive transition still clears the selection and cools the simulation exactly as before; the only change is that re-runs where the slideshow was never active no longer touch the selection.
