### PR TITLE
fix(validation): reject non-positive page/limit in pagination query schemas

### DIFF
--- a/packages/validation/api.test.ts
+++ b/packages/validation/api.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it } from "bun:test"
 import { readFileSync } from "node:fs"
-import { SearchRequestSchema, Searchv4RequestSchema } from "./api"
+import {
+	DocumentsWithMemoriesQuerySchema,
+	ListMemoriesQuerySchema,
+	SearchRequestSchema,
+	Searchv4RequestSchema,
+} from "./api"
 
 describe("search threshold schemas", () => {
 	it("do not contain redundant number transforms or unreachable range guards", () => {
@@ -78,5 +83,72 @@ describe("search threshold schemas", () => {
 				threshold: "0.5",
 			}).success,
 		).toBe(false)
+	})
+})
+
+describe("pagination query schemas", () => {
+	it("preserve page/limit defaults", () => {
+		const listed = ListMemoriesQuerySchema.parse({})
+		expect(listed.page).toBe(1)
+		expect(listed.limit).toBe(10)
+
+		const docs = DocumentsWithMemoriesQuerySchema.parse({})
+		expect(docs.page).toBe(1)
+		expect(docs.limit).toBe(10)
+	})
+
+	it.each([
+		1, 50, 1100,
+	])("ListMemoriesQuerySchema accepts numeric limit %p", (limit) => {
+		expect(ListMemoriesQuerySchema.parse({ limit }).limit).toBe(limit)
+	})
+
+	it("ListMemoriesQuerySchema accepts numeric string page/limit", () => {
+		const parsed = ListMemoriesQuerySchema.parse({ page: "3", limit: "25" })
+		expect(parsed.page).toBe(3)
+		expect(parsed.limit).toBe(25)
+	})
+
+	it.each([
+		0, -5, 2.5,
+	])("ListMemoriesQuerySchema rejects non-positive or fractional numeric limit %p", (limit) => {
+		expect(ListMemoriesQuerySchema.safeParse({ limit }).success).toBe(false)
+	})
+
+	it.each([
+		0, -1, 1.5,
+	])("ListMemoriesQuerySchema rejects non-positive or fractional numeric page %p", (page) => {
+		expect(ListMemoriesQuerySchema.safeParse({ page }).success).toBe(false)
+	})
+
+	it("ListMemoriesQuerySchema still caps limit at 1100", () => {
+		expect(ListMemoriesQuerySchema.safeParse({ limit: 1101 }).success).toBe(
+			false,
+		)
+	})
+
+	it.each([
+		0, -1, 2.5,
+	])("DocumentsWithMemoriesQuerySchema rejects invalid page %p", (page) => {
+		expect(DocumentsWithMemoriesQuerySchema.safeParse({ page }).success).toBe(
+			false,
+		)
+	})
+
+	it.each([
+		0, -10, 2.5,
+	])("DocumentsWithMemoriesQuerySchema rejects invalid limit %p", (limit) => {
+		expect(DocumentsWithMemoriesQuerySchema.safeParse({ limit }).success).toBe(
+			false,
+		)
+	})
+
+	it("DocumentsWithMemoriesQuerySchema accepts a normal request", () => {
+		const parsed = DocumentsWithMemoriesQuerySchema.parse({
+			page: 2,
+			limit: 50,
+		})
+		expect(parsed.page).toBe(2)
+		expect(parsed.limit).toBe(50)
 	})
 })

--- a/packages/validation/api.ts
+++ b/packages/validation/api.ts
@@ -275,6 +275,9 @@ export const ListMemoriesQuerySchema = z
 			.regex(/^\d+$/)
 			.or(z.number())
 			.transform(Number)
+			.refine((value) => Number.isInteger(value) && value >= 1, {
+				message: "Limit must be a positive integer",
+			})
 			.refine((value) => value <= 1100, {
 				message: "Limit cannot be greater than 1100",
 			})
@@ -292,6 +295,9 @@ export const ListMemoriesQuerySchema = z
 			.regex(/^\d+$/)
 			.or(z.number())
 			.transform(Number)
+			.refine((value) => Number.isInteger(value) && value >= 1, {
+				message: "Page must be a positive integer",
+			})
 			.default("1")
 			.openapi({ description: "Page number to fetch", example: "1" }),
 		sort: z
@@ -1092,11 +1098,11 @@ export const DocumentsWithMemoriesResponseSchema = z
 
 export const DocumentsWithMemoriesQuerySchema = z
 	.object({
-		page: z.number().default(1).openapi({
+		page: z.number().int().min(1).default(1).openapi({
 			description: "Page number to fetch",
 			example: 1,
 		}),
-		limit: z.number().default(10).openapi({
+		limit: z.number().int().min(1).default(10).openapi({
 			description: "Number of items per page",
 			example: 10,
 		}),


### PR DESCRIPTION
## What

Both pagination query schemas in `@repo/validation` validate only the upper bound, so malformed pagination passes the API's source-of-truth validation and flows into the query layer instead of failing with a clean 400:

- `ListMemoriesQuerySchema` guards its string branch with `/^\d+$/` (which still admits `"0"`), but the `z.number()` branch accepts anything: `{ page: -1, limit: -5 }` and fractional values like `2.5` all parse successfully. Only `limit > 1100` is rejected.
- `DocumentsWithMemoriesQuerySchema` — the input schema for `POST /documents/documents`, which the web app and MCP both use — has bare `z.number()` for `page` and `limit` with no bounds at all.

## Fix

Require `page` and `limit` to be positive integers in both schemas:

- `ListMemoriesQuerySchema`: a `Number.isInteger(value) && value >= 1` refine on both fields, ahead of the existing 1100 cap
- `DocumentsWithMemoriesQuerySchema`: `.int().min(1)` on both

Defaults (`page: 1`, `limit: 10`), the numeric-string branch, and the 1100 cap are unchanged. No new upper bound is added to the documents schema, since existing web flows legitimately request large pages.

## Testing

- New `bun test` cases in `packages/validation/api.test.ts`: defaults preserved, numeric and numeric-string acceptance, the 1100 cap, and rejection of zero/negative/fractional `page`/`limit` on both schemas — 27 pass
- `tsc --noEmit -p packages/validation` — clean
- `biome check` on both files — clean
