### PR TITLE
fix(lib): stop re-subscribing global error listeners on every render

### DIFF
--- a/packages/lib/error-tracking.tsx
+++ b/packages/lib/error-tracking.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import { usePathname } from "next/navigation"
-import { useEffect } from "react"
+import { useEffect, useRef } from "react"
 import { useSession } from "./auth"
 import { usePostHog } from "./posthog"
 
@@ -79,10 +79,19 @@ export function ErrorTrackingProvider({
 }) {
 	const { trackError } = useErrorTracking()
 
+	// trackError is a fresh closure every render (it captures posthog, session and
+	// pathname), so keying the listener effect on it re-subscribed the two global
+	// window listeners on every render of this app-wide provider. Hold the latest
+	// trackError in a ref and register the listeners once for the provider's life.
+	const trackErrorRef = useRef(trackError)
+	useEffect(() => {
+		trackErrorRef.current = trackError
+	}, [trackError])
+
 	useEffect(() => {
 		// Global error handler for unhandled errors
 		const handleError = (event: ErrorEvent) => {
-			trackError(event.error, {
+			trackErrorRef.current(event.error, {
 				error_type: "global_error",
 				source: "window_error",
 				filename: event.filename,
@@ -93,7 +102,7 @@ export function ErrorTrackingProvider({
 
 		// Global handler for unhandled promise rejections
 		const handleUnhandledRejection = (event: PromiseRejectionEvent) => {
-			trackError(event.reason, {
+			trackErrorRef.current(event.reason, {
 				error_type: "unhandled_promise_rejection",
 				source: "promise_rejection",
 			})
@@ -106,7 +115,7 @@ export function ErrorTrackingProvider({
 			window.removeEventListener("error", handleError)
 			window.removeEventListener("unhandledrejection", handleUnhandledRejection)
 		}
-	}, [trackError])
+	}, [])
 
 	return <>{children}</>
 }


### PR DESCRIPTION
### Problem

`ErrorTrackingProvider` is mounted at the root of the app (`app/layout.tsx`) and installs global `window` `"error"` and `"unhandledrejection"` listeners in an effect keyed on `trackError`:

```tsx
const { trackError } = useErrorTracking()

useEffect(() => {
  const handleError = (event: ErrorEvent) => trackError(event.error, { ... })
  const handleUnhandledRejection = (event: PromiseRejectionEvent) => trackError(event.reason, { ... })
  window.addEventListener("error", handleError)
  window.addEventListener("unhandledrejection", handleUnhandledRejection)
  return () => { /* remove both */ }
}, [trackError])
```

`useErrorTracking` returns a fresh `trackError` on every render (it is a plain closure over `posthog`, `session` and `pathname`, not memoized), so the dependency changes every render. That tears down and re-adds both global listeners on every render of a provider that wraps the entire app, including on each navigation and session refresh. It is wasted work on a hot path, and it leaves a small window on each cycle where a synchronously thrown error can land between the `removeEventListener` and the following `addEventListener`.

### Fix

Keep the latest `trackError` in a ref and register the listeners once for the provider's lifetime, dispatching through the ref:

```tsx
const trackErrorRef = useRef(trackError)
useEffect(() => { trackErrorRef.current = trackError }, [trackError])

useEffect(() => {
  const handleError = (event: ErrorEvent) => trackErrorRef.current(event.error, { ... })
  const handleUnhandledRejection = (event: PromiseRejectionEvent) => trackErrorRef.current(event.reason, { ... })
  window.addEventListener("error", handleError)
  window.addEventListener("unhandledrejection", handleUnhandledRejection)
  return () => { /* remove both */ }
}, [])
```

The listeners are now added once and removed on unmount, and each report still reads the current `posthog` / `session` / `pathname` context through the ref. No functional change to what gets tracked, just no more churn.
