### PR TITLE
ci: grant least-privilege GITHUB_TOKEN in ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,11 @@ name: CI - Type Check, Format & Lint
 on:
   pull_request:
 
+# Least-privilege token: this workflow only checks out the repo and runs
+# typecheck/lint. It does not need write access.
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
## Summary

- Adds an explicit workflow-level `permissions: contents: read` block to `.github/workflows/ci.yml`.
- The `quality-checks` job only checks out the repo and runs typecheck/lint, so it does not need write access.
- Matches the least-privilege pattern already used by the publish workflows and addresses the supply-chain / blast-radius concern in #1218.

## Test plan

- [x] Confirmed the workflow YAML is valid and only changes permissions.
- [ ] CI runs successfully on this PR with the restricted token (checkout, install, typecheck, Biome).

Fixes #1218