### PR TITLE
fix(memory-graph): center arrow-key navigation in the visible graph area

### DIFF
--- a/packages/memory-graph/src/components/memory-graph.tsx
+++ b/packages/memory-graph/src/components/memory-graph.tsx
@@ -467,10 +467,10 @@ export function MemoryGraph({
 					n.x,
 					n.y,
 					containerSize.width,
-					containerSize.height,
+					graphFitHeight,
 				)
 		},
-		[nodes, containerSize.width, containerSize.height],
+		[nodes, containerSize.width, graphFitHeight],
 	)
 
 	const navigateUp = useCallback(() => {


### PR DESCRIPTION
### Problem

`viewport.centerOn(worldX, worldY, width, height)` positions the target point at `height / 2` on screen:

```ts
this.targetPanY = height / 2 - worldY * this.zoom
```

The component derives a separate `graphFitHeight` that, on compact viewports, reserves room for the bottom control bar:

```ts
const graphFitHeight = isCompactViewport
  ? Math.max(containerSize.height - 170, 240)
  : containerSize.height
```

Auto-fit, the center button, and the zoom controls all pass `graphFitHeight`, so they place content in the middle of the visible graph area. But `selectAndCenter` (arrow-key node navigation) passed the full `containerSize.height`:

```ts
viewportRef.current.centerOn(n.x, n.y, containerSize.width, containerSize.height)
```

So on mobile, stepping through nodes with the keyboard centers the selected node at the midpoint of the whole container, which puts it partly behind the bottom controls, while the dedicated center button drops the same graph correctly above them.

### Fix

Pass `graphFitHeight` (and depend on it) so `selectAndCenter` lands the node where the other centering paths already do:

```ts
viewportRef.current.centerOn(n.x, n.y, containerSize.width, graphFitHeight)
```

On desktop `graphFitHeight === containerSize.height`, so nothing changes there. Full memory-graph suite (188 tests) passes and `tsc --noEmit` is clean.
