### PR TITLE
docs(readme): surface latest research numbers front and center

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,12 @@
   <strong>English</strong> · <a href="README.zh-CN.md">简体中文</a>
 </p>
 
+<p align="center">
+  <strong>#1 on every major AI memory benchmark — <a href="https://github.com/xiaowu0162/LongMemEval">LongMemEval</a>, <a href="https://github.com/snap-research/locomo">LoCoMo</a>, and <a href="https://github.com/Salesforce/ConvoMem">ConvoMem</a>.</strong><br/>
+  <strong>95% Recall@15 with a 99.4% context reduction · ~50ms user profiles.</strong><br/>
+  <a href="https://supermemory.ai/research">Read the research →</a>
+</p>
+
 ---
 
 Supermemory is the memory and context layer for AI. **#1 on [LongMemEval](https://github.com/xiaowu0162/LongMemEval), [LoCoMo](https://github.com/snap-research/locomo), and [ConvoMem](https://github.com/Salesforce/ConvoMem)** — the three major benchmarks for AI memory. 
@@ -356,9 +362,13 @@ Supermemory is state of the art across all major AI memory benchmarks:
 
 | Benchmark | What it measures | Result |
 |---|---|---|
-| **[LongMemEval](https://github.com/xiaowu0162/LongMemEval)** | Long-term memory across sessions with knowledge updates | **81.6% — #1** |
+| **[LongMemEval](https://github.com/xiaowu0162/LongMemEval)** | Long-term memory across sessions with knowledge updates | **#1** |
 | **[LoCoMo](https://github.com/snap-research/locomo)** | Fact recall across extended conversations (single-hop, multi-hop, temporal, adversarial) | **#1** |
 | **[ConvoMem](https://github.com/Salesforce/ConvoMem)** | Personalization and preference learning | **#1** |
+
+On LongMemEval, supermemory reaches **95% Recall@15 while adding only ~720 tokens of context — a 99.4% context reduction** (99.6% at @10, 99.8% at @5). Recall by category: Knowledge Updates 99%, Assistant recall 100%, User recall 97%, Multi-session 93%, Temporal Reasoning 91%, Preference 90%.
+
+We also built the **Supermemory Filesystem (SMFS)**, which uses **3.0× fewer tokens on Claude** (24M vs 72M) and **1.75× fewer on Codex** across the 110-question xAFS benchmark. See the full write-ups on our [research page](https://supermemory.ai/research).
 
 We also built **[MemoryBench](https://supermemory.ai/docs/memorybench/overview)** — an open-source framework for standardized, reproducible benchmarks of memory providers. Compare Supermemory, Mem0, Zep, and others head-to-head:
 


### PR DESCRIPTION
## What

Updates the README with the latest numbers from [supermemory.ai/research](https://supermemory.ai/research) and puts them front and center — the way Mem0 and Hindsight lead with their headline stats.

### Changes
- **Hero stat block** right under the language line: `#1 on LongMemEval, LoCoMo, and ConvoMem` + `95% Recall@15 with a 99.4% context reduction · ~50ms user profiles` + a link to the research page.
- **Benchmarks section**: added the LongMemEval Recall@15 / context-reduction figures and per-category recall breakdown, plus the SMFS filesystem token-efficiency numbers (3.0× fewer tokens on Claude, 1.75× on Codex).

### Notes
- Removed the previous `81.6% on LongMemEval` figure (flagged as incorrect).
- Only `README.md` is touched — unrelated working-tree changes (`.env.example`, `bun.lock`) were left out of the commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to README.md with no code, config, or runtime impact.
> 
> **Overview**
> **README marketing copy** now leads with headline research stats (similar to competitor READMEs): a centered block under the language line highlights **#1** on LongMemEval, LoCoMo, and ConvoMem, plus **95% Recall@15**, **99.4% context reduction**, **~50ms user profiles**, and a link to [supermemory.ai/research](https://supermemory.ai/research).
> 
> In **Benchmarks**, the LongMemEval table cell drops the old **81.6%** figure in favor of **#1**, and new prose adds Recall@15 / token-efficiency details (including @10/@5 reductions), per-category recall breakdowns, and **Supermemory Filesystem (SMFS)** token savings on Claude and Codex for the xAFS benchmark, with a pointer to the research page.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 80597d39a3ec3394b23e8bed5396209040d2b5e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->