### PR TITLE
fix(docs): prefix JSX-prop image paths with /docs to fix 404s

### DIFF
--- a/apps/docs/company-brain/use-cases/support-escalation.mdx
+++ b/apps/docs/company-brain/use-cases/support-escalation.mdx
@@ -14,7 +14,7 @@ A customer files a ticket through Plain. It lands in `#support`, gets triaged wi
 ## What happens
 
 <SlackThread channel="#support" members={24}>
-  <SlackMessage name="Plain" badges={["APP"]} avatar="/images/company-brain/plain-icon.png" time="10:12 AM">
+  <SlackMessage name="Plain" badges={["APP"]} avatar="/docs/images/company-brain/plain-icon.png" time="10:12 AM">
     New conversation: <AgentLink href="#">rewriteQuery param not working</AgentLink>
     <br />
     **Jordan Alvarez** (acme-corp.io) sent a **new message**.
@@ -34,12 +34,12 @@ A customer files a ticket through Plain. It lands in `#support`, gets triaged wi
     <br />
     <FileAttachment name="Context.md" />
   </SlackMessage>
-  <SlackMessage name="Cursor" badges={["AGENT"]} avatar="/images/company-brain/cursor-icon.png" time="10:14 AM">
+  <SlackMessage name="Cursor" badges={["AGENT"]} avatar="/docs/images/company-brain/cursor-icon.png" time="10:14 AM">
     <AgentLink href="#">Agent thread started</AgentLink>
     <br />
     Reproducing against the v3 search test suite now.
   </SlackMessage>
-  <SlackMessage name="Cursor" badges={["AGENT"]} avatar="/images/company-brain/cursor-icon.png" time="10:19 AM">
+  <SlackMessage name="Cursor" badges={["AGENT"]} avatar="/docs/images/company-brain/cursor-icon.png" time="10:19 AM">
     Fixed — `rewriteQuery` was getting skipped by the new cost short-circuit whenever a query was already cached. Pushed on <AgentLink href="#">#2312</AgentLink>.
     <br />
     <br />

--- a/apps/docs/connectors/overview.mdx
+++ b/apps/docs/connectors/overview.mdx
@@ -10,7 +10,7 @@ Connect external platforms to automatically sync documents into supermemory. Sup
 ## Supported Connectors
 
 <CardGroup cols={2}>
-  <Card title="Google Drive" icon="/images/google-drive-icon.svg" href="/connectors/google-drive">
+  <Card title="Google Drive" icon="/docs/images/google-drive-icon.svg" href="/connectors/google-drive">
     **Google Docs, Slides, Sheets**
 
     Real-time sync via webhooks. Supports shared drives, nested folders, and collaborative documents.
@@ -22,26 +22,26 @@ Connect external platforms to automatically sync documents into supermemory. Sup
     Real-time sync via Pub/Sub webhooks. Syncs threads with full conversation history and metadata.
   </Card>
 
-  <Card title="Notion" icon="/images/notion-icon.svg" href="/connectors/notion">
+  <Card title="Notion" icon="/docs/images/notion-icon.svg" href="/connectors/notion">
     **Pages, Databases, Blocks**
 
     Instant sync of workspace content. Handles rich formatting, embeds, and database properties.
   </Card>
 
-  <Card title="OneDrive" icon="/images/microsoft-icon.svg" href="/connectors/onedrive">
+  <Card title="OneDrive" icon="/docs/images/microsoft-icon.svg" href="/connectors/onedrive">
     **Word, Excel, PowerPoint**
 
     Scheduled sync every 4 hours. Supports personal and business accounts with file versioning.
   </Card>
   
   
-  <Card title="GitHub" icon="/images/github-icon.svg" href="/connectors/github">
+  <Card title="GitHub" icon="/docs/images/github-icon.svg" href="/connectors/github">
     **GitHub Repositories**
 
     Real-time incremental sync via webhooks. Supports documentation files in repositories.
   </Card>
 
-  <Card title="Granola" icon="/images/granola.svg" href="/connectors/granola">
+  <Card title="Granola" icon="/docs/images/granola.svg" href="/connectors/granola">
     **Meeting notes and transcripts**
 
     Syncs AI meeting notes, summaries, attendees, and transcripts from your Granola workspace.

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -62,25 +62,25 @@ export const HeroCard = ({ imageUrl, title, description, href }) => {
 
     <div className="mt-12 sm:mt-14 grid sm:grid-cols-2 gap-5 sm:gap-6">
       <HeroCard
-        imageUrl="/images/intro-company-brain.jpg"
+        imageUrl="/docs/images/intro-company-brain.jpg"
         title="Developer platform"
         description="API reference, concepts, and SDKs"
         href="/overview/what-is-supermemory"
       />
       <HeroCard
-        imageUrl="/images/intro-company-brain-card.jpg"
+        imageUrl="/docs/images/intro-company-brain-card.jpg"
         title="Company brain"
         description="Team knowledge on the same engine"
         href="/company-brain/overview"
       />
       <HeroCard
-        imageUrl="/images/intro-plugins.jpg"
+        imageUrl="/docs/images/intro-plugins.jpg"
         title="Plugins and MCP"
         description="Drop memory into Claude and coding agents"
         href="/supermemory-mcp/mcp"
       />
       <HeroCard
-        imageUrl="/images/intro-developer-platform.png"
+        imageUrl="/docs/images/intro-developer-platform.png"
         title="Self-hosting"
         description="Run it locally with zero config"
         href="/self-hosting/overview"

--- a/apps/docs/integrations/claude-code.mdx
+++ b/apps/docs/integrations/claude-code.mdx
@@ -7,7 +7,7 @@ icon: "/images/claude-code-icon.svg"
 
 <div className="w-1/2">
   <img
-    src="/images/claude-code-supermemory.png"
+    src="/docs/images/claude-code-supermemory.png"
     alt="Claude Code + Supermemory"
     className="rounded-lg shadow-lg"
   />
@@ -141,7 +141,7 @@ Per-repo overrides in `.claude/.supermemory-claude/config.json`. Run `/supermemo
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="GitHub Repository" icon="/images/github-icon.svg" href="https://github.com/supermemoryai/claude-supermemory">
+  <Card title="GitHub Repository" icon="/docs/images/github-icon.svg" href="https://github.com/supermemoryai/claude-supermemory">
     Source code, issues, and detailed README.
   </Card>
 

--- a/apps/docs/integrations/codex.mdx
+++ b/apps/docs/integrations/codex.mdx
@@ -166,7 +166,7 @@ tail -f ~/.codex-supermemory.log
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="GitHub Repository" icon="/images/github-icon.svg" href="https://github.com/supermemoryai/codex-supermemory">
+  <Card title="GitHub Repository" icon="/docs/images/github-icon.svg" href="https://github.com/supermemoryai/codex-supermemory">
     Source code, issues, and detailed README.
   </Card>
 

--- a/apps/docs/integrations/hermes.mdx
+++ b/apps/docs/integrations/hermes.mdx
@@ -141,7 +141,7 @@ If you run your own supermemory API, set **`base_url`** (and any other host-spec
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="Hermes + plugin README" icon="/images/github-icon.svg" href="https://github.com/NousResearch/hermes-agent/tree/main/plugins/memory/supermemory">
+  <Card title="Hermes + plugin README" icon="/docs/images/github-icon.svg" href="https://github.com/NousResearch/hermes-agent/tree/main/plugins/memory/supermemory">
     Full config table, env vars, and multi-container details.
   </Card>
 

--- a/apps/docs/integrations/openclaw.mdx
+++ b/apps/docs/integrations/openclaw.mdx
@@ -286,7 +286,7 @@ openclaw supermemory wipe               # Delete all memories (requires confirma
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="GitHub Repository" icon="/images/github-icon.svg" href="https://github.com/supermemoryai/openclaw-supermemory">
+  <Card title="GitHub Repository" icon="/docs/images/github-icon.svg" href="https://github.com/supermemoryai/openclaw-supermemory">
     Source code, issues, and detailed README.
   </Card>
 

--- a/apps/docs/integrations/opencode.mdx
+++ b/apps/docs/integrations/opencode.mdx
@@ -148,7 +148,7 @@ tail -f ~/.opencode-supermemory.log
 ## Next Steps
 
 <CardGroup cols={2}>
-  <Card title="GitHub Repository" icon="/images/github-icon.svg" href="https://github.com/supermemoryai/opencode-supermemory">
+  <Card title="GitHub Repository" icon="/docs/images/github-icon.svg" href="https://github.com/supermemoryai/opencode-supermemory">
     Source code, issues, and detailed README.
   </Card>
 

--- a/apps/docs/integrations/pipecat.mdx
+++ b/apps/docs/integrations/pipecat.mdx
@@ -236,7 +236,7 @@ For a complete example using Gemini Live speech-to-speech with Supermemory, chec
 
 <Card
   title="Pipecat Memory Example"
-  icon="/images/github-icon.svg"
+  icon="/docs/images/github-icon.svg"
   href="https://github.com/supermemoryai/pipecat-memory"
 >
   Full working example with Gemini Live, including frontend and backend code.

--- a/apps/docs/overview/what-is-supermemory.mdx
+++ b/apps/docs/overview/what-is-supermemory.mdx
@@ -30,47 +30,47 @@ It provides all the building blocks — Memory, Retrieval, Profiles, Connectors,
 
 <div className="not-prose my-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
   <BuildingBlock
-    icon="/images/building-blocks/memory-router.svg"
+    icon="/docs/images/building-blocks/memory-router.svg"
     title="Memory & Continual Learning"
     href="/concepts/graph-memory"
   />
   <BuildingBlock
-    icon="/images/building-blocks/document-retrieval.svg"
+    icon="/docs/images/building-blocks/document-retrieval.svg"
     title="SuperRAG (Retrieval)"
     href="/concepts/super-rag"
   />
   <BuildingBlock
-    icon="/images/building-blocks/file-systems.svg"
+    icon="/docs/images/building-blocks/file-systems.svg"
     title="Filesystems"
     href="/smfs/overview"
   />
   <BuildingBlock
-    icon="/images/building-blocks/user-profiles.svg"
+    icon="/docs/images/building-blocks/user-profiles.svg"
     title="Profiles"
     href="/concepts/user-profiles"
   />
   <BuildingBlock
-    icon="/images/building-blocks/connectors.svg"
+    icon="/docs/images/building-blocks/connectors.svg"
     title="Connectors"
     href="/connectors/overview"
   />
   <BuildingBlock
-    icon="/images/building-blocks/extractor.svg"
+    icon="/docs/images/building-blocks/extractor.svg"
     title="Extractors"
     href="/concepts/content-types"
   />
   <BuildingBlock
-    icon="/images/building-blocks/qualitative-analysis.svg"
+    icon="/docs/images/building-blocks/qualitative-analysis.svg"
     title="Qualitative Analysis"
     href="https://supermemory.ai/research"
   />
   <BuildingBlock
-    icon="/images/building-blocks/hermes.svg"
+    icon="/docs/images/building-blocks/hermes.svg"
     title="Plugins"
     href="/supermemory-mcp/mcp"
   />
   <BuildingBlock
-    icon="/images/building-blocks/brain-head.png"
+    icon="/docs/images/building-blocks/brain-head.png"
     title="Company Brain"
     href="/company-brain/overview"
   />

--- a/apps/docs/supermemory-mcp/mcp.mdx
+++ b/apps/docs/supermemory-mcp/mcp.mdx
@@ -164,7 +164,7 @@ In Cursor and Claude Code you can often invoke this with **`/context`**, which g
   <Card title="Setup and Usage" icon="settings" href="/supermemory-mcp/setup">
     Client configs, API keys, and project scoping.
   </Card>
-  <Card title="MCP Server Source" icon="/images/github-icon.svg" href="https://github.com/supermemoryai/supermemory/tree/main/apps/mcp">
+  <Card title="MCP Server Source" icon="/docs/images/github-icon.svg" href="https://github.com/supermemoryai/supermemory/tree/main/apps/mcp">
     Open-source implementation.
   </Card>
 </CardGroup>


### PR DESCRIPTION
Markdown ![]() images get auto-rewritten by Mintlify to mintcdn.com URLs
and work fine, but JSX-prop image references (icon=, imageUrl=, avatar=,
src=) using /images/... are left as literal root-relative paths, which
404 since the docs site is mounted at supermemory.ai/docs. Prefixed all
such references with /docs.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only path fixes with no runtime or API impact.
> 
> **Overview**
> Fixes broken images and icons on the docs site mounted at **supermemory.ai/docs** by changing JSX image paths from `/images/...` to **`/docs/images/...`**.
> 
> Mintlify rewrites markdown `![]()` assets to CDN URLs, but literal paths in props like **`icon=`**, **`imageUrl=`**, **`avatar=`**, and **`src=`** were requested from the site root and **404**’d. Updates span the docs home hero cards, connectors overview cards, overview building blocks, company-brain Slack avatars, integration pages (hero images and GitHub cards), Pipecat, and MCP source card.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dec8f464dfbfcb7ab9691a7d63fa79fe844f72e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->