### PR TITLE
fix(mcp): bound the API-key session fetch with a 30s timeout

### DIFF
--- a/apps/mcp/src/auth.ts
+++ b/apps/mcp/src/auth.ts
@@ -32,6 +32,7 @@ export async function validateApiKey(
 			headers: {
 				Authorization: `Bearer ${apiKey}`,
 			},
+			signal: AbortSignal.timeout(30_000),
 		})
 
 		if (!sessionResponse.ok) {


### PR DESCRIPTION
`validateOAuthToken` aborts its upstream `/v3/session` call after 30 seconds, but `validateApiKey` had no signal at all. A hung session response therefore stalled every API-key-authenticated MCP request until platform limits kicked in, instead of failing cleanly.

This applies the same `AbortSignal.timeout(30_000)` to the API-key session fetch. The existing catch already maps `TimeoutError` to a null auth result, so no other change is needed.

Note: an earlier revision of this PR also flushed PostHog events within the request lifetime; that was dropped at the maintainer's request since the buffering is intentional. The PR is now the single auth-timeout line.