### PR TITLE
fix(web): use native Codex MCP transport

### DIFF
--- a/apps/web/lib/mcp-manual-instructions.ts
+++ b/apps/web/lib/mcp-manual-instructions.ts
@@ -30,8 +30,7 @@ export function buildMcpUrlRemoteJson(apiKeyPlaceholder: string) {
 }
 
 export const CODEX_MCP_TOML = `[mcp_servers.supermemory]
-command = "npx"
-args = ["-y", "mcp-remote@latest", "https://mcp.supermemory.ai/mcp"]
+url = "${CHATGPT_REMOTE_MCP_URL}"
 `
 
 /** Full file merge target: Claude Desktop `claude_desktop_config.json` → `mcpServers`. */


### PR DESCRIPTION
## Problem

The Codex MCP setup tells users to run the third-party `mcp-remote` bridge even though current Codex supports Streamable HTTP and OAuth natively.

## Fix

Configure the Supermemory URL directly in `config.toml`. This removes an unnecessary runtime dependency and lets Codex handle OAuth itself.

## Validation

- `bunx biome check apps/web/lib/mcp-manual-instructions.ts`
- `codex mcp add supermemory --url https://mcp.supermemory.ai/mcp` produced the same native TOML and detected OAuth support.