### PR TITLE
register SpaceState durable object

### DIFF
--- a/apps/mcp/src/index.ts
+++ b/apps/mcp/src/index.ts
@@ -197,5 +197,6 @@ app.all("/mcp/*", handleMcpRequest)
 
 // Export the Durable Object class for Cloudflare Workers
 export { SupermemoryMCP }
+export { SpaceState } from "./server/space-state"
 
 export default app

--- a/apps/mcp/src/server/space-state.ts
+++ b/apps/mcp/src/server/space-state.ts
@@ -1,0 +1,3 @@
+import { DurableObject } from "cloudflare:workers"
+
+export class SpaceState extends DurableObject {}

--- a/apps/mcp/wrangler.jsonc
+++ b/apps/mcp/wrangler.jsonc
@@ -25,6 +25,10 @@
 			{
 				"name": "MCP_SERVER",
 				"class_name": "SupermemoryMCP"
+			},
+			{
+				"name": "SPACE_STATE",
+				"class_name": "SpaceState"
 			}
 		]
 	},
@@ -33,6 +37,10 @@
 		{
 			"tag": "v1",
 			"new_sqlite_classes": ["SupermemoryMCP"]
+		},
+		{
+			"tag": "v2",
+			"new_sqlite_classes": ["SpaceState"]
 		}
 	],
 


### PR DESCRIPTION
Registers `SpaceState` before the stateless MCP starts routing requests through it. The class is intentionally unused here, so this changes no request behavior.

Rollout:
1. Apply this exact commit once with `wrangler deploy`, not `wrangler versions upload`.
2. Rerun the Workers check and merge this parent PR.
3. Land #1120, which adds the active-space methods and request routing.

Verified with the MCP widget build, isolated class typecheck, and Wrangler deploy/version dry runs.