### PR TITLE
fix(pipecat): use client.add, memories.add was removed in supermemory 3.x

### DIFF
--- a/packages/pipecat-sdk-python/src/supermemory_pipecat/service.py
+++ b/packages/pipecat-sdk-python/src/supermemory_pipecat/service.py
@@ -179,7 +179,7 @@ class SupermemoryPipecatService(FrameProcessor):
             if self.session_id:
                 add_params["custom_id"] = self.session_id
 
-            await self._supermemory_client.memories.add(**add_params)
+            await self._supermemory_client.add(**add_params)
 
         except Exception as e:
             logger.error(f"Error storing messages: {e}")

--- a/packages/pipecat-sdk-python/tests/test_empty_profile.py
+++ b/packages/pipecat-sdk-python/tests/test_empty_profile.py
@@ -121,3 +121,29 @@ class TestSupermemoryPipecatNullProfile(unittest.IsolatedAsyncioTestCase):
                 "search_results": [],
             },
         )
+
+
+class _MockAddClient:
+    """a client that only exposes the top-level add, not memories.add."""
+
+    def __init__(self):
+        self.add = AsyncMock(return_value=SimpleNamespace(id="doc_123"))
+
+
+class TestSupermemoryPipecatStoreMessages(unittest.IsolatedAsyncioTestCase):
+    async def test_store_messages_calls_top_level_add(self) -> None:
+        # regression guard: supermemory 3.x moved add off client.memories to the
+        # top level. _store_messages must call client.add, not client.memories.add.
+        # the mock has no memories attribute, so a reverted call would raise,
+        # get swallowed by the fire-and-forget block, and add would never fire.
+        service = SupermemoryPipecatService(api_key="mock_key", user_id="user_123")
+        client = _MockAddClient()
+        service._supermemory_client = client
+
+        await service._store_messages([{"role": "user", "content": "hello"}])
+
+        client.add.assert_awaited_once()
+        _, kwargs = client.add.await_args
+        self.assertIn("content", kwargs)
+        self.assertEqual(kwargs["container_tags"], ["user_123"])
+        self.assertFalse(hasattr(client, "memories"))


### PR DESCRIPTION
supermemory_pipecat stores messages with `client.memories.add(...)`, but
`.add` was moved off `memories` to the top level (`client.add(...)`) in
supermemory 3.x. the package pins `supermemory>=3.16.0`, a range where
`memories.add` no longer exists, so a fresh install pulls 3.51 and every
store raises AttributeError.

it's worse than a hard crash: the call sits in a fire-and-forget block that
only logs the error (service.py _store_messages), so memory silently never
gets stored and the user never sees why.

fix is one line: call `client.add(**add_params)`. confirmed the top-level
add accepts the same params this passes (content, container_tags, custom_id,
metadata), and that `client.memories.add` is gone on current supermemory ^^
