### PR TITLE
fix(memory-graph): accessible names and states for graph controls

### DIFF
--- a/packages/memory-graph/src/__tests__/controls-a11y.e2e.test.tsx
+++ b/packages/memory-graph/src/__tests__/controls-a11y.e2e.test.tsx
@@ -1,0 +1,95 @@
+/**
+ * Mounted-render accessibility checks for the graph control surfaces:
+ * accessible names on icon-only zoom buttons, disclosure state on the legend,
+ * and a live region on the loading indicator.
+ */
+
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render } from "@testing-library/react"
+import { afterEach, describe, expect, it } from "vitest"
+
+afterEach(cleanup)
+
+import { Legend } from "../components/legend"
+import { LoadingIndicator } from "../components/loading-indicator"
+import { NavigationControls } from "../components/navigation-controls"
+import { DEFAULT_COLORS, DEFAULT_LABELS } from "../constants"
+import type { GraphNode } from "../types"
+
+const node: GraphNode = {
+	id: "doc-1",
+	type: "document",
+	x: 0,
+	y: 0,
+	data: {
+		id: "doc-1",
+		title: "Doc",
+		summary: null,
+		type: "text",
+		createdAt: "2026-01-01",
+		updatedAt: "2026-01-01",
+		memories: [],
+	},
+	size: 40,
+	borderColor: "#fff",
+	isHovered: false,
+	isDragging: false,
+}
+
+const noop = () => {}
+
+describe("NavigationControls accessibility", () => {
+	it("gives the icon-only zoom buttons accessible names", () => {
+		const { getByLabelText } = render(
+			<NavigationControls
+				onCenter={noop}
+				onZoomIn={noop}
+				onZoomOut={noop}
+				onAutoFit={noop}
+				nodes={[node]}
+				zoomLevel={100}
+				colors={DEFAULT_COLORS}
+			/>,
+		)
+
+		expect(getByLabelText("Zoom in")).toBeTruthy()
+		expect(getByLabelText("Zoom out")).toBeTruthy()
+	})
+})
+
+describe("Legend accessibility", () => {
+	it("exposes disclosure state via aria-expanded and toggles it", () => {
+		const { getByRole } = render(
+			<Legend
+				nodes={[node]}
+				edges={[]}
+				colors={DEFAULT_COLORS}
+				labels={DEFAULT_LABELS}
+			/>,
+		)
+
+		const toggle = getByRole("button", { name: "Legend" })
+		expect(toggle.getAttribute("aria-expanded")).toBe("false")
+
+		fireEvent.click(toggle)
+		expect(toggle.getAttribute("aria-expanded")).toBe("true")
+	})
+})
+
+describe("LoadingIndicator accessibility", () => {
+	it("announces loading through a status live region", () => {
+		const { getByRole } = render(
+			<LoadingIndicator
+				isLoading
+				isLoadingMore={false}
+				totalLoaded={0}
+				colors={DEFAULT_COLORS}
+				labels={DEFAULT_LABELS}
+			/>,
+		)
+
+		const status = getByRole("status")
+		expect(status.getAttribute("aria-live")).toBe("polite")
+	})
+})

--- a/packages/memory-graph/src/components/legend.tsx
+++ b/packages/memory-graph/src/components/legend.tsx
@@ -244,6 +244,7 @@ function StatRow({
 				onClick={expandable ? onToggle : undefined}
 				style={buttonStyle}
 				type="button"
+				aria-expanded={expandable ? expanded : undefined}
 			>
 				<div style={leftStyle}>
 					{icon}
@@ -428,6 +429,7 @@ export const Legend = memo(function Legend({
 						onClick={() => setIsExpanded(!isExpanded)}
 						style={headerBtnStyle}
 						type="button"
+						aria-expanded={isExpanded}
 					>
 						{isExpanded ? (
 							<ChevronDownIcon color={colors.textPrimary} />

--- a/packages/memory-graph/src/components/loading-indicator.tsx
+++ b/packages/memory-graph/src/components/loading-indicator.tsx
@@ -76,7 +76,7 @@ export const LoadingIndicator = memo<
 		}
 
 		return (
-			<div style={containerStyle}>
+			<output style={containerStyle} aria-live="polite">
 				<div style={flexStyle}>
 					<svg
 						aria-hidden="true"
@@ -96,7 +96,7 @@ export const LoadingIndicator = memo<
 							: labels.loadingMoreDocuments(totalLoaded)}
 					</span>
 				</div>
-			</div>
+			</output>
 		)
 	},
 )

--- a/packages/memory-graph/src/components/navigation-controls.tsx
+++ b/packages/memory-graph/src/components/navigation-controls.tsx
@@ -168,6 +168,7 @@ export const NavigationControls = memo<NavigationControlsProps>(
 							onClick={onZoomOut}
 							style={zoomBtnStyle}
 							type="button"
+							aria-label="Zoom out"
 							onMouseEnter={(e) => {
 								e.currentTarget.style.opacity = "0.8"
 							}}
@@ -175,12 +176,15 @@ export const NavigationControls = memo<NavigationControlsProps>(
 								e.currentTarget.style.opacity = "1"
 							}}
 						>
-							<span style={{ fontSize: 12 }}>−</span>
+							<span aria-hidden="true" style={{ fontSize: 12 }}>
+								−
+							</span>
 						</button>
 						<button
 							onClick={onZoomIn}
 							style={zoomBtnStyle}
 							type="button"
+							aria-label="Zoom in"
 							onMouseEnter={(e) => {
 								e.currentTarget.style.opacity = "0.8"
 							}}
@@ -188,7 +192,9 @@ export const NavigationControls = memo<NavigationControlsProps>(
 								e.currentTarget.style.opacity = "1"
 							}}
 						>
-							<span style={{ fontSize: 12 }}>+</span>
+							<span aria-hidden="true" style={{ fontSize: 12 }}>
+								+
+							</span>
 						</button>
 					</div>
 				</div>


### PR DESCRIPTION
A few screen-reader gaps in the published `@supermemory/memory-graph` control surfaces.

### Zoom buttons had no accessible name

The zoom in/out buttons render only a `+` / `−` glyph inside a `<span>`, with no text or label, so assistive tech announces them as an unnamed "button". Added `aria-label` ("Zoom in" / "Zoom out") and marked the decorative glyphs `aria-hidden`. The neighbouring Fit/Center buttons already have visible text, so only the icon-only zoom controls needed it.

### Legend disclosure buttons never exposed `aria-expanded`

The Legend header toggle and the expandable "Connections" row are disclosure widgets that show/hide content on click, but neither set `aria-expanded`, so a screen-reader user cannot tell whether the section is open or closed. Wired `aria-expanded` to the actual state (and left it off non-expandable rows).

### Loading indicator was not announced

The loading card was a plain `<div>`, so when loading starts or flips to "loading more" the status text is never announced. Switched the container to an `<output>` element (implicit `status` role) with `aria-live="polite"`, matching how a status region should behave.

### Tests

Added `controls-a11y.e2e.test.tsx` (mounted, happy-dom, same pattern as the existing popover render test): asserts the zoom buttons resolve by accessible name, the Legend toggle flips `aria-expanded` false → true on click, and the loading indicator exposes a polite `status` live region. Full package suite (198 tests) and `tsc --noEmit` are green.
