### PR TITLE
fix(web): use organization branding in Company Brain shares

### DIFF
--- a/apps/web/components/share-modal.tsx
+++ b/apps/web/components/share-modal.tsx
@@ -15,6 +15,7 @@ import { XIcon, Download, Copy, Check } from "lucide-react"
 import { GradientLogo } from "@ui/assets/Logo"
 import { useAuth } from "@lib/auth-context"
 import { useLocalStorageUsername } from "@hooks/use-local-storage-username"
+import { useHasCompanyBrain } from "@/hooks/use-company-brain"
 import { toast } from "sonner"
 import * as htmlToImage from "html-to-image"
 
@@ -276,7 +277,8 @@ export function ShareModal({
 	onClose,
 	graphCanvasRef,
 }: ShareModalProps) {
-	const { user } = useAuth()
+	const { user, org } = useAuth()
+	const isCompanyBrain = useHasCompanyBrain()
 	const [selectedTheme, setSelectedTheme] =
 		useState<BackgroundTheme>("gradient")
 	const [isCopying, setIsCopying] = useState(false)
@@ -291,6 +293,15 @@ export function ShareModal({
 		user?.email?.split("@")[0] ||
 		""
 	const userName = displayName ? `${displayName.split(" ")[0]}'s` : "Your"
+	const orgLabel = org?.name.replace(/\s*organizations?\s*$/i, "").trim()
+	const ownerLabel = isCompanyBrain
+		? orgLabel
+			? /['’]s$/i.test(orgLabel)
+				? orgLabel
+				: `${orgLabel}'s`
+			: "Your company's"
+		: userName
+	const productName = isCompanyBrain ? "Company Brain" : "supermemory"
 
 	const capturePreview = useCallback(async (): Promise<Blob | null> => {
 		if (!previewRef.current) return null
@@ -439,10 +450,10 @@ export function ShareModal({
 							<GradientLogo className="w-7 h-6" />
 							<div className="flex flex-col">
 								<span className="text-[10px] text-white/70 leading-tight">
-									{userName}
+									{ownerLabel}
 								</span>
 								<span className="text-sm text-white font-semibold leading-tight">
-									supermemory
+									{productName}
 								</span>
 							</div>
 						</div>


### PR DESCRIPTION
<!-- VORFLUX_AGENT_PR_BODY_BEGIN -->
Company Brain share snapshots now use the active organization’s branding instead of the signed-in user’s personal name.

## Changes

- Detect Company Brain workspaces through the canonical hook.
- Render the normalized organization name with `Company Brain`, preserving personal share branding for other workspaces.
- Handle missing, organization-suffixed, and already-possessive organization names.

## Testing

- **Passed:** `node_modules/.bin/biome ci apps/web/components/share-modal.tsx`
- **Passed:** `git diff --check -- apps/web/components/share-modal.tsx`
- **Baseline failure:** `node_modules/.bin/tsc --noEmit --incremental false -p apps/web/tsconfig.json` reports existing workspace diagnostics. The only diagnostic in `share-modal.tsx` is present on `HEAD`; none reference the new branding code.
- **Blocked:** authenticated visual verification was not performed because no authenticated browser state was available and no login retry was requested.
  - Blocker screenshot:
  - Blocked-flow recording:

---
**Attached Images and Videos**

![share-personal.png](https://api.us1.vorflux.com/assets/artifacts/c3VwZXJtZW1vcnk6Zjo3NDI0.XIMCcXoYysALm_LIfpnvO2S9fa6ME5753QqP6-8JZQE.png)

🎥 [View recording: share-branding-walkthrough.webm](https://api.us1.vorflux.com/assets/artifacts/c3VwZXJtZW1vcnk6Zjo3NDI1.PLlwgZToeGPRdV49tEQESgrTiADIUq5pHQcQjzfGMQ0.mp4)
<!-- VORFLUX_AGENT_PR_BODY_END -->

---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/22b72a15-9127-44be-b15b-3d341e26d016)
- Requested by: Dhravya Shah (dhravya@supermemory.com)
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only UI in the share preview with no auth, API, or data-handling changes.
> 
> **Overview**
> Share snapshot previews now switch branding when the workspace is **Company Brain**, instead of always showing the signed-in user’s name and **supermemory**.
> 
> The modal uses `useHasCompanyBrain` and org data from auth to set the preview header: a normalized org possessive label (with fallbacks for missing names, trailing “organization”, and names that already end in `'s`) plus **Company Brain** as the product line. Non–Company Brain workspaces keep the existing personal **supermemory** branding.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 087019f357b8c9c028bd2e9e915a550bcce24573. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->