### PR TITLE
fix: list every memory container

### DIFF
--- a/apps/mcp/src/client.test.ts
+++ b/apps/mcp/src/client.test.ts
@@ -65,4 +65,68 @@ describe("SupermemoryClient", () => {
 			}),
 		)
 	})
+
+	it("ignores malformed container tag entries", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockResolvedValue(
+					new Response(
+						JSON.stringify([
+							null,
+							{},
+							{ containerTag: 42 },
+							{ containerTag: "project-valid" },
+						]),
+					),
+				),
+		)
+
+		const client = new SupermemoryClient(
+			"sm_test",
+			undefined,
+			"https://api.example.com",
+		)
+
+		await expect(client.getContainerTags()).resolves.toEqual(["project-valid"])
+	})
+
+	it("returns an empty list for a malformed response", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(new Response(JSON.stringify({ projects: [] }))),
+		)
+
+		const client = new SupermemoryClient(
+			"sm_test",
+			undefined,
+			"https://api.example.com",
+		)
+
+		await expect(client.getContainerTags()).resolves.toEqual([])
+	})
+
+	it("preserves the upstream failure as an error cause", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(
+				new Response(null, {
+					status: 503,
+					statusText: "Service Unavailable",
+				}),
+			),
+		)
+
+		const client = new SupermemoryClient(
+			"sm_test",
+			undefined,
+			"https://api.example.com",
+		)
+
+		await expect(client.getContainerTags()).rejects.toMatchObject({
+			cause: "Service Unavailable",
+			message: "Failed to fetch container tags",
+		})
+	})
 })

--- a/apps/mcp/src/client.test.ts
+++ b/apps/mcp/src/client.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { SupermemoryClient } from "./client"
+
+afterEach(() => {
+	vi.unstubAllGlobals()
+})
+
+describe("SupermemoryClient", () => {
+	it("lists every accessible container tag", async () => {
+		const fetchMock = vi.fn().mockResolvedValue(
+			new Response(
+				JSON.stringify([
+					{
+						id: "space_vene",
+						name: "Vene Work",
+						containerTag: "vene-work",
+						createdAt: "2026-07-20T00:00:00.000Z",
+						updatedAt: "2026-07-20T00:00:00.000Z",
+						isExperimental: false,
+						isNova: false,
+					},
+					{
+						id: "space_sujal",
+						name: "Sujal Codex",
+						containerTag: "sujal-codex",
+						createdAt: "2026-07-20T00:00:00.000Z",
+						updatedAt: "2026-07-20T00:00:00.000Z",
+						isExperimental: false,
+						isNova: false,
+					},
+					{
+						id: "space_default",
+						name: "Default",
+						containerTag: "sm_project_default",
+						createdAt: "2026-07-20T00:00:00.000Z",
+						updatedAt: "2026-07-20T00:00:00.000Z",
+						isExperimental: false,
+						isNova: true,
+					},
+				]),
+				{ headers: { "Content-Type": "application/json" } },
+			),
+		)
+		vi.stubGlobal("fetch", fetchMock)
+
+		const client = new SupermemoryClient(
+			"sm_test",
+			undefined,
+			"https://api.example.com",
+		)
+
+		await expect(client.getContainerTags()).resolves.toEqual([
+			"vene-work",
+			"sujal-codex",
+			"sm_project_default",
+		])
+		expect(fetchMock).toHaveBeenCalledWith(
+			"https://api.example.com/v3/container-tags/list",
+			expect.objectContaining({
+				headers: {
+					Authorization: "Bearer sm_test",
+					"Content-Type": "application/json",
+				},
+				method: "GET",
+			}),
+		)
+	})
+})

--- a/apps/mcp/src/client.ts
+++ b/apps/mcp/src/client.ts
@@ -58,13 +58,16 @@ export interface ProfileResponse {
 }
 
 export interface ContainerTag {
-	id: string
-	name: string
 	containerTag: string
-	createdAt: string
-	updatedAt: string
-	isExperimental: boolean
-	isNova: boolean
+}
+
+function isContainerTag(value: unknown): value is ContainerTag {
+	return (
+		typeof value === "object" &&
+		value !== null &&
+		"containerTag" in value &&
+		typeof value.containerTag === "string"
+	)
 }
 
 // Documents API types
@@ -348,13 +351,15 @@ export class SupermemoryClient {
 				if (response.status === 401) {
 					throw new Error("Authentication failed. Please re-authenticate.")
 				}
-				throw new Error(
-					`Failed to fetch container tags: ${response.statusText}`,
-				)
+				throw new Error("Failed to fetch container tags", {
+					cause: response.statusText,
+				})
 			}
 
-			const data = (await response.json()) as ContainerTag[]
-			return data.map((entry) => entry.containerTag)
+			const data: unknown = await response.json()
+			return Array.isArray(data)
+				? data.filter(isContainerTag).map((entry) => entry.containerTag)
+				: []
 		} catch (error) {
 			this.handleError(error)
 		}

--- a/apps/mcp/src/client.ts
+++ b/apps/mcp/src/client.ts
@@ -57,14 +57,14 @@ export interface ProfileResponse {
 	searchResults?: SearchResult
 }
 
-export interface Project {
+export interface ContainerTag {
 	id: string
 	name: string
 	containerTag: string
 	createdAt: string
 	updatedAt: string
 	isExperimental: boolean
-	documentCount?: number
+	isNova: boolean
 }
 
 // Documents API types
@@ -329,11 +329,13 @@ export class SupermemoryClient {
 		}
 	}
 
-	// Get projects list
-	async getProjects(options?: { signal?: AbortSignal }): Promise<string[]> {
+	// Get every container tag available to the current organization member
+	async getContainerTags(options?: {
+		signal?: AbortSignal
+	}): Promise<string[]> {
 		try {
 			const signal = options?.signal ?? AbortSignal.timeout(FETCH_TIMEOUT_MS)
-			const response = await fetch(`${this.apiUrl}/v3/projects`, {
+			const response = await fetch(`${this.apiUrl}/v3/container-tags/list`, {
 				method: "GET",
 				headers: {
 					Authorization: `Bearer ${this.bearerToken}`,
@@ -346,13 +348,13 @@ export class SupermemoryClient {
 				if (response.status === 401) {
 					throw new Error("Authentication failed. Please re-authenticate.")
 				}
-				throw new Error(`Failed to fetch projects: ${response.statusText}`)
+				throw new Error(
+					`Failed to fetch container tags: ${response.statusText}`,
+				)
 			}
 
-			const data = (await response.json()) as {
-				projects: Project[]
-			}
-			return data.projects?.map((p) => p.containerTag) || []
+			const data = (await response.json()) as ContainerTag[]
+			return data.map((entry) => entry.containerTag)
 		} catch (error) {
 			this.handleError(error)
 		}

--- a/apps/mcp/src/server.ts
+++ b/apps/mcp/src/server.ts
@@ -835,7 +835,7 @@ export class SupermemoryMCP extends McpAgent<Env, unknown, Props> {
 	private async refreshContainerTags(): Promise<void> {
 		try {
 			const client = this.getClient()
-			this.cachedContainerTags = await client.getProjects()
+			this.cachedContainerTags = await client.getContainerTags()
 			this.containerTagsLastFetchedAt = Date.now()
 		} catch (error) {
 			console.error("Failed to fetch container tags:", error)


### PR DESCRIPTION
## Summary
- Switch MCP project discovery from the Nova-only projects endpoint to the organization-wide container-tags endpoint.
- Preserve the existing `listProjects` tool and projects resource while returning every accessible container tag, including developer containers.
- Validate the container-tag response and preserve upstream failure details without crashing on malformed payloads.

## Root cause
The MCP client queried `GET /v3/projects`, whose contract only includes user-created `sm_project_*` projects. General organization container tags such as `vene-work` and `sujal-codex` are returned by `GET /v3/container-tags/list`, so they were invisible to MCP clients.

## User impact
After the MCP Worker is deployed, connected clients can discover and select all container tags their organization membership permits; no client-side configuration change is required.

## Verification
- [x] `bunx vitest run src/client.test.ts src/format.test.ts` (12 tests)
- [x] `bunx biome check apps/mcp/src/client.ts apps/mcp/src/server.ts apps/mcp/src/client.test.ts`
- [x] Strict targeted TypeScript check for `client.ts` and `client.test.ts`
- [x] `bun run build:ui`
- [x] `bunx wrangler deploy --dry-run`

The package-wide TypeScript invocation remains blocked by existing duplicate MCP SDK private-type conflicts and missing DOM typings in the graph UI; it reported no diagnostics in the changed client or regression test.