### PR TITLE
fix(extension): avoid recapturing recalled memories

### DIFF
--- a/apps/browser-extension/entrypoints/content/chatgpt.ts
+++ b/apps/browser-extension/entrypoints/content/chatgpt.ts
@@ -13,6 +13,7 @@ import {
 	createChatGPTInputBarElement,
 	DOMUtils,
 } from "../../utils/ui-components"
+import { preparePromptForSubmission } from "../../utils/prompt-capture"
 
 let chatGPTDebounceTimeout: NodeJS.Timeout | null = null
 let chatGPTRouteObserver: MutationObserver | null = null
@@ -642,23 +643,24 @@ function setupChatGPTPromptCapture() {
 		}
 
 		const storedMemories = promptTextarea?.dataset.supermemories
-		if (
-			storedMemories &&
-			promptTextarea &&
-			!promptContent.includes("Supermemories of user")
-		) {
-			promptTextarea.appendChild(document.createTextNode(storedMemories))
-			promptContent = promptTextarea.textContent || ""
+		const { promptToCapture, promptToSubmit } = preparePromptForSubmission(
+			promptContent,
+			storedMemories,
+		)
+		if (promptTextarea && promptToSubmit !== promptContent) {
+			promptTextarea.appendChild(
+				document.createTextNode(promptToSubmit.slice(promptContent.length)),
+			)
 		}
 
-		if (promptTextarea && promptContent.trim()) {
-			console.log(`ChatGPT prompt submitted via ${source}:`, promptContent)
+		if (promptTextarea && promptToCapture.trim()) {
+			console.log(`ChatGPT prompt submitted via ${source}:`, promptToCapture)
 
 			try {
 				await browser.runtime.sendMessage({
 					action: MESSAGE_TYPES.CAPTURE_PROMPT,
 					data: {
-						prompt: promptContent,
+						prompt: promptToCapture,
 						platform: "chatgpt",
 						source: source,
 					},

--- a/apps/browser-extension/entrypoints/content/claude.ts
+++ b/apps/browser-extension/entrypoints/content/claude.ts
@@ -13,6 +13,7 @@ import {
 	createClaudeInputBarElement,
 	DOMUtils,
 } from "../../utils/ui-components"
+import { preparePromptForSubmission } from "../../utils/prompt-capture"
 
 let claudeDebounceTimeout: NodeJS.Timeout | null = null
 let claudeRouteObserver: MutationObserver | null = null
@@ -705,24 +706,24 @@ function setupClaudePromptCapture() {
 		}
 
 		const storedMemories = contentEditableDiv?.dataset.supermemories
-		if (
-			storedMemories &&
-			contentEditableDiv &&
-			!promptContent.includes("Supermemories of user")
-		) {
-			contentEditableDiv.appendChild(document.createTextNode(storedMemories))
-			promptContent =
-				contentEditableDiv.textContent || contentEditableDiv.innerText || ""
+		const { promptToCapture, promptToSubmit } = preparePromptForSubmission(
+			promptContent,
+			storedMemories,
+		)
+		if (contentEditableDiv && promptToSubmit !== promptContent) {
+			contentEditableDiv.appendChild(
+				document.createTextNode(promptToSubmit.slice(promptContent.length)),
+			)
 		}
 
-		if (promptContent.trim()) {
-			console.log(`Claude prompt submitted via ${source}:`, promptContent)
+		if (promptToCapture.trim()) {
+			console.log(`Claude prompt submitted via ${source}:`, promptToCapture)
 
 			try {
 				await browser.runtime.sendMessage({
 					action: MESSAGE_TYPES.CAPTURE_PROMPT,
 					data: {
-						prompt: promptContent,
+						prompt: promptToCapture,
 						platform: "claude",
 						source: source,
 					},

--- a/apps/browser-extension/entrypoints/content/t3.ts
+++ b/apps/browser-extension/entrypoints/content/t3.ts
@@ -10,6 +10,7 @@ import {
 	autoCapturePromptsEnabled,
 } from "../../utils/storage"
 import { createT3InputBarElement, DOMUtils } from "../../utils/ui-components"
+import { preparePromptForSubmission } from "../../utils/prompt-capture"
 
 let t3DebounceTimeout: NodeJS.Timeout | null = null
 let t3RouteObserver: MutationObserver | null = null
@@ -521,30 +522,29 @@ function setupT3PromptCapture() {
 			textarea ||
 			(document.querySelector('div[contenteditable="true"]') as HTMLElement)
 		const storedMemories = textareaElement?.dataset.supermemories
-		if (
-			storedMemories &&
-			textareaElement &&
-			!promptContent.includes("Supermemories of user")
-		) {
+		const { promptToCapture, promptToSubmit } = preparePromptForSubmission(
+			promptContent,
+			storedMemories,
+			textareaElement?.tagName === "TEXTAREA" ? " " : "",
+		)
+		if (textareaElement && promptToSubmit !== promptContent) {
 			if (textareaElement.tagName === "TEXTAREA") {
-				;(textareaElement as HTMLTextAreaElement).value =
-					`${promptContent} ${storedMemories}`
-				promptContent = (textareaElement as HTMLTextAreaElement).value
+				;(textareaElement as HTMLTextAreaElement).value = promptToSubmit
 			} else {
-				textareaElement.appendChild(document.createTextNode(storedMemories))
-				promptContent =
-					textareaElement.textContent || textareaElement.innerText || ""
+				textareaElement.appendChild(
+					document.createTextNode(promptToSubmit.slice(promptContent.length)),
+				)
 			}
 		}
 
-		if (promptContent.trim()) {
-			console.log(`T3 prompt submitted via ${source}:`, promptContent)
+		if (promptToCapture.trim()) {
+			console.log(`T3 prompt submitted via ${source}:`, promptToCapture)
 
 			try {
 				await browser.runtime.sendMessage({
 					action: MESSAGE_TYPES.CAPTURE_PROMPT,
 					data: {
-						prompt: promptContent,
+						prompt: promptToCapture,
 						platform: "t3",
 						source: source,
 					},

--- a/apps/browser-extension/utils/prompt-capture.test.ts
+++ b/apps/browser-extension/utils/prompt-capture.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test"
+import { preparePromptForSubmission } from "./prompt-capture"
+
+describe("preparePromptForSubmission", () => {
+	it("keeps recalled memories out of the captured prompt", () => {
+		const storedMemories =
+			"\n\nSupermemories of user (only for the reference): Prefers TypeScript"
+
+		expect(
+			preparePromptForSubmission("Explain this code", storedMemories),
+		).toEqual({
+			promptToCapture: "Explain this code",
+			promptToSubmit: `Explain this code${storedMemories}`,
+		})
+	})
+
+	it("leaves prompts without recalled memories unchanged", () => {
+		expect(preparePromptForSubmission("Explain this code")).toEqual({
+			promptToCapture: "Explain this code",
+			promptToSubmit: "Explain this code",
+		})
+	})
+
+	it("supports platform-specific separation before recalled memories", () => {
+		expect(
+			preparePromptForSubmission("Explain this code", "recalled context", " "),
+		).toEqual({
+			promptToCapture: "Explain this code",
+			promptToSubmit: "Explain this code recalled context",
+		})
+	})
+
+	it("does not append recalled memories more than once", () => {
+		const prompt =
+			"Explain this code\n\nSupermemories of user (only for the reference): Prefers TypeScript"
+
+		expect(preparePromptForSubmission(prompt, "ignored")).toEqual({
+			promptToCapture: prompt,
+			promptToSubmit: prompt,
+		})
+	})
+})

--- a/apps/browser-extension/utils/prompt-capture.ts
+++ b/apps/browser-extension/utils/prompt-capture.ts
@@ -1,0 +1,15 @@
+export function preparePromptForSubmission(
+	promptContent: string,
+	storedMemories?: string,
+	memorySeparator = "",
+) {
+	const shouldIncludeMemories =
+		storedMemories && !promptContent.includes("Supermemories of user")
+
+	return {
+		promptToCapture: promptContent,
+		promptToSubmit: shouldIncludeMemories
+			? `${promptContent}${memorySeparator}${storedMemories}`
+			: promptContent,
+	}
+}


### PR DESCRIPTION
### Summary

  When auto-search and auto-capture were enabled together, recalled memories were appended to the submitted prompt and then persisted through
  CAPTURE_PROMPT as if they were new user input.

  This caused retrieved memories to be repeatedly re-ingested, potentially amplifying duplicates, outdated information, and incorrect source
  attribution.

  ### Changes

  - Preserve the original user prompt before injecting recalled context.
  - Send only the original prompt to CAPTURE_PROMPT.
  - Continue injecting recalled memories into the composer for model context.
  - Apply the fix consistently to:
      - ChatGPT
      - Claude
      - T3

  - Preserve T3’s existing prompt-separation behavior.
  - Add shared prompt-preparation logic and regression tests.

  ### Testing

  - 4 prompt-capture regression tests pass.
  - Browser-extension TypeScript compilation passes.
  - Browser-extension production build passes.
  - Biome checks pass.
  - Full repository suite: 312 passed, 64 skipped, with 21 pre-existing unrelated failures.

  ### Notes

  This changes only the content persisted by auto-capture. The prompt sent to the chat platform still includes recalled memories as before.
