### PR TITLE
fix(web): allow custom MCP connections

### DIFF
--- a/apps/web/components/settings/company-brain-connections.tsx
+++ b/apps/web/components/settings/company-brain-connections.tsx
@@ -20,7 +20,6 @@ import {
 import { toast } from "sonner"
 import { dmSans125ClassName } from "@/lib/fonts"
 import { useHasCompanyBrain } from "@/hooks/use-company-brain"
-import { useAuth } from "@lib/auth-context"
 import { brainConnectorIcon, SlackMark } from "../brain-connector-icons"
 import { PillButton } from "../integrations/install-steps"
 
@@ -310,7 +309,6 @@ function RowSkeleton() {
 
 export default function CompanyBrainConnections() {
 	const isCompanyBrain = useHasCompanyBrain()
-	const { user } = useAuth()
 	const [catalog, setCatalog] = useState<CatalogEntry[] | null>(null)
 	const [catalogLoaded, setCatalogLoaded] = useState(false)
 	const [rows, setRows] = useState<ConnRow[]>([])
@@ -367,9 +365,6 @@ export default function CompanyBrainConnections() {
 				r.status === "active" &&
 				(shared ? r.userId === null : r.userId !== null),
 		)
-
-	const isStaff =
-		user?.email?.toLowerCase().endsWith("@supermemory.com") ?? false
 
 	const connect = async (entry: CatalogEntry, shared: boolean) => {
 		const key = `${entry.slug}:${shared ? "org" : "user"}`
@@ -462,10 +457,6 @@ export default function CompanyBrainConnections() {
 					redirectUrl: window.location.href,
 				}),
 			})
-			if (res.status === 403) {
-				toast.error("Custom MCP URLs are staff-only.")
-				return
-			}
 			const data = (await res.json().catch(() => ({}))) as {
 				authUrl?: string
 				ok?: boolean
@@ -609,20 +600,18 @@ export default function CompanyBrainConnections() {
 								}
 							/>
 						))}
-						{isStaff ? (
-							<button
-								type="button"
-								onClick={() => setCustomOpen(true)}
-								className={cn(
-									dmSans125ClassName(),
-									"flex min-h-[104px] cursor-pointer items-center justify-center gap-2 rounded-xl border border-[#2A313C] border-dashed",
-									"text-[13px] font-medium text-[#737B87] transition-colors hover:border-[#3A4150] hover:text-[#FAFAFA]",
-								)}
-							>
-								<Plus className="size-4" />
-								Add custom MCP
-							</button>
-						) : null}
+						<button
+							type="button"
+							onClick={() => setCustomOpen(true)}
+							className={cn(
+								dmSans125ClassName(),
+								"flex min-h-[104px] cursor-pointer items-center justify-center gap-2 rounded-xl border border-[#2A313C] border-dashed",
+								"text-[13px] font-medium text-[#737B87] transition-colors hover:border-[#3A4150] hover:text-[#FAFAFA]",
+							)}
+						>
+							<Plus className="size-4" />
+							Add custom MCP
+						</button>
 					</>
 				)}
 			</div>


### PR DESCRIPTION
<!-- VORFLUX_AGENT_PR_BODY_BEGIN -->
Show the custom MCP connection action to every Company Brain user instead of limiting it to `@supermemory.com` accounts.

## Changes

- Remove the client-side staff-email gate around **Add custom MCP**.
- Remove the stale staff-only error message and use the API response for connection failures.
- Keep the existing non-Company-Brain guard and personal custom MCP flow unchanged.

## Testing

- `NODE_ENV=production bun run build` — passed; all 26 static pages generated.
- `bunx biome check apps/web/components/settings/company-brain-connections.tsx` — passed.
- Static assertions for removed `isStaff`, `@supermemory.com`, `useAuth`, and staff-only toast — passed.
- Authenticated browser verification — blocked because no non-staff Company Brain browser session was available.
- Repository-wide `bun run check-types --filter=@repo/web` — blocked by pre-existing missing `vitest` and `@testing-library/react` types in `packages/memory-graph`; no errors referenced the changed component.

<!-- VORFLUX_AGENT_PR_BODY_END -->

---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/b217b93a-8d7e-42da-a890-46d8b094e457)
- Requested by: Dhravya Shah (dhravya@supermemory.com)
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit aba94f04cce71dde50c75a592ade6cb377bcd5c8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->