### PR TITLE
Add .well-known/openai-apps-challenge route to MCP server

### DIFF
--- a/apps/mcp/src/server/index.ts
+++ b/apps/mcp/src/server/index.ts
@@ -70,6 +70,10 @@ function resourceMetadata(c: Context<{ Bindings: Bindings }>) {
 app.get("/.well-known/oauth-protected-resource", resourceMetadata)
 app.get(PROTECTED_RESOURCE_METADATA_PATH, resourceMetadata)
 
+app.get("/.well-known/openai-apps-challenge", (c) => {
+	return c.text(c.env.OPENAI_APPS_CHALLENGE || "")
+})
+
 app.get("/.well-known/oauth-authorization-server", async (c) => {
 	const apiUrl = c.env.API_URL || DEFAULT_API_URL
 

--- a/apps/mcp/src/server/types.ts
+++ b/apps/mcp/src/server/types.ts
@@ -14,4 +14,5 @@ export interface ServerEnv {
 	ALLOWED_MCP_ORIGIN_HOSTNAMES?: string
 	POSTHOG_API_KEY?: string
 	POSTHOG_HOST?: string
+	OPENAI_APPS_CHALLENGE?: string
 }


### PR DESCRIPTION
## Summary
- Serve the `OPENAI_APPS_CHALLENGE` Cloudflare secret as plain text at `/.well-known/openai-apps-challenge` on the MCP worker, so `https://mcp.supermemory.ai/.well-known/openai-apps-challenge` resolves for OpenAI Apps SDK domain verification.
- The secret already exists in Cloudflare for this worker; no wrangler.jsonc changes needed (secrets aren't declared there).

## Test plan
- [ ] `bun run dev` in `apps/mcp` and curl `/.well-known/openai-apps-challenge` locally with `OPENAI_APPS_CHALLENGE` set in `.dev.vars`
- [ ] After deploy, verify `https://mcp.supermemory.ai/.well-known/openai-apps-challenge` returns the challenge value

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, unauthenticated well-known endpoint intended for public domain verification; no changes to OAuth or MCP request handling.
> 
> **Overview**
> Adds **`GET /.well-known/openai-apps-challenge`** on the MCP worker so OpenAI Apps SDK can verify domain ownership for `mcp.supermemory.ai`. The handler returns the **`OPENAI_APPS_CHALLENGE`** Cloudflare secret as plain text (or an empty body if unset).
> 
> **`ServerEnv`** now includes optional **`OPENAI_APPS_CHALLENGE`** typing alongside existing worker bindings.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 433aa60cd3b5982e9de117f23bee9bdf048629a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->