### PR TITLE
Add consent flow for Slack workspace reassignment

### DIFF
--- a/apps/web/components/settings/company-brain-models.tsx
+++ b/apps/web/components/settings/company-brain-models.tsx
@@ -57,6 +57,13 @@ const EFFORT_LABELS: Record<BrainReasoningEffort, string> = {
 	high: "High",
 	xhigh: "Extra high",
 }
+const EFFORT_ORDER: BrainReasoningEffort[] = [
+	"auto",
+	"low",
+	"medium",
+	"high",
+	"xhigh",
+]
 
 const AUTO_EFFORT_HELP =
 	"Chooses Low, Medium, or High per request based on complexity. Manual choices skip the decider and use fixed effort, subject to provider limits."
@@ -170,6 +177,13 @@ const CONFIG_KEYS = [
 
 const extraHighIsBounded = (model: string): boolean =>
 	model.startsWith("grok-") || model.startsWith("gpt-")
+
+const orderedEfforts = (
+	options: BrainReasoningEffort[],
+): BrainReasoningEffort[] =>
+	[...options].sort(
+		(a, b) => EFFORT_ORDER.indexOf(a) - EFFORT_ORDER.indexOf(b),
+	)
 
 const controlClass = cn(
 	dmSans125ClassName(),
@@ -352,8 +366,10 @@ export default function CompanyBrainModels({
 							{ROWS.map(({ role, effortKey, title, help, effortHelp }) => {
 								const options = choices?.[role] ?? []
 								const current = valueFor(role)
-								const effortOptions = (choices?.[effortKey] ?? []).filter(
-									(effort) => role === "main" || effort !== "auto",
+								const effortOptions = orderedEfforts(
+									(choices?.[effortKey] ?? []).filter(
+										(effort) => role === "main" || effort !== "auto",
+									),
 								)
 								const currentEffort = effortFor(effortKey)
 								const isDefault =
@@ -449,7 +465,8 @@ export default function CompanyBrainModels({
 																}
 																className={cn(
 																	dmSans125ClassName(),
-																	"h-7 min-w-0 flex-1 cursor-pointer whitespace-nowrap rounded-full px-1 text-[11.5px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+																	"h-7 min-w-0 cursor-pointer whitespace-nowrap rounded-full px-1.5 text-[11.5px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+																	effort === "xhigh" ? "flex-[1.35]" : "flex-1",
 																	isOn
 																		? "bg-white/[0.10] text-[#FAFAFA]"
 																		: "text-[#8B929E] hover:text-[#FAFAFA]",

--- a/apps/web/components/settings/company-brain-models.tsx
+++ b/apps/web/components/settings/company-brain-models.tsx
@@ -66,7 +66,7 @@ const EFFORT_ORDER: BrainReasoningEffort[] = [
 ]
 
 const AUTO_EFFORT_HELP =
-	"Chooses Low, Medium, or High per request based on complexity. Manual choices skip the decider and use fixed effort, subject to provider limits."
+	"Automatically adjusts thinking depth for each request."
 
 const ROWS: {
 	role: BrainModelRole

--- a/apps/web/components/settings/company-brain-models.tsx
+++ b/apps/web/components/settings/company-brain-models.tsx
@@ -51,10 +51,17 @@ const MODEL_TAGS: Record<string, string> = {
 }
 
 const EFFORT_LABELS: Record<BrainReasoningEffort, string> = {
+	auto: "Auto",
 	low: "Low",
 	medium: "Medium",
 	high: "High",
 	xhigh: "Extra high",
+}
+
+const AUTO_EFFORT_HELP: Record<BrainModelRole, string> = {
+	main: "Chooses Low, Medium, or High per request based on complexity. Manual choices skip the decider and use fixed effort, subject to provider limits.",
+	triage: "Uses the selected model provider's default thinking depth.",
+	research: "Uses the selected model provider's default thinking depth.",
 }
 
 const ROWS: {
@@ -443,7 +450,7 @@ export default function CompanyBrainModels({
 																}
 																className={cn(
 																	dmSans125ClassName(),
-																	"h-7 min-w-0 flex-1 cursor-pointer rounded-full px-1 text-[11.5px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50",
+																	"h-7 min-w-0 flex-1 cursor-pointer whitespace-nowrap rounded-full px-1 text-[11.5px] font-medium transition-colors disabled:cursor-not-allowed disabled:opacity-50",
 																	isOn
 																		? "bg-white/[0.10] text-[#FAFAFA]"
 																		: "text-[#8B929E] hover:text-[#FAFAFA]",
@@ -454,9 +461,8 @@ export default function CompanyBrainModels({
 														)
 													})}
 												</div>
-												<div className="flex items-center justify-between px-1.5 text-[10px] font-medium text-[#4A5260]">
-													<span>Faster</span>
-													<span>Smarter</span>
+												<div className="px-1.5 text-center text-[10px] font-medium text-[#4A5260]">
+													Manual: faster → smarter
 												</div>
 												<p
 													className={cn(
@@ -464,7 +470,9 @@ export default function CompanyBrainModels({
 														"text-[11px] leading-[1.5] text-[#5F6673]",
 													)}
 												>
-													{effortHelp}
+													{currentEffort === "auto"
+														? AUTO_EFFORT_HELP[role]
+														: effortHelp}
 												</p>
 												{currentEffort === "xhigh" &&
 												extraHighIsBounded(current) ? (

--- a/apps/web/components/settings/company-brain-models.tsx
+++ b/apps/web/components/settings/company-brain-models.tsx
@@ -225,6 +225,13 @@ export default function CompanyBrainModels({
 	const [draft, setDraft] = useState<Partial<BrainModelConfig>>({})
 	const [advancedOpen, setAdvancedOpen] = useState(false)
 
+	const updateDraft = (patch: Partial<BrainModelConfig>) => {
+		// A saved custom config opens Advanced automatically. Keep it open if an
+		// edit happens to match a preset again, instead of collapsing mid-click.
+		setAdvancedOpen(true)
+		setDraft((currentDraft) => ({ ...currentDraft, ...patch }))
+	}
+
 	const resolved = modelsQuery.data?.resolved
 	const defaults = modelsQuery.data?.defaults
 	const choices = modelsQuery.data?.choices
@@ -364,10 +371,16 @@ export default function CompanyBrainModels({
 							{ROWS.map(({ role, effortKey, title, help, effortHelp }) => {
 								const options = choices?.[role] ?? []
 								const current = valueFor(role)
+								const availableEfforts = choices?.[effortKey] ?? []
 								const effortOptions = orderedEfforts(
-									(choices?.[effortKey] ?? []).filter(
-										(effort) => role === "main" || effort !== "auto",
-									),
+									role === "main"
+										? [
+												...new Set<BrainReasoningEffort>([
+													"auto",
+													...availableEfforts,
+												]),
+											]
+										: availableEfforts.filter((effort) => effort !== "auto"),
 								)
 								const currentEffort = effortFor(effortKey)
 								const isDefault =
@@ -415,9 +428,7 @@ export default function CompanyBrainModels({
 											<Select
 												value={current}
 												disabled={disabled}
-												onValueChange={(v) =>
-													setDraft((d) => ({ ...d, [role]: v }))
-												}
+												onValueChange={(v) => updateDraft({ [role]: v })}
 											>
 												<SelectTrigger className={controlClass}>
 													<SelectValue placeholder="Select a model…" />
@@ -456,10 +467,7 @@ export default function CompanyBrainModels({
 																aria-pressed={isOn}
 																disabled={disabled}
 																onClick={() =>
-																	setDraft((currentDraft) => ({
-																		...currentDraft,
-																		[effortKey]: effort,
-																	}))
+																	updateDraft({ [effortKey]: effort })
 																}
 																className={cn(
 																	dmSans125ClassName(),

--- a/apps/web/components/settings/company-brain-models.tsx
+++ b/apps/web/components/settings/company-brain-models.tsx
@@ -58,11 +58,8 @@ const EFFORT_LABELS: Record<BrainReasoningEffort, string> = {
 	xhigh: "Extra high",
 }
 
-const AUTO_EFFORT_HELP: Record<BrainModelRole, string> = {
-	main: "Chooses Low, Medium, or High per request based on complexity. Manual choices skip the decider and use fixed effort, subject to provider limits.",
-	triage: "Uses the selected model provider's default thinking depth.",
-	research: "Uses the selected model provider's default thinking depth.",
-}
+const AUTO_EFFORT_HELP =
+	"Chooses Low, Medium, or High per request based on complexity. Manual choices skip the decider and use fixed effort, subject to provider limits."
 
 const ROWS: {
 	role: BrainModelRole
@@ -351,11 +348,13 @@ export default function CompanyBrainModels({
 					</button>
 
 					{advancedOpen || activePresetId === null ? (
-						<div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+						<div className="grid gap-3 sm:grid-cols-2 xl:grid-cols-3">
 							{ROWS.map(({ role, effortKey, title, help, effortHelp }) => {
 								const options = choices?.[role] ?? []
 								const current = valueFor(role)
-								const effortOptions = choices?.[effortKey] ?? []
+								const effortOptions = (choices?.[effortKey] ?? []).filter(
+									(effort) => role === "main" || effort !== "auto",
+								)
 								const currentEffort = effortFor(effortKey)
 								const isDefault =
 									defaults?.[role] === current &&
@@ -470,8 +469,8 @@ export default function CompanyBrainModels({
 														"text-[11px] leading-[1.5] text-[#5F6673]",
 													)}
 												>
-													{currentEffort === "auto"
-														? AUTO_EFFORT_HELP[role]
+													{role === "main" && currentEffort === "auto"
+														? AUTO_EFFORT_HELP
 														: effortHelp}
 												</p>
 												{currentEffort === "xhigh" &&

--- a/apps/web/components/settings/company-brain-models.tsx
+++ b/apps/web/components/settings/company-brain-models.tsx
@@ -181,9 +181,7 @@ const extraHighIsBounded = (model: string): boolean =>
 const orderedEfforts = (
 	options: BrainReasoningEffort[],
 ): BrainReasoningEffort[] =>
-	[...options].sort(
-		(a, b) => EFFORT_ORDER.indexOf(a) - EFFORT_ORDER.indexOf(b),
-	)
+	[...options].sort((a, b) => EFFORT_ORDER.indexOf(a) - EFFORT_ORDER.indexOf(b))
 
 const controlClass = cn(
 	dmSans125ClassName(),

--- a/apps/web/hooks/use-brain-models.ts
+++ b/apps/web/hooks/use-brain-models.ts
@@ -7,7 +7,7 @@ const BACKEND =
 const BASE = `${BACKEND}/brain/models`
 
 export type BrainModelRole = "main" | "triage" | "research"
-export type BrainReasoningEffort = "low" | "medium" | "high" | "xhigh"
+export type BrainReasoningEffort = "auto" | "low" | "medium" | "high" | "xhigh"
 export type BrainReasoningKey = "mainEffort" | "triageEffort" | "researchEffort"
 
 export type BrainModelConfig = Record<BrainModelRole, string> &


### PR DESCRIPTION
Adds an authenticated consent screen for Slack workspaces that are already connected to another Company Brain. Reassignment now requires an explicit typed confirmation instead of happening silently.

## Changes

- Add pending, armed, submitting, recovery, expired, cancelled, and conflict states aligned with the Company Brain OAuth flow.
- Require the Slack workspace name or the exact `OVERRIDE` confirmation before enabling the destructive reassignment action.
- Handle ambiguous network outcomes safely by requesting status inspection instead of automatically retrying a mutation.
- Preserve safe same-origin destinations and the absolute override URL through sign-in, including the opaque request identifier.
- Support keyboard and screen-reader behavior, with reachable controls on short, mobile, and zoomed viewports.
- Document the Slack reassignment warning for Company Brain administrators.

## Testing

- Focused Biome checks passed.
- Changed-file TypeScript checks passed.
- Contract/helper matrix passed: 12/12.
- Production web build passed for the final changed route.
- Browser matrix passed for pending, armed, applying, error, expired, cancellation, connected handoff, and ambiguous network recovery.
- Login-resume test passed with an opaque request containing reserved characters and Unicode. The decoded login redirect exactly matched the absolute current override URL.
- Mobile 390px, short 900×500 viewport, and 200%-equivalent reflow passed with no horizontal overflow and reachable controls.
- Keyboard operation, terminal focus, and live announcements passed.

## Known limitations

- The root frontend typecheck remains blocked by unrelated existing `@supermemory/tools` errors.
- An earlier full-build attempt also encountered the unrelated existing `/auth/agent-connect` prerender failure.

## Rollout

Requires the companion `supermemoryai/mono` backend guard and API routes. Keep the backend feature flag off until both changes are deployed.

<img width="377" height="371" alt="Screenshot 2026-07-27 at 2 37 26 PM" src="https://github.com/user-attachments/assets/a3590cf9-3339-464c-9141-3402de81294e" />
![Uploading Screenshot 2026-07-27 at 2.37.21 PM.png…]()
