### PR TITLE
fix(ui): reset the CopyButton checkmark after each copy

### DIFF
--- a/packages/ui/copy-button.tsx
+++ b/packages/ui/copy-button.tsx
@@ -24,10 +24,12 @@ export function CopyButton({
 	const [hasCopied, setHasCopied] = React.useState(false)
 
 	useEffect(() => {
-		setTimeout(() => {
+		if (!hasCopied) return
+		const timer = setTimeout(() => {
 			setHasCopied(false)
 		}, 2000)
-	}, [])
+		return () => clearTimeout(timer)
+	}, [hasCopied])
 
 	return (
 		<Button


### PR DESCRIPTION
## What

The `CopyButton` checkmark never resets. The reset timer runs once on **mount** with an empty dependency array — i.e. it fires (uselessly) two seconds after render, before any click — and nothing ever sets `hasCopied` back to `false` after a copy:

```tsx
useEffect(() => {
    setTimeout(() => { setHasCopied(false) }, 2000)
}, [])
```

In the integrations install-steps (the component's consumer), the first copy click swaps the clipboard icon to a checkmark permanently; subsequent copies give no visual feedback at all.

## Fix

Key the effect on `hasCopied` with proper cleanup — the same pattern the sibling `copyable-cell.tsx` already uses:

```tsx
useEffect(() => {
    if (!hasCopied) return
    const timer = setTimeout(() => setHasCopied(false), 2000)
    return () => clearTimeout(timer)
}, [hasCopied])
```

Each copy now shows the checkmark for 2 seconds and reverts; rapid re-copies restart the window cleanly, and the stray mount-time timer is gone.

## Testing

- `bun run build` in `apps/web` (the consumer) — clean
- `biome check` on the touched file — clean
