### PR TITLE
fix(web): register the drifted document endpoints in the api contract

### DIFF
--- a/apps/web/hooks/use-document-mutations.ts
+++ b/apps/web/hooks/use-document-mutations.ts
@@ -522,7 +522,8 @@ export function useDocumentMutations({
 				const data = (await response.json()) as { id: string }
 
 				if (applyMeta && (title || description)) {
-					await $fetch(`@patch/documents/${data.id}`, {
+					await $fetch("@patch/documents/:id", {
+						params: { id: data.id },
 						body: {
 							metadata: {
 								...(title && { title }),
@@ -643,7 +644,8 @@ export function useDocumentMutations({
 			documentId: string
 			content: string
 		}) => {
-			const response = await $fetch(`@patch/documents/${documentId}`, {
+			const response = await $fetch("@patch/documents/:id", {
+				params: { id: documentId },
 				body: {
 					content,
 					metadata: { sm_source: "consumer" },

--- a/packages/lib/api.ts
+++ b/packages/lib/api.ts
@@ -11,6 +11,8 @@ import {
 	CreateProjectSchema,
 	DeleteProjectResponseSchema,
 	DeleteProjectSchema,
+	DocumentFacetsQuerySchema,
+	DocumentFacetsResponseSchema,
 	DocumentsWithMemoriesQuerySchema,
 	DocumentsWithMemoriesResponseSchema,
 	ListContainerTagsResponseSchema,
@@ -18,6 +20,7 @@ import {
 	ListProjectsResponseSchema,
 	MemoryAddSchema,
 	MemoryResponseSchema,
+	MemoryUpdateSchema,
 	MigrateMCPRequestSchema,
 	MigrateMCPResponseSchema,
 	ProcessingDocumentsResponseSchema,
@@ -260,6 +263,10 @@ export const apiSchema = createSchema({
 		input: DocumentsWithMemoriesQuerySchema,
 		output: DocumentsWithMemoriesResponseSchema,
 	},
+	"@post/documents/documents/facets": {
+		input: DocumentFacetsQuerySchema,
+		output: DocumentFacetsResponseSchema,
+	},
 	"@post/documents/documents/by-ids": {
 		input: z.object({
 			ids: z.array(z.string()),
@@ -284,6 +291,13 @@ export const apiSchema = createSchema({
 
 	"@get/documents/:id": {
 		output: z.any(),
+	},
+
+	// Update a memory
+	"@patch/documents/:id": {
+		input: MemoryUpdateSchema,
+		output: MemoryResponseSchema,
+		params: z.object({ id: z.string() }),
 	},
 
 	// Delete a memory

--- a/packages/validation/api.test.ts
+++ b/packages/validation/api.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test"
 import { readFileSync } from "node:fs"
 import {
+	DocumentFacetsResponseSchema,
 	DocumentsWithMemoriesQuerySchema,
 	ListMemoriesQuerySchema,
 	SearchRequestSchema,
@@ -150,5 +151,33 @@ describe("pagination query schemas", () => {
 		})
 		expect(parsed.page).toBe(2)
 		expect(parsed.limit).toBe(50)
+	})
+})
+
+describe("documents contract schemas", () => {
+	it("DocumentsWithMemoriesQuerySchema accepts the categories filter", () => {
+		const parsed = DocumentsWithMemoriesQuerySchema.parse({
+			categories: ["webpage", "tweet"],
+		})
+		expect(parsed.categories).toEqual(["webpage", "tweet"])
+	})
+
+	it("DocumentsWithMemoriesQuerySchema leaves categories undefined when omitted", () => {
+		expect(
+			DocumentsWithMemoriesQuerySchema.parse({}).categories,
+		).toBeUndefined()
+	})
+
+	it("DocumentFacetsResponseSchema parses a facets payload", () => {
+		const parsed = DocumentFacetsResponseSchema.parse({
+			facets: [{ category: "webpage", count: 42, label: "Web pages" }],
+			total: 42,
+		})
+		expect(parsed.facets[0]?.category).toBe("webpage")
+	})
+
+	it("DocumentFacetsResponseSchema tolerates a missing total", () => {
+		const parsed = DocumentFacetsResponseSchema.parse({ facets: [] })
+		expect(parsed.total).toBeUndefined()
 	})
 })

--- a/packages/validation/api.ts
+++ b/packages/validation/api.ts
@@ -1106,6 +1106,13 @@ export const DocumentsWithMemoriesQuerySchema = z
 			description: "Number of items per page",
 			example: 10,
 		}),
+		categories: z
+			.array(z.string())
+			.optional()
+			.openapi({
+				description: "Optional document categories to filter by",
+				example: ["webpage", "tweet"],
+			}),
 		sort: z.enum(["createdAt", "updatedAt"]).default("createdAt").openapi({
 			description: "Field to sort by",
 			example: "createdAt",
@@ -1146,6 +1153,33 @@ export const DocumentFacetsQuerySchema = z
 	.openapi({
 		description: "Query parameters for getting document facets",
 	})
+
+export const DocumentFacetSchema = z
+	.object({
+		category: z.string().openapi({
+			description: "Document category identifier",
+			example: "webpage",
+		}),
+		count: z.number().openapi({
+			description: "Number of documents in this category",
+			example: 42,
+		}),
+		label: z.string().openapi({
+			description: "Human-readable category label",
+			example: "Web pages",
+		}),
+	})
+	.openapi({ description: "A single document-category facet" })
+
+export const DocumentFacetsResponseSchema = z
+	.object({
+		facets: z.array(DocumentFacetSchema),
+		total: z.number().optional().openapi({
+			description: "Total number of documents across all categories",
+			example: 120,
+		}),
+	})
+	.openapi({ description: "Document category facets" })
 
 export const MigrateMCPRequestSchema = z
 	.object({


### PR DESCRIPTION
## What

The `@repo/lib` endpoint map and validation schemas have drifted behind what the web app actually exchanges with the API. Three concrete gaps:

1. **`categories` is missing from `DocumentsWithMemoriesQuerySchema`.** The memories grid and the X-bookmarks status query both filter by `categories` on `@post/documents/documents` — and both smuggle it past client validation with `disableValidation: true` because the schema doesn't know the field. Any future caller that filters by category *without* remembering that flag gets the key silently stripped and a filter that no-ops.

2. **`@post/documents/documents/facets` was never registered.** `DocumentFacetsQuerySchema` exists in the validation package but is imported nowhere — dead code — while the memories grid calls the endpoint as an untyped raw URL and hand-casts the response to a local type.

3. **`@patch/documents/:id` was never registered.** `MemoryUpdateSchema` exists for exactly this (its own comment pairs it with `MemoryAddSchema`, but only the add path got wired). The document-edit and file-metadata mutations PATCH via template-literal URLs (`` `@patch/documents/${id}` ``), bypassing all request/response typing.

## Changes

- `DocumentsWithMemoriesQuerySchema` gains `categories: z.array(z.string()).optional()`
- New `DocumentFacetSchema` / `DocumentFacetsResponseSchema` (mirroring the shape the grid already consumes, with `total` optional since the UI guards it), and `@post/documents/documents/facets` registered with the previously-dead query schema as input
- `@patch/documents/:id` registered with `MemoryUpdateSchema` / `MemoryResponseSchema` / `params`, and both PATCH call sites in `use-document-mutations.ts` converted to the typed route with `params: { id }`
- bun tests covering the `categories` field and the facets response shape

## Deliberately out of scope

The existing `disableValidation: true` flags stay put, including on the two calls that motivated the `categories` fix. Every current caller of `@post/documents/documents` sets the flag, which means output validation against `DocumentsWithMemoriesResponseSchema` has never been exercised in production — removing the flags safely needs someone to verify the declared response schemas against live responses (I don't have staging access). With the schemas now correct, that cleanup becomes a mechanical follow-up.

## Testing

- `bun test` in `packages/validation` — 12 pass (4 new)
- `tsc --noEmit -p packages/validation` — clean
- `bun test` + `bun run build` in `apps/web` — clean
- `biome check` on all touched files — clean

cc @MaheshtheDev
