### PR TITLE
docs: drop Pro-plan banner for Claude Code & OpenCode (now free-tier)

### DIFF
--- a/apps/docs/integrations/claude-code.mdx
+++ b/apps/docs/integrations/claude-code.mdx
@@ -13,10 +13,6 @@ icon: "/images/claude-code-icon.svg"
   />
 </div>
 
-<Warning>
-This integration requires the **Supermemory Pro plan**. [Upgrade here](https://console.supermemory.ai/billing).
-</Warning>
-
 [supermemory](https://github.com/supermemoryai/claude-supermemory) is a Claude Code plugin that gives your AI persistent memory across sessions. Your agent remembers what you worked on — across sessions, across projects.
 
 <Tip>

--- a/apps/docs/integrations/opencode.mdx
+++ b/apps/docs/integrations/opencode.mdx
@@ -5,10 +5,6 @@ description: "OpenCode Supermemory Plugin — persistent memory across coding se
 icon: "/images/opencode-logo.png"
 ---
 
-<Warning>
-This integration requires the **Supermemory Pro plan**. [Upgrade here](https://console.supermemory.ai/billing).
-</Warning>
-
 [OpenCode-Supermemory](https://github.com/supermemoryai/opencode-supermemory) is an OpenCode plugin that gives your AI persistent memory across sessions. Your agent remembers what you worked on — across sessions, across projects.
 
 <Tip>


### PR DESCRIPTION
## What

Removes the `<Warning>` "This integration requires the **Supermemory Pro plan**" banner from the **Claude Code** and **OpenCode** integration pages.

## Why

`claude_code`, `opencode`, and `cursor` are now free-tier plugins (backend change in supermemoryai/mono#2570). The Pro-plan requirement banner on these pages is no longer accurate.

## Scope

- ✅ `apps/docs/integrations/claude-code.mdx` — banner removed
- ✅ `apps/docs/integrations/opencode.mdx` — banner removed
- ⏸️ `apps/docs/integrations/openclaw.mdx` — **left as-is**; OpenClaw remains a paid (Pro) integration
- Unrelated Pro-plan mentions left untouched: the Granola connector page (connectors are still paid) and an example string in agent-framework.mdx

There is no separate Cursor integration page in the docs, so nothing to change there.

Depends on / pairs with supermemoryai/mono#2570.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only edits with no runtime or product behavior changes in this repo.
> 
> **Overview**
> Removes the **Supermemory Pro plan** `<Warning>` banner from the **Claude Code** and **OpenCode** integration docs so the pages match plugins that are now available on the free tier (paired with the backend change in mono#2570).
> 
> No other doc content on those pages changes; **OpenClaw** and other Pro-only mentions elsewhere are intentionally unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 36fe1cd57f525d789515ce0bb6b5fe1f9419fe35. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->