### PR TITLE
fix(web): keep highlights card active index in range on refresh

### DIFF
--- a/apps/web/components/highlights-card.tsx
+++ b/apps/web/components/highlights-card.tsx
@@ -92,8 +92,12 @@ export function HighlightsCard({
 		if (isReplyOpen) replyInputRef.current?.focus()
 	}, [isReplyOpen])
 
-	// biome-ignore lint/correctness/useExhaustiveDependencies: intentionally re-run when items changes
 	useEffect(() => {
+		// The Daily Brief refreshes on its own every few hours, so items can be
+		// replaced with a shorter list while the user is on a later page. Pull the
+		// active index back into range, otherwise currentItem is undefined and the
+		// card falls through to the empty state even though highlights exist.
+		setActiveIndex((i) => Math.min(i, Math.max(items.length - 1, 0)))
 		setIsReplyOpen(false)
 		setReplyText("")
 		setIsExpanded(false)

--- a/apps/web/components/highlights-card.tsx
+++ b/apps/web/components/highlights-card.tsx
@@ -93,10 +93,6 @@ export function HighlightsCard({
 	}, [isReplyOpen])
 
 	useEffect(() => {
-		// The Daily Brief refreshes on its own every few hours, so items can be
-		// replaced with a shorter list while the user is on a later page. Pull the
-		// active index back into range, otherwise currentItem is undefined and the
-		// card falls through to the empty state even though highlights exist.
 		setActiveIndex((i) => Math.min(i, Math.max(items.length - 1, 0)))
 		setIsReplyOpen(false)
 		setReplyText("")


### PR DESCRIPTION
### Problem

`HighlightsCard` tracks the visible highlight with `activeIndex`, and derives `currentItem = items[activeIndex]`. When `items` changes, the effect keyed on `[items]` resets the reply and expansion state but never touches `activeIndex`:

```ts
useEffect(() => {
  setIsReplyOpen(false)
  setReplyText("")
  setIsExpanded(false)
}, [items])
```

The Daily Brief "refreshes automatically every few hours" (per the card's own info popover), which replaces `items` wholesale. If the user has paged to a later highlight and the refresh returns a shorter list, `activeIndex` is left pointing past the end. `currentItem` becomes `undefined`, and the render falls through to:

```ts
if (!currentItem || items.length === 0) {
  return ( /* "Add some documents to see highlights here" empty state */ )
}
```

So the card shows the empty "add documents" state even though highlights exist. The pagination row is only rendered in the populated branch, so there is no visible control to page back into range — the card stays stuck on the empty state until it remounts.

### Repro

1. Have at least 2 highlights so the pager shows.
2. Page to the last highlight (`activeIndex > 0`).
3. Let the brief refresh (or simulate it) with fewer highlights than the current `activeIndex + 1`.

Result on `main`: the card renders "Add some documents to see highlights here" despite having highlights, with no way to recover in-place. The same happens for any parent that swaps `items` for a shorter array while the user is on a later page.

### Fix

Clamp `activeIndex` into range whenever `items` changes, next to the existing reset:

```ts
setActiveIndex((i) => Math.min(i, Math.max(items.length - 1, 0)))
```

This keeps the current position when it is still valid and only pulls it back when the list shrank. When `items` is genuinely empty it resolves to `0`, and the existing `items.length === 0` guard renders the empty state correctly.

Also removes a `useExhaustiveDependencies` suppression that is no longer needed: the effect body now reads `items.length`, so `items` is a real dependency rather than a suppressed one.

No test is included because `apps/web` has no component test harness set up; the change is a two-line clamp mirroring the same pattern used elsewhere for selection bounds. cc @MaheshtheDev @ishaanxgupta
