### PR TITLE
fix(docs): update quickstart link to correct path

### DIFF
--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -46,7 +46,7 @@ export const HeroCard = ({ imageUrl, title, description, href }) => {
           Architecture
         </a>
         <a
-          href="/quickstart"
+          href="/docs/quickstart"
           className="inline-flex items-center justify-center rounded-lg border border-gray-200 dark:border-zinc-700 bg-white dark:bg-zinc-950 px-4 py-2.5 text-sm font-medium text-gray-900 dark:text-zinc-100 hover:bg-gray-50 dark:hover:bg-zinc-900 transition-colors"
         >
           Quickstart


### PR DESCRIPTION
- It was pointing to 404. Now it redirects to `/docs/quickstart`