### PR TITLE
feat(memory-graph): add onNodeSelect callback for selection changes

### DIFF
--- a/packages/memory-graph/README.md
+++ b/packages/memory-graph/README.md
@@ -66,6 +66,7 @@ function App() {
 | `error` | `Error \| null` | Error to display |
 | `loadMoreDocuments` | `() => Promise<void>` | Function to load more data |
 | `highlightDocumentIds` | `string[]` | IDs of documents to highlight |
+| `onNodeSelect` | `(nodeId: string \| null) => void` | Called when the selected node changes (click, keyboard, slideshow, or cleared) |
 
 ## Documentation
 

--- a/packages/memory-graph/src/components/memory-graph.tsx
+++ b/packages/memory-graph/src/components/memory-graph.tsx
@@ -39,6 +39,7 @@ export function MemoryGraph({
 	colors: colorOverrides,
 	totalCount,
 	onOpenDocument,
+	onNodeSelect,
 	labels: labelOverrides,
 	layering,
 }: MemoryGraphProps) {
@@ -72,6 +73,21 @@ export function MemoryGraph({
 	// Monotonic counter that increments on any viewport change (pan or zoom)
 	// Used as a dependency proxy to recalculate popover positions
 	const [viewportVersion, setViewportVersion] = useState(0)
+
+	// Surface selection changes to the host without making selection controlled.
+	// Keyed on selectedNode only; the callback is read through a ref so a changing
+	// callback identity does not re-fire it. The initial mount is skipped so a
+	// host does not receive a spurious null before any interaction.
+	const onNodeSelectRef = useRef(onNodeSelect)
+	onNodeSelectRef.current = onNodeSelect
+	const hasEmittedSelectionRef = useRef(false)
+	useEffect(() => {
+		if (!hasEmittedSelectionRef.current) {
+			hasEmittedSelectionRef.current = true
+			return
+		}
+		onNodeSelectRef.current?.(selectedNode)
+	}, [selectedNode])
 
 	// Limit documents so total node count (documents + their memories) stays under maxNodes
 	const limitedDocuments = useMemo(() => {

--- a/packages/memory-graph/src/types.ts
+++ b/packages/memory-graph/src/types.ts
@@ -216,6 +216,13 @@ export interface MemoryGraphProps {
 	totalCount?: number
 	/** Callback when user wants to view full document content */
 	onOpenDocument?: (documentId: string) => void
+	/**
+	 * Called whenever the selected node changes, by click, keyboard navigation,
+	 * slideshow, or clearing the selection (nodeId is null when nothing is
+	 * selected). Lets a host observe selection without owning the state, e.g. to
+	 * drive a side panel or sync the URL.
+	 */
+	onNodeSelect?: (nodeId: string | null) => void
 	/** Custom user-facing labels (partial) - merged with defaults */
 	labels?: MemoryGraphLabels
 	/** Overlay layering controls */


### PR DESCRIPTION
### Motivation

`selectedNode` lives entirely inside `MemoryGraph`. A host that embeds the graph currently has no way to observe which node is selected except through `onSlideshowNodeChange` (slideshow mode only) or `onOpenDocument` (fires only on the explicit open-document action). So common integrations are awkward: showing details in the host's own side panel, syncing the selection into the URL, or firing analytics when a user selects a node.

### Change

Add an optional, backward-compatible `onNodeSelect?: (nodeId: string | null) => void` prop:

```tsx
<MemoryGraph
  documents={documents}
  onNodeSelect={(nodeId) => {
    // nodeId is null when the selection is cleared
    setActivePanelNode(nodeId)
  }}
/>
```

It fires whenever the selection changes, regardless of source (click, keyboard navigation, slideshow, or clearing), with `null` when nothing is selected.

Implementation notes:
- Emitted from an effect keyed only on the selection state; the callback is read through a ref, so a changing callback identity does not re-fire it and does not force the effect to re-run. This mirrors the existing `onSlideshowNodeChangeRef` pattern already used in this component.
- The selection stays fully **uncontrolled** — this is an observation hook, not a controlled prop.
- The initial mount is skipped, so a host does not receive a spurious `null` before any interaction.

### Verification

`tsc --noEmit` clean, `vite build` succeeds, and the full package suite (198 tests) passes. I did not add a unit test that drives a live selection because the full `MemoryGraph` mount needs a real canvas/container size that happy-dom does not provide (the existing `onSlideshowNodeChange` / `onOpenDocument` callback props are untested for the same reason). Happy to wire this differently if you would prefer it emitted inline at the click/keyboard call sites instead of from the selection effect.
