### PR TITLE
fix(web): update ChatGPT MCP setup instructions

### DIFF
--- a/apps/web/components/connect-ai-modal.tsx
+++ b/apps/web/components/connect-ai-modal.tsx
@@ -672,10 +672,8 @@ export function ConnectAIModal({
 															</a>
 															.
 														</li>
-														<li>
-															Paste the URL below and complete OAuth in
-															ChatGPT.
-														</li>
+														<li>Paste the URL below.</li>
+														<li>Complete OAuth in ChatGPT.</li>
 													</ol>
 													<div className="relative max-w-full sm:max-w-xl">
 														<Input
@@ -693,6 +691,14 @@ export function ConnectAIModal({
 															<CopyIcon className="size-4" />
 														</Button>
 													</div>
+													<a
+														className="text-xs text-primary underline"
+														href="https://developers.openai.com/api/docs/guides/developer-mode/"
+														rel="noopener noreferrer"
+														target="_blank"
+													>
+														Developer mode docs (OpenAI)
+													</a>
 												</div>
 											)
 										}

--- a/apps/web/components/connect-ai-modal.tsx
+++ b/apps/web/components/connect-ai-modal.tsx
@@ -650,16 +650,32 @@ export function ConnectAIModal({
 										if (manual.kind === "chatgpt") {
 											return (
 												<div className="space-y-3">
+													<p className="text-xs leading-relaxed text-amber-600 dark:text-amber-500/90">
+														Write-capable custom MCP apps are only supported on
+														Business & Enterprise plans.
+													</p>
 													<ol className="list-decimal space-y-2 pl-5 text-sm text-muted-foreground">
 														<li>Open ChatGPT in your browser.</li>
 														<li>
-															Settings → Apps → Advanced settings → enable
-															Developer mode.
+															Go to Settings → Security and Login → scroll to
+															the bottom to enable Developer mode.
 														</li>
 														<li>
-															Create an app and paste the MCP URL when asked.
+															Go to{" "}
+															<a
+																className="text-primary underline"
+																href="https://chatgpt.com/plugins"
+																rel="noopener noreferrer"
+																target="_blank"
+															>
+																chatgpt.com/plugins
+															</a>
+															.
 														</li>
-														<li>Complete OAuth in ChatGPT.</li>
+														<li>
+															Paste the URL below and complete OAuth in
+															ChatGPT.
+														</li>
 													</ol>
 													<div className="relative max-w-full sm:max-w-xl">
 														<Input
@@ -677,14 +693,6 @@ export function ConnectAIModal({
 															<CopyIcon className="size-4" />
 														</Button>
 													</div>
-													<a
-														className="text-xs text-primary underline"
-														href="https://developers.openai.com/api/docs/guides/developer-mode/"
-														rel="noopener noreferrer"
-														target="_blank"
-													>
-														Developer mode docs (OpenAI)
-													</a>
 												</div>
 											)
 										}

--- a/apps/web/components/mcp-modal/mcp-detail-view.tsx
+++ b/apps/web/components/mcp-modal/mcp-detail-view.tsx
@@ -502,15 +502,27 @@ export function MCPSteps({ variant = "full" }: MCPStepsProps) {
 									if (manual.kind === "chatgpt") {
 										return (
 											<div className="space-y-3">
+												<p className="text-[12px] leading-relaxed text-amber-500/90">
+													Write-capable custom MCP apps are only supported on
+													Business & Enterprise plans.
+												</p>
 												<ol className="list-decimal space-y-2 pl-5 text-[13px] leading-relaxed text-[#A1A1AA]">
 													<li>Open ChatGPT in your browser.</li>
 													<li>
-														Go to Settings → Apps → Advanced settings → enable
-														Developer mode.
+														Go to Settings → Security and Login → scroll to the
+														bottom to enable Developer mode.
 													</li>
 													<li>
-														Create an app and choose your MCP server URL when
-														asked.
+														Go to{" "}
+														<a
+															className="text-[#4BA0FA] underline hover:text-[#8BC6FF]"
+															href="https://chatgpt.com/plugins"
+															rel="noopener noreferrer"
+															target="_blank"
+														>
+															chatgpt.com/plugins
+														</a>
+														.
 													</li>
 													<li>
 														Paste the URL below and complete OAuth in ChatGPT.
@@ -523,14 +535,6 @@ export function MCPSteps({ variant = "full" }: MCPStepsProps) {
 														setActiveStep(3)
 													}}
 												/>
-												<a
-													className="inline-block text-[13px] text-[#4BA0FA] underline hover:text-[#8BC6FF]"
-													href="https://developers.openai.com/api/docs/guides/developer-mode/"
-													rel="noopener noreferrer"
-													target="_blank"
-												>
-													Developer mode docs (OpenAI)
-												</a>
 											</div>
 										)
 									}

--- a/apps/web/components/mcp-modal/mcp-detail-view.tsx
+++ b/apps/web/components/mcp-modal/mcp-detail-view.tsx
@@ -524,9 +524,8 @@ export function MCPSteps({ variant = "full" }: MCPStepsProps) {
 														</a>
 														.
 													</li>
-													<li>
-														Paste the URL below and complete OAuth in ChatGPT.
-													</li>
+													<li>Paste the URL below.</li>
+													<li>Complete OAuth in ChatGPT.</li>
 												</ol>
 												<McpCodeBlock
 													code={CHATGPT_REMOTE_MCP_URL}
@@ -535,6 +534,14 @@ export function MCPSteps({ variant = "full" }: MCPStepsProps) {
 														setActiveStep(3)
 													}}
 												/>
+												<a
+													className="inline-block text-[13px] text-[#4BA0FA] underline hover:text-[#8BC6FF]"
+													href="https://developers.openai.com/api/docs/guides/developer-mode/"
+													rel="noopener noreferrer"
+													target="_blank"
+												>
+													Developer mode docs (OpenAI)
+												</a>
 											</div>
 										)
 									}


### PR DESCRIPTION
## Summary
- Update ChatGPT MCP install steps to Security and Login → Developer mode, then chatgpt.com/plugins
- Add a warning that write-capable custom MCP apps require Business & Enterprise plans

## Test plan
1. Open Connect AI / MCP modal → ChatGPT
2. Confirm warning + new numbered steps render in both places
3. Confirm MCP URL copy still works