### PR TITLE
fix(web): reset command palette selection when the result list changes

### DIFF
--- a/apps/web/components/documents-command-palette.tsx
+++ b/apps/web/components/documents-command-palette.tsx
@@ -199,10 +199,16 @@ export function DocumentsCommandPalette({
 		for (const a of actions) items.push(a)
 	}
 
-	// Reset selection on items change
+	// biome-ignore lint/correctness/useExhaustiveDependencies: search is the trigger — snap the selection back to the top result whenever the query changes
 	useEffect(() => {
 		setSelectedIndex(0)
-	}, [])
+	}, [search])
+
+	// Keep the selection in range when the list shrinks (async results
+	// replacing recent docs, refetches, etc.)
+	useEffect(() => {
+		setSelectedIndex((i) => Math.min(i, Math.max(items.length - 1, 0)))
+	}, [items.length])
 
 	// Scroll selected into view
 	useEffect(() => {


### PR DESCRIPTION
## What

The documents command palette keeps a `selectedIndex` into its item list, and the effect commented "Reset selection on items change" has an empty dependency array — so it only ever runs on mount:

```ts
// Reset selection on items change
useEffect(() => {
    setSelectedIndex(0)
}, [])
```

Arrow down to row 5 of the recent-documents list, then type a query that returns two results: `selectedIndex` stays 5, the highlight disappears (no row renders `data-index="5"`), and Enter silently does nothing because `items[5]` is `undefined`. The selection also never snaps back to the top result when fresh results stream in.

## Fix

Two small effects that match the comment's intent:

- snap the selection to the top whenever the query text changes
- clamp it into range whenever the item list shrinks (async search results replacing the recent docs, refetches while the palette is open)

Clamping rather than always resetting keeps the cursor position stable when the list merely refreshes without shrinking.

## Testing

- `bun test` in `apps/web` — 37 pass
- `bun run build` in `apps/web` — clean
- `biome check` on the touched file — clean (the one remaining warning about `items` in `handleKeyDown` deps predates this change)
