### PR TITLE
fix(docs): revert homepage href prefixes causing doubled /docs/docs/ 404s

### DIFF
--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -40,19 +40,19 @@ export const HeroCard = ({ imageUrl, title, description, href }) => {
       </p>
       <div className="mt-8 flex flex-wrap items-center gap-3">
         <a
-          href="/docs/concepts/how-it-works"
+          href="/concepts/how-it-works"
           className="inline-flex items-center justify-center rounded-lg bg-gray-900 dark:bg-zinc-100 px-4 py-2.5 text-sm font-medium text-white dark:text-zinc-900 hover:bg-gray-800 dark:hover:bg-white transition-colors"
         >
           Architecture
         </a>
         <a
-          href="/docs/quickstart"
+          href="/quickstart"
           className="inline-flex items-center justify-center rounded-lg border border-gray-200 dark:border-zinc-700 bg-white dark:bg-zinc-950 px-4 py-2.5 text-sm font-medium text-gray-900 dark:text-zinc-100 hover:bg-gray-50 dark:hover:bg-zinc-900 transition-colors"
         >
           Quickstart
         </a>
         <a
-          href="/docs/company-brain/setup"
+          href="/company-brain/setup"
           className="inline-flex items-center justify-center rounded-lg px-3 py-2.5 text-sm font-medium text-gray-600 dark:text-zinc-400 hover:text-gray-900 dark:hover:text-zinc-100 hover:bg-gray-100/80 dark:hover:bg-zinc-800/80 transition-colors"
         >
           Set up your company brain
@@ -65,25 +65,25 @@ export const HeroCard = ({ imageUrl, title, description, href }) => {
         imageUrl="/docs/images/intro-company-brain.jpg"
         title="Developer platform"
         description="API reference, concepts, and SDKs"
-        href="/docs/overview/what-is-supermemory"
+        href="/overview/what-is-supermemory"
       />
       <HeroCard
         imageUrl="/docs/images/intro-company-brain-card.jpg"
         title="Company brain"
         description="Team knowledge on the same engine"
-        href="/docs/company-brain/overview"
+        href="/company-brain/overview"
       />
       <HeroCard
         imageUrl="/docs/images/intro-plugins.jpg"
         title="Plugins and MCP"
         description="Drop memory into Claude and coding agents"
-        href="/docs/supermemory-mcp/mcp"
+        href="/supermemory-mcp/mcp"
       />
       <HeroCard
         imageUrl="/docs/images/intro-developer-platform.png"
         title="Self-hosting"
         description="Run it locally with zero config"
-        href="/docs/self-hosting/overview"
+        href="/self-hosting/overview"
       />
     </div>
   </div>


### PR DESCRIPTION
Mintlify's client-side router intercepts same-origin anchor clicks
(including raw <a> tags, not just its own components) and automatically
prepends /docs on navigation — that's how the unprefixed top-nav links
correctly land on /docs/company-brain/overview etc. Hardcoding /docs
into these homepage hrefs made the router double it up to
/docs/docs/company-brain/overview, a real 404 confirmed by clicking
through in a live browser. Reverted to unprefixed hrefs, matching every
other internal link in the docs and what `mintlify broken-links` expects.
Image src/icon/imageUrl paths are untouched — those are literal
resource fetches never touched by the router, so they still need the
explicit /docs prefix.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only link path fix with no runtime, auth, or data impact.
> 
> **Overview**
> Fixes **broken homepage navigation** by changing internal `href`s on the docs landing page from `/docs/...` back to **site-root paths** (e.g. `/quickstart`, `/company-brain/overview`).
> 
> Mintlify’s client-side router already prepends `/docs` on same-origin link clicks, so explicit `/docs` prefixes were doubled to `/docs/docs/...` and 404’d. The update aligns the hero buttons and `HeroCard` links with **other internal doc links** and `mintlify broken-links` expectations.
> 
> **Image `imageUrl` paths are unchanged** — they still use `/docs/images/...` because those are static asset URLs, not router-handled navigation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d05a657714f93e22273baa3e10da621ac8d4dd0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->