### PR TITLE
fix(memory-graph): stop painting expired memories as expiring

### DIFF
--- a/packages/memory-graph/src/__tests__/graph-data-utils.test.ts
+++ b/packages/memory-graph/src/__tests__/graph-data-utils.test.ts
@@ -65,6 +65,13 @@ describe("getMemoryBorderColor", () => {
 		expect(getMemoryBorderColor(mem, colors)).toBe(colors.memBorderExpiring)
 	})
 
+	it("does not treat an already-elapsed forgetAfter as expiring", () => {
+		const past = new Date(Date.now() - 60 * 1000).toISOString()
+		const old = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString()
+		const mem = makeMemory({ forgetAfter: past, createdAt: old })
+		expect(getMemoryBorderColor(mem, colors)).toBe(colors.memStrokeDefault)
+	})
+
 	it("returns recent color for memories created within 24 hours", () => {
 		const recent = new Date(Date.now() - 1000).toISOString()
 		const mem = makeMemory({ createdAt: recent })

--- a/packages/memory-graph/src/hooks/use-graph-data.ts
+++ b/packages/memory-graph/src/hooks/use-graph-data.ts
@@ -47,7 +47,10 @@ export function getMemoryBorderColor(
 	if (mem.isForgotten) return colors.memBorderForgotten
 	if (mem.forgetAfter) {
 		const msLeft = new Date(mem.forgetAfter).getTime() - Date.now()
-		if (msLeft < SEVEN_DAYS_MS) return colors.memBorderExpiring
+		// Only "expiring" while there is time left. A forgetAfter already in the
+		// past leaves msLeft negative, which still satisfied `< SEVEN_DAYS_MS` and
+		// painted the expiring border forever; let those fall through instead.
+		if (msLeft > 0 && msLeft < SEVEN_DAYS_MS) return colors.memBorderExpiring
 	}
 	const age = Date.now() - new Date(mem.createdAt).getTime()
 	if (age < ONE_DAY_MS) return colors.memBorderRecent

--- a/packages/memory-graph/src/hooks/use-graph-data.ts
+++ b/packages/memory-graph/src/hooks/use-graph-data.ts
@@ -47,9 +47,6 @@ export function getMemoryBorderColor(
 	if (mem.isForgotten) return colors.memBorderForgotten
 	if (mem.forgetAfter) {
 		const msLeft = new Date(mem.forgetAfter).getTime() - Date.now()
-		// Only "expiring" while there is time left. A forgetAfter already in the
-		// past leaves msLeft negative, which still satisfied `< SEVEN_DAYS_MS` and
-		// painted the expiring border forever; let those fall through instead.
 		if (msLeft > 0 && msLeft < SEVEN_DAYS_MS) return colors.memBorderExpiring
 	}
 	const age = Date.now() - new Date(mem.createdAt).getTime()


### PR DESCRIPTION
### Problem

`getMemoryBorderColor` decides the expiring border from the time left until `forgetAfter`:

```ts
if (mem.forgetAfter) {
  const msLeft = new Date(mem.forgetAfter).getTime() - Date.now()
  if (msLeft < SEVEN_DAYS_MS) return colors.memBorderExpiring
}
```

`msLeft < SEVEN_DAYS_MS` is meant to catch "expires within the next week", but it is also true for every `forgetAfter` in the past, where `msLeft` is negative. So a memory whose forget time has already elapsed, but which the server has not yet swept to `isForgotten`, keeps the expiring border forever. It reads as "about to expire" indefinitely instead of as a normal or already-expired node, and the closer to the past it gets the more wrong the signal is.

### Fix

Require that there is actually time left before marking a memory expiring:

```ts
if (msLeft > 0 && msLeft < SEVEN_DAYS_MS) return colors.memBorderExpiring
```

Elapsed memories fall through to the existing recency / default branch, which matches how an unremarkable node is drawn. The `isForgotten` early return above is unchanged, so anything already marked forgotten still gets the forgotten color first.

### Test

Added a case to `graph-data-utils.test.ts` for a memory with a `forgetAfter` a minute in the past and an old `createdAt`: it now resolves to `memStrokeDefault` rather than `memBorderExpiring`. Full package suite passes and `tsc --noEmit` is clean.
