### PR TITLE
fix(docs): add missing /docs/ prefix to custom component hrefs

### DIFF
--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -40,19 +40,19 @@ export const HeroCard = ({ imageUrl, title, description, href }) => {
       </p>
       <div className="mt-8 flex flex-wrap items-center gap-3">
         <a
-          href="/concepts/how-it-works"
+          href="/docs/concepts/how-it-works"
           className="inline-flex items-center justify-center rounded-lg bg-gray-900 dark:bg-zinc-100 px-4 py-2.5 text-sm font-medium text-white dark:text-zinc-900 hover:bg-gray-800 dark:hover:bg-white transition-colors"
         >
           Architecture
         </a>
         <a
-          href="/quickstart"
+          href="/docs/quickstart"
           className="inline-flex items-center justify-center rounded-lg border border-gray-200 dark:border-zinc-700 bg-white dark:bg-zinc-950 px-4 py-2.5 text-sm font-medium text-gray-900 dark:text-zinc-100 hover:bg-gray-50 dark:hover:bg-zinc-900 transition-colors"
         >
           Quickstart
         </a>
         <a
-          href="/company-brain/setup"
+          href="/docs/company-brain/setup"
           className="inline-flex items-center justify-center rounded-lg px-3 py-2.5 text-sm font-medium text-gray-600 dark:text-zinc-400 hover:text-gray-900 dark:hover:text-zinc-100 hover:bg-gray-100/80 dark:hover:bg-zinc-800/80 transition-colors"
         >
           Set up your company brain
@@ -65,25 +65,25 @@ export const HeroCard = ({ imageUrl, title, description, href }) => {
         imageUrl="/docs/images/intro-company-brain.jpg"
         title="Developer platform"
         description="API reference, concepts, and SDKs"
-        href="/overview/what-is-supermemory"
+        href="/docs/overview/what-is-supermemory"
       />
       <HeroCard
         imageUrl="/docs/images/intro-company-brain-card.jpg"
         title="Company brain"
         description="Team knowledge on the same engine"
-        href="/company-brain/overview"
+        href="/docs/company-brain/overview"
       />
       <HeroCard
         imageUrl="/docs/images/intro-plugins.jpg"
         title="Plugins and MCP"
         description="Drop memory into Claude and coding agents"
-        href="/supermemory-mcp/mcp"
+        href="/docs/supermemory-mcp/mcp"
       />
       <HeroCard
         imageUrl="/docs/images/intro-developer-platform.png"
         title="Self-hosting"
         description="Run it locally with zero config"
-        href="/self-hosting/overview"
+        href="/docs/self-hosting/overview"
       />
     </div>
   </div>

--- a/apps/docs/overview/what-is-supermemory.mdx
+++ b/apps/docs/overview/what-is-supermemory.mdx
@@ -32,32 +32,32 @@ It provides all the building blocks — Memory, Retrieval, Profiles, Connectors,
   <BuildingBlock
     icon="/docs/images/building-blocks/memory-router.svg"
     title="Memory & Continual Learning"
-    href="/concepts/graph-memory"
+    href="/docs/concepts/graph-memory"
   />
   <BuildingBlock
     icon="/docs/images/building-blocks/document-retrieval.svg"
     title="SuperRAG (Retrieval)"
-    href="/concepts/super-rag"
+    href="/docs/concepts/super-rag"
   />
   <BuildingBlock
     icon="/docs/images/building-blocks/file-systems.svg"
     title="Filesystems"
-    href="/smfs/overview"
+    href="/docs/smfs/overview"
   />
   <BuildingBlock
     icon="/docs/images/building-blocks/user-profiles.svg"
     title="Profiles"
-    href="/concepts/user-profiles"
+    href="/docs/concepts/user-profiles"
   />
   <BuildingBlock
     icon="/docs/images/building-blocks/connectors.svg"
     title="Connectors"
-    href="/connectors/overview"
+    href="/docs/connectors/overview"
   />
   <BuildingBlock
     icon="/docs/images/building-blocks/extractor.svg"
     title="Extractors"
-    href="/concepts/content-types"
+    href="/docs/concepts/content-types"
   />
   <BuildingBlock
     icon="/docs/images/building-blocks/qualitative-analysis.svg"
@@ -67,12 +67,12 @@ It provides all the building blocks — Memory, Retrieval, Profiles, Connectors,
   <BuildingBlock
     icon="/docs/images/building-blocks/hermes.svg"
     title="Plugins"
-    href="/supermemory-mcp/mcp"
+    href="/docs/supermemory-mcp/mcp"
   />
   <BuildingBlock
     icon="/docs/images/building-blocks/brain-head.png"
     title="Company Brain"
-    href="/company-brain/overview"
+    href="/docs/company-brain/overview"
   />
 </div>
 


### PR DESCRIPTION
## Summary

Custom MDX components (HeroCard, BuildingBlock) use raw `<a>` tags whose `href` values were missing the `/docs/` base path. Mintlify doesn't auto-prefix these, causing 404s.

## Changes

**`apps/docs/index.mdx`** - 7 links fixed:
- Architecture: `/concepts/how-it-works` -> `/docs/concepts/how-it-works`
- Quickstart: `/quickstart` -> `/docs/quickstart`
- Set up your company brain: `/company-brain/setup` -> `/docs/company-brain/setup`
- All 4 HeroCard hrefs (Developer platform, Company brain, Plugins, Self-hosting)

**`apps/docs/overview/what-is-supermemory.mdx`** - 8 BuildingBlock hrefs fixed

## Follow-up

Consider adding a broken link checker to CI (`mintlify broken-links`) to catch these in the future.
