### PR TITLE
fix(agent-framework): restore importability on current agent-framework-core releases

### DIFF
--- a/packages/agent-framework-python/src/supermemory_agent_framework/context_provider.py
+++ b/packages/agent-framework-python/src/supermemory_agent_framework/context_provider.py
@@ -9,7 +9,13 @@ following the same pattern as the built-in Mem0 integration.
 
 from typing import Any, Literal, Optional
 
-from agent_framework import BaseContextProvider
+try:
+    from agent_framework import BaseContextProvider
+except ImportError:
+    # Renamed in agent-framework-core 1.0.0 stable; the interface is
+    # unchanged (source_id __init__, before_run/after_run hooks with
+    # identical keyword-only signatures).
+    from agent_framework import ContextProvider as BaseContextProvider
 
 from .connection import AgentSupermemory
 from .utils import (


### PR DESCRIPTION
## What

A fresh `pip install supermemory-agent-framework` produces a package that cannot be imported.

The package pins `agent-framework-core>=1.0.0rc3` but imports `BaseContextProvider`, which only existed in the rc series — it was renamed to `ContextProvider` in 1.0.0 stable. Every version pip resolves today (1.0.0 through 1.11.0) satisfies the pin and lacks the symbol, so `from supermemory_agent_framework import ...` raises `ImportError` through the eager package `__init__`. All six exported classes are unusable.

## Fix

The rename is interface-neutral — verified with `inspect` against both 1.0.0rc3 and 1.11.0:

- `__init__(self, source_id: str)` — identical
- `before_run` / `after_run` — byte-identical keyword-only signatures (`agent`, `session`, `context`, `state`)

So `context_provider.py` now falls back:

```python
try:
    from agent_framework import BaseContextProvider
except ImportError:
    from agent_framework import ContextProvider as BaseContextProvider
```

which keeps rc3 compatibility while restoring every stable release. The dependency pin is untouched — with this change its declared range is actually honest.

## Testing

Ran the full test suite (54 tests) twice in clean venvs:

- `agent-framework-core==1.0.0rc3` + `supermemory` — 54 passed
- `agent-framework-core==1.11.0` + `supermemory` — 54 passed (collection previously died with `ImportError: cannot import name 'BaseContextProvider'`)

cc @MaheshtheDev
