### PR TITLE
fix(python-sdks): stop mishandling SDK model objects in memory dedup and formatting

### DIFF
--- a/packages/agent-framework-python/src/supermemory_agent_framework/utils.py
+++ b/packages/agent-framework-python/src/supermemory_agent_framework/utils.py
@@ -101,6 +101,12 @@ def deduplicate_memories(
         if isinstance(item, str):
             trimmed = item.strip()
             return trimmed if trimmed else None
+        # SDK search results are pydantic models, not dicts — read the
+        # memory field off the object so they aren't silently dropped.
+        memory = getattr(item, "memory", None)
+        if isinstance(memory, str):
+            trimmed = memory.strip()
+            return trimmed if trimmed else None
         return None
 
     static_memories: list[str] = []

--- a/packages/agent-framework-python/tests/test_utils.py
+++ b/packages/agent-framework-python/tests/test_utils.py
@@ -1,5 +1,7 @@
 """Tests for utility functions."""
 
+from types import SimpleNamespace
+
 import pytest
 
 from supermemory_agent_framework.utils import (
@@ -55,6 +57,30 @@ class TestDeduplicateMemories:
             static=[None, {"memory": "valid"}],
         )
         assert result.static == ["valid"]
+
+    def test_model_object_search_results(self) -> None:
+        # SDK search results are pydantic models (attribute access, no
+        # .get()); they used to fall through extract_memory_text and be
+        # silently dropped.
+        results = [
+            SimpleNamespace(memory="User prefers async"),
+            SimpleNamespace(memory="User prefers async"),
+            SimpleNamespace(memory="  "),
+            SimpleNamespace(memory=None),
+        ]
+        result = deduplicate_memories(search_results=results)
+        assert result.search_results == ["User prefers async"]
+
+    def test_model_objects_deduplicate_against_profile(self) -> None:
+        result = deduplicate_memories(
+            static=["User likes Python"],
+            search_results=[
+                SimpleNamespace(memory="User likes Python"),
+                SimpleNamespace(memory="User prefers async"),
+            ],
+        )
+        assert result.static == ["User likes Python"]
+        assert result.search_results == ["User prefers async"]
 
 
 class TestConvertProfileToMarkdown:

--- a/packages/cartesia-sdk-python/src/supermemory_cartesia/utils.py
+++ b/packages/cartesia-sdk-python/src/supermemory_cartesia/utils.py
@@ -49,17 +49,45 @@ def format_relative_time(iso_timestamp: str) -> str:
         return ""
 
 
+def extract_search_result_fields(item: Any) -> tuple[str, str]:
+    """Extract (memory, updatedAt) from a search result.
+
+    The Supermemory SDK returns search results as pydantic models
+    (attribute access, snake_case fields), while raw JSON payloads use
+    dicts with camelCase keys — support both so results survive
+    regardless of how they were fetched.
+    """
+    if isinstance(item, dict):
+        memory = item.get("memory", "")
+        updated_at = item.get("updatedAt", "")
+    else:
+        memory = getattr(item, "memory", None) or ""
+        updated_at = getattr(item, "updated_at", None)
+        if updated_at is None:
+            updated_at = getattr(item, "updatedAt", "")
+
+    if not isinstance(memory, str):
+        memory = ""
+    if isinstance(updated_at, datetime):
+        updated_at = updated_at.isoformat()
+    elif not isinstance(updated_at, str):
+        updated_at = ""
+
+    return memory, updated_at
+
+
 def deduplicate_memories(
     static: List[str],
     dynamic: List[str],
-    search_results: List[Dict[str, Any]],
-) -> Dict[str, Union[List[str], List[Dict[str, Any]]]]:
+    search_results: List[Any],
+) -> Dict[str, Union[List[str], List[Any]]]:
     """Deduplicate memories. Priority: static > dynamic > search.
 
     Args:
         static: List of static memory strings.
         dynamic: List of dynamic memory strings.
-        search_results: List of search result dicts with 'memory' and 'updatedAt'.
+        search_results: List of search results ('memory' and 'updatedAt'
+            as dicts or SDK model objects).
     """
     seen = set()
 
@@ -71,10 +99,10 @@ def deduplicate_memories(
                 out.append(m)
         return out
 
-    def unique_search(results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def unique_search(results: List[Any]) -> List[Any]:
         out = []
         for r in results:
-            memory = r.get("memory", "")
+            memory, _ = extract_search_result_fields(r)
             if memory and memory not in seen:
                 seen.add(memory)
                 out.append(r)
@@ -116,16 +144,15 @@ def format_memories_to_text(
         sections.append("## Relevant Memories")
         lines = []
         for item in search_results:
-            if isinstance(item, dict):
-                memory = item.get("memory", "")
-                updated_at = item.get("updatedAt", "")
-                time_str = format_relative_time(updated_at) if updated_at else ""
-                if time_str:
-                    lines.append(f"- [{time_str}] {memory}")
-                else:
-                    lines.append(f"- {memory}")
-            else:
+            if isinstance(item, str):
                 lines.append(f"- {item}")
+                continue
+            memory, updated_at = extract_search_result_fields(item)
+            time_str = format_relative_time(updated_at) if updated_at else ""
+            if time_str:
+                lines.append(f"- [{time_str}] {memory}")
+            else:
+                lines.append(f"- {memory}")
         sections.append("\n".join(lines))
 
     if not sections:

--- a/packages/cartesia-sdk-python/tests/test_search_result_objects.py
+++ b/packages/cartesia-sdk-python/tests/test_search_result_objects.py
@@ -1,0 +1,87 @@
+﻿"""Regression tests for SDK model-object search results.
+
+The Supermemory SDK returns search results as pydantic models (attribute
+access), not dicts. deduplicate_memories used to call r.get() on them,
+raising AttributeError and killing memory injection for any user whose
+profile lookup returned search results.
+"""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from supermemory_cartesia.utils import (
+    deduplicate_memories,
+    extract_search_result_fields,
+    format_memories_to_text,
+)
+
+
+def _model(memory, updated_at=None):
+    """Stand-in for an SDK pydantic Result: attribute access, no .get()."""
+    return SimpleNamespace(memory=memory, updated_at=updated_at)
+
+
+class TestModelObjectSearchResults(unittest.TestCase):
+    def test_deduplicates_model_objects_without_crashing(self):
+        results = [
+            _model("User likes Python"),
+            _model("User likes Python"),
+            _model("User works remotely"),
+        ]
+        deduped = deduplicate_memories(static=[], dynamic=[], search_results=results)
+        memories = [
+            extract_search_result_fields(r)[0] for r in deduped["search_results"]
+        ]
+        self.assertEqual(memories, ["User likes Python", "User works remotely"])
+
+    def test_profile_entries_still_win_over_model_search_results(self):
+        deduped = deduplicate_memories(
+            static=["User likes Python"],
+            dynamic=[],
+            search_results=[
+                _model("User likes Python"),
+                _model("User prefers async"),
+            ],
+        )
+        self.assertEqual(deduped["static"], ["User likes Python"])
+        self.assertEqual(
+            [extract_search_result_fields(r)[0] for r in deduped["search_results"]],
+            ["User prefers async"],
+        )
+
+    def test_format_renders_memory_text_not_object_repr(self):
+        deduped = deduplicate_memories(
+            static=[], dynamic=[], search_results=[_model("User prefers async")]
+        )
+        text = format_memories_to_text(deduped)
+        self.assertIn("- User prefers async", text)
+        self.assertNotIn("namespace", text)
+
+    def test_dict_results_keep_working(self):
+        deduped = deduplicate_memories(
+            static=[],
+            dynamic=[],
+            search_results=[
+                {"memory": "From a dict", "updatedAt": "2026-01-01T00:00:00Z"}
+            ],
+        )
+        text = format_memories_to_text(deduped)
+        self.assertIn("From a dict", text)
+
+    def test_extract_handles_datetime_updated_at(self):
+        item = _model("x", updated_at=datetime(2026, 1, 1, tzinfo=timezone.utc))
+        memory, updated_at = extract_search_result_fields(item)
+        self.assertEqual(memory, "x")
+        self.assertTrue(updated_at.startswith("2026-01-01"))
+
+    def test_extract_tolerates_missing_fields(self):
+        memory, updated_at = extract_search_result_fields(SimpleNamespace())
+        self.assertEqual(memory, "")
+        self.assertEqual(updated_at, "")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/packages/pipecat-sdk-python/src/supermemory_pipecat/utils.py
+++ b/packages/pipecat-sdk-python/src/supermemory_pipecat/utils.py
@@ -49,17 +49,45 @@ def format_relative_time(iso_timestamp: str) -> str:
         return ""
 
 
+def extract_search_result_fields(item: Any) -> tuple[str, str]:
+    """Extract (memory, updatedAt) from a search result.
+
+    The Supermemory SDK returns search results as pydantic models
+    (attribute access, snake_case fields), while raw JSON payloads use
+    dicts with camelCase keys — support both so results survive
+    regardless of how they were fetched.
+    """
+    if isinstance(item, dict):
+        memory = item.get("memory", "")
+        updated_at = item.get("updatedAt", "")
+    else:
+        memory = getattr(item, "memory", None) or ""
+        updated_at = getattr(item, "updated_at", None)
+        if updated_at is None:
+            updated_at = getattr(item, "updatedAt", "")
+
+    if not isinstance(memory, str):
+        memory = ""
+    if isinstance(updated_at, datetime):
+        updated_at = updated_at.isoformat()
+    elif not isinstance(updated_at, str):
+        updated_at = ""
+
+    return memory, updated_at
+
+
 def deduplicate_memories(
     static: List[str],
     dynamic: List[str],
-    search_results: List[Dict[str, Any]],
-) -> Dict[str, Union[List[str], List[Dict[str, Any]]]]:
+    search_results: List[Any],
+) -> Dict[str, Union[List[str], List[Any]]]:
     """Deduplicate memories. Priority: static > dynamic > search.
 
     Args:
         static: List of static memory strings.
         dynamic: List of dynamic memory strings.
-        search_results: List of search result dicts with 'memory' and 'updatedAt'.
+        search_results: List of search results ('memory' and 'updatedAt'
+            as dicts or SDK model objects).
     """
     seen = set()
 
@@ -71,10 +99,10 @@ def deduplicate_memories(
                 out.append(m)
         return out
 
-    def unique_search(results: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def unique_search(results: List[Any]) -> List[Any]:
         out = []
         for r in results:
-            memory = r.get("memory", "")
+            memory, _ = extract_search_result_fields(r)
             if memory and memory not in seen:
                 seen.add(memory)
                 out.append(r)
@@ -116,16 +144,15 @@ def format_memories_to_text(
         sections.append("## Relevant Memories")
         lines = []
         for item in search_results:
-            if isinstance(item, dict):
-                memory = item.get("memory", "")
-                updated_at = item.get("updatedAt", "")
-                time_str = format_relative_time(updated_at) if updated_at else ""
-                if time_str:
-                    lines.append(f"- [{time_str}] {memory}")
-                else:
-                    lines.append(f"- {memory}")
-            else:
+            if isinstance(item, str):
                 lines.append(f"- {item}")
+                continue
+            memory, updated_at = extract_search_result_fields(item)
+            time_str = format_relative_time(updated_at) if updated_at else ""
+            if time_str:
+                lines.append(f"- [{time_str}] {memory}")
+            else:
+                lines.append(f"- {memory}")
         sections.append("\n".join(lines))
 
     if not sections:

--- a/packages/pipecat-sdk-python/tests/test_search_result_objects.py
+++ b/packages/pipecat-sdk-python/tests/test_search_result_objects.py
@@ -1,0 +1,87 @@
+"""Regression tests for SDK model-object search results.
+
+The Supermemory SDK returns search results as pydantic models (attribute
+access), not dicts. deduplicate_memories used to call r.get() on them,
+raising AttributeError and killing memory injection for any user whose
+profile lookup returned search results.
+"""
+
+from __future__ import annotations
+
+import unittest
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from supermemory_pipecat.utils import (
+    deduplicate_memories,
+    extract_search_result_fields,
+    format_memories_to_text,
+)
+
+
+def _model(memory, updated_at=None):
+    """Stand-in for an SDK pydantic Result: attribute access, no .get()."""
+    return SimpleNamespace(memory=memory, updated_at=updated_at)
+
+
+class TestModelObjectSearchResults(unittest.TestCase):
+    def test_deduplicates_model_objects_without_crashing(self):
+        results = [
+            _model("User likes Python"),
+            _model("User likes Python"),
+            _model("User works remotely"),
+        ]
+        deduped = deduplicate_memories(static=[], dynamic=[], search_results=results)
+        memories = [
+            extract_search_result_fields(r)[0] for r in deduped["search_results"]
+        ]
+        self.assertEqual(memories, ["User likes Python", "User works remotely"])
+
+    def test_profile_entries_still_win_over_model_search_results(self):
+        deduped = deduplicate_memories(
+            static=["User likes Python"],
+            dynamic=[],
+            search_results=[
+                _model("User likes Python"),
+                _model("User prefers async"),
+            ],
+        )
+        self.assertEqual(deduped["static"], ["User likes Python"])
+        self.assertEqual(
+            [extract_search_result_fields(r)[0] for r in deduped["search_results"]],
+            ["User prefers async"],
+        )
+
+    def test_format_renders_memory_text_not_object_repr(self):
+        deduped = deduplicate_memories(
+            static=[], dynamic=[], search_results=[_model("User prefers async")]
+        )
+        text = format_memories_to_text(deduped)
+        self.assertIn("- User prefers async", text)
+        self.assertNotIn("namespace", text)
+
+    def test_dict_results_keep_working(self):
+        deduped = deduplicate_memories(
+            static=[],
+            dynamic=[],
+            search_results=[
+                {"memory": "From a dict", "updatedAt": "2026-01-01T00:00:00Z"}
+            ],
+        )
+        text = format_memories_to_text(deduped)
+        self.assertIn("From a dict", text)
+
+    def test_extract_handles_datetime_updated_at(self):
+        item = _model("x", updated_at=datetime(2026, 1, 1, tzinfo=timezone.utc))
+        memory, updated_at = extract_search_result_fields(item)
+        self.assertEqual(memory, "x")
+        self.assertTrue(updated_at.startswith("2026-01-01"))
+
+    def test_extract_tolerates_missing_fields(self):
+        memory, updated_at = extract_search_result_fields(SimpleNamespace())
+        self.assertEqual(memory, "")
+        self.assertEqual(updated_at, "")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes #1266

## What

The pipecat, cartesia, and agent-framework packages all feed search results from the `supermemory` SDK — **pydantic models** with attribute access and snake_case fields — into dedup/format helpers written for plain dicts. The failure mode differs per package, but in each one the core feature is broken on its primary path:

- **pipecat**: `deduplicate_memories` calls `r.get("memory", "")` on a `Result` model → `AttributeError` → caught by the generic frame handler, frame forwarded unchanged. Memories are never injected for any user whose profile lookup returns search results; it only "works" for brand-new users with empty results.
- **cartesia**: identical crash, swallowed one level up — `memory_context` silently comes back `None` and the process method then strips the previous memory block from the system prompt. Persistent recall is dead for users with stored memories.
- **agent-framework**: `extract_memory_text` handles only `dict`/`str`, so model objects fall through to `return None` and every search-result memory is silently dropped (no crash, just data loss).

The OpenAI package shares the same helper shape but works, because it fetches profile data over raw `aiohttp` and receives dicts — that asymmetry is what hid this.

## Fix

- pipecat/cartesia: a new `extract_search_result_fields` helper reads `memory`/`updatedAt` off dicts (camelCase keys) or SDK models (snake_case attributes, tolerant of `datetime` values), and both `deduplicate_memories` and `format_memories_to_text` go through it. The formatter also stops printing raw object reprs for non-dict, non-str items.
- agent-framework: `extract_memory_text` gains a model-object branch (`getattr(item, "memory", None)`), keeping the existing trim/empty filtering.

Dict-shaped inputs behave exactly as before in all three packages.

## Testing

- Verified against the **real SDK model**: built `supermemory.types.search_memories_response.Result` from an API-shaped payload and ran it through dedup → extract → format. Before: `AttributeError: 'Result' object has no attribute 'get'`. After: renders `- [1 Jan] User prefers async`.
- New regression tests: `tests/test_search_result_objects.py` in pipecat and cartesia (dedup without crashing, priority vs profile entries, no-repr formatting, dict compatibility, datetime `updated_at`, missing fields), plus two model-object cases in agent-framework's `tests/test_utils.py`.
- Suites: pipecat **7 passed**, cartesia **7 passed**, agent-framework **56 passed** (full suite, in a venv with `agent-framework-core==1.0.0rc3` — as noted in #1266, newer releases dropped `BaseContextProvider` and break the package import independently of this change).

cc @MaheshtheDev
