### PR TITLE
fix(docs): prefix raw internal href/src literals with /docs

### DIFF
--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -40,19 +40,19 @@ export const HeroCard = ({ imageUrl, title, description, href }) => {
       </p>
       <div className="mt-8 flex flex-wrap items-center gap-3">
         <a
-          href="/concepts/how-it-works"
+          href="/docs/concepts/how-it-works"
           className="inline-flex items-center justify-center rounded-lg bg-gray-900 dark:bg-zinc-100 px-4 py-2.5 text-sm font-medium text-white dark:text-zinc-900 hover:bg-gray-800 dark:hover:bg-white transition-colors"
         >
           Architecture
         </a>
         <a
-          href="/quickstart"
+          href="/docs/quickstart"
           className="inline-flex items-center justify-center rounded-lg border border-gray-200 dark:border-zinc-700 bg-white dark:bg-zinc-950 px-4 py-2.5 text-sm font-medium text-gray-900 dark:text-zinc-100 hover:bg-gray-50 dark:hover:bg-zinc-900 transition-colors"
         >
           Quickstart
         </a>
         <a
-          href="/company-brain/setup"
+          href="/docs/company-brain/setup"
           className="inline-flex items-center justify-center rounded-lg px-3 py-2.5 text-sm font-medium text-gray-600 dark:text-zinc-400 hover:text-gray-900 dark:hover:text-zinc-100 hover:bg-gray-100/80 dark:hover:bg-zinc-800/80 transition-colors"
         >
           Set up your company brain
@@ -65,25 +65,25 @@ export const HeroCard = ({ imageUrl, title, description, href }) => {
         imageUrl="/docs/images/intro-company-brain.jpg"
         title="Developer platform"
         description="API reference, concepts, and SDKs"
-        href="/overview/what-is-supermemory"
+        href="/docs/overview/what-is-supermemory"
       />
       <HeroCard
         imageUrl="/docs/images/intro-company-brain-card.jpg"
         title="Company brain"
         description="Team knowledge on the same engine"
-        href="/company-brain/overview"
+        href="/docs/company-brain/overview"
       />
       <HeroCard
         imageUrl="/docs/images/intro-plugins.jpg"
         title="Plugins and MCP"
         description="Drop memory into Claude and coding agents"
-        href="/supermemory-mcp/mcp"
+        href="/docs/supermemory-mcp/mcp"
       />
       <HeroCard
         imageUrl="/docs/images/intro-developer-platform.png"
         title="Self-hosting"
         description="Run it locally with zero config"
-        href="/self-hosting/overview"
+        href="/docs/self-hosting/overview"
       />
     </div>
   </div>

--- a/apps/docs/snippets/slack-message.mdx
+++ b/apps/docs/snippets/slack-message.mdx
@@ -1,9 +1,9 @@
 export const DHRAVYA = {
   name: "Dhravya Shah",
-  avatar: "/images/company-brain/dhravya-slack-icon.jpg",
+  avatar: "/docs/images/company-brain/dhravya-slack-icon.jpg",
 };
 
-export const BOT_AVATAR = "/images/company-brain/supermemory-slack-icon.png";
+export const BOT_AVATAR = "/docs/images/company-brain/supermemory-slack-icon.png";
 
 export const Mention = ({ children, self = false }) => (
   <span
@@ -92,7 +92,7 @@ export const SlackThread = ({
         <div className="flex items-center gap-2 border-b border-black/10 px-4 py-3 dark:border-white/10">
           <div className="relative h-6 w-6 flex-none">
             <img
-              src={dmWith?.avatar || "/images/company-brain/supermemory-slack-icon.png"}
+              src={dmWith?.avatar || "/docs/images/company-brain/supermemory-slack-icon.png"}
               alt={dmWith?.name || "DM"}
               className="h-6 w-6 rounded-md object-cover"
             />
@@ -221,8 +221,8 @@ export const SlackMessage = ({
   children,
 }) => {
   const SELF_NAME = "Dhravya Shah";
-  const SELF_AVATAR = "/images/company-brain/dhravya-slack-icon.jpg";
-  const BOT_AVATAR = "/images/company-brain/supermemory-slack-icon.png";
+  const SELF_AVATAR = "/docs/images/company-brain/dhravya-slack-icon.jpg";
+  const BOT_AVATAR = "/docs/images/company-brain/supermemory-slack-icon.png";
 
   const resolvedName = bot ? "supermemory" : self ? SELF_NAME : name || SELF_NAME;
   const resolvedAvatar = bot ? BOT_AVATAR : self ? SELF_AVATAR : avatar;


### PR DESCRIPTION
index.mdx uses `mode: "custom"`, which renders raw HTML instead of
Mintlify's own components — Mintlify only auto-prefixes internal links
it generates itself (nav, Card href), not literal href/src strings in
raw <a>/<img> tags or JS string literals, so those still 404 under the
/docs mount. Fixed the homepage's raw <a href> links and the hardcoded
avatar path literals in the shared Slack-message snippet component.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL path fixes with no runtime or security impact.
> 
> **Overview**
> Fixes **broken navigation and images** on the docs homepage and in Slack UI snippets when the site is served under the `/docs` mount.
> 
> Because `index.mdx` uses **`mode: "custom"`**, Mintlify does not rewrite literal `href` values on raw `<a>` tags or `HeroCard` props—those links now use paths like `/docs/quickstart` and `/docs/overview/what-is-supermemory` instead of root-relative paths that 404.
> 
> The shared **`slack-message`** snippet updates hardcoded avatar `src` strings (including DM fallbacks and `SlackMessage` defaults) from `/images/...` to **`/docs/images/...`** so assets resolve correctly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec1817e8ca8c62557c6a6b4bff101c921a053cfd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->