### PR TITLE
fix(extension): paginate Twitter bookmark-folder imports past the first page

### DIFF
--- a/apps/browser-extension/utils/twitter-import.ts
+++ b/apps/browser-extension/utils/twitter-import.ts
@@ -113,19 +113,14 @@ export class TwitterImporter {
 			const headers = createTwitterAPIHeaders(tokens)
 
 			// Build API request with pagination
-			const variables =
-				this.config.isFolderImport && this.config.bookmarkCollectionId
-					? buildBookmarkCollectionVariables(this.config.bookmarkCollectionId)
-					: buildRequestVariables(cursor)
-			const urlWithCursor = cursor
-				? `${
-						this.config.isFolderImport && this.config.bookmarkCollectionId
-							? `${BOOKMARK_COLLECTION_URL}&variables=${encodeURIComponent(JSON.stringify(variables))}`
-							: BOOKMARKS_URL
-					}&variables=${encodeURIComponent(JSON.stringify(variables))}`
-				: this.config.isFolderImport && this.config.bookmarkCollectionId
-					? `${BOOKMARK_COLLECTION_URL}&variables=${encodeURIComponent(JSON.stringify(variables))}`
-					: `${BOOKMARKS_URL}&variables=${encodeURIComponent(JSON.stringify(variables))}`
+			const collectionId = this.config.isFolderImport
+				? this.config.bookmarkCollectionId
+				: undefined
+			const variables = collectionId
+				? buildBookmarkCollectionVariables(collectionId, cursor)
+				: buildRequestVariables(cursor)
+			const baseUrl = collectionId ? BOOKMARK_COLLECTION_URL : BOOKMARKS_URL
+			const urlWithCursor = `${baseUrl}&variables=${encodeURIComponent(JSON.stringify(variables))}`
 
 			const response = await fetch(urlWithCursor, {
 				method: "GET",
@@ -199,7 +194,7 @@ export class TwitterImporter {
 				[]
 			const nextCursor = extractNextCursor(instructions)
 
-			if (nextCursor && tweets.length > 0 && !this.config.isFolderImport) {
+			if (nextCursor && tweets.length > 0) {
 				await new Promise((resolve) => setTimeout(resolve, 1000)) // Rate limiting
 				await this.batchImportAll(nextCursor, importedCount, uniqueGroupId)
 			} else {

--- a/apps/browser-extension/utils/twitter-utils.ts
+++ b/apps/browser-extension/utils/twitter-utils.ts
@@ -434,9 +434,18 @@ export function buildRequestVariables(cursor?: string, count = 100) {
 /**
  * Build Twitter API request variables for bookmark collection
  */
-export function buildBookmarkCollectionVariables(bookmarkCollectionId: string) {
-	return {
+export function buildBookmarkCollectionVariables(
+	bookmarkCollectionId: string,
+	cursor?: string,
+) {
+	const variables: Record<string, unknown> = {
 		bookmark_collection_id: bookmarkCollectionId,
 		includePromotedContent: true,
 	}
+
+	if (cursor) {
+		variables.cursor = cursor
+	}
+
+	return variables
 }


### PR DESCRIPTION
Fixes #1267

## What

Importing a Twitter bookmark **folder** silently capped at the first API page while reporting the truncated count as a complete import. Three related defects in the import path:

1. the pagination recursion was gated on `!this.config.isFolderImport`, so folder imports never followed the cursor
2. `buildBookmarkCollectionVariables` had no cursor parameter, so even with recursion every request would re-fetch page 1
3. the folder branch of the URL construction appended `&variables=...` twice when a cursor was present (the inner ternary already included it, then the outer template appended it again)

## Fix

- `buildBookmarkCollectionVariables(bookmarkCollectionId, cursor?)` threads the cursor exactly like `buildRequestVariables` does for the regular flow
- the recursion guard drops the folder exclusion; termination works the same way as the all-bookmarks flow (the last page yields a cursor but zero tweets, which stops the recursion)
- the nested URL ternaries collapse into a single `baseUrl + variables` expression, which removes the double-append path entirely

The 1s inter-page delay and 429 backoff apply to folder pages the same as regular pages.

## Testing

- `bun run compile` (tsc --noEmit) — clean
- `bun run build` (wxt, chrome-mv3) — clean
- `biome check` on both touched files — clean

I don't have a Twitter account with a 100+ tweet bookmark folder to drive the full flow end-to-end, so a maintainer with one may want to sanity-check the second page lands; the cursor extraction (`extractNextCursor`) and tweet parsing (`getAllTweets`) already handle the folder timeline shape and are unchanged.

cc @MaheshtheDev
