### PR TITLE
fix(web): don't use consumer email domains as the company domain

### DIFF
--- a/apps/web/components/onboarding-brain/types.ts
+++ b/apps/web/components/onboarding-brain/types.ts
@@ -43,6 +43,11 @@ const FREE_EMAIL_DOMAINS = new Set([
 	"duck.com",
 ])
 
+export function isFreeEmailDomain(domain: string | undefined | null): boolean {
+	if (!domain) return false
+	return FREE_EMAIL_DOMAINS.has(domain.toLowerCase().trim())
+}
+
 export function detectModeFromEmail(
 	email: string | undefined | null,
 ): BrainMode {
@@ -54,7 +59,7 @@ export function detectModeFromEmail(
 		.toLowerCase()
 		.trim()
 	if (!domain) return "personal"
-	if (FREE_EMAIL_DOMAINS.has(domain)) return "personal"
+	if (isFreeEmailDomain(domain)) return "personal"
 	return "team"
 }
 
@@ -86,6 +91,7 @@ export function workspaceNameFromDomain(
 	return host.charAt(0).toUpperCase() + host.slice(1)
 }
 
+/** Company domain from an email, or null for consumer providers (gmail.com etc). */
 export function workspaceDomainFromEmail(
 	email: string | undefined | null,
 ): string | null {
@@ -96,7 +102,8 @@ export function workspaceDomainFromEmail(
 		.slice(at + 1)
 		.toLowerCase()
 		.trim()
-	return domain || null
+	if (!domain || isFreeEmailDomain(domain)) return null
+	return domain
 }
 
 export type BrainMetadata = {


### PR DESCRIPTION
workspaceDomainFromEmail returned the raw domain for free providers, so a gmail.com user picking Team was shown gmail.com as their company domain. Confirming it named the org "Gmail", persisted brainWorkspaceDomain, and ran company research against Gmail.

It now returns null for consumer providers, so the confirm step starts empty and requires a real company domain.