### PR TITLE
fix(mcp): add missing tool safety annotations

### DIFF
--- a/apps/mcp/src/server/tools/annotations.ts
+++ b/apps/mcp/src/server/tools/annotations.ts
@@ -12,3 +12,11 @@ export const MEMORY_TOOL_ANNOTATIONS = {
 	idempotentHint: false,
 	openWorldHint: false,
 } as const
+
+/** Non-destructive account/session mutations, e.g. switching the active space. */
+export const SETTINGS_TOOL_ANNOTATIONS = {
+	readOnlyHint: false,
+	destructiveHint: false,
+	idempotentHint: true,
+	openWorldHint: false,
+} as const

--- a/apps/mcp/src/server/tools/guided-save.ts
+++ b/apps/mcp/src/server/tools/guided-save.ts
@@ -2,6 +2,7 @@ import { z } from "zod"
 import type { ViewMessage } from "../../shared/types"
 import { appResultMeta, appToolMeta } from "../app-metadata"
 import { effectiveContainerTagAccess } from "../auth/rbac"
+import { READ_ONLY_TOOL_ANNOTATIONS } from "./annotations"
 import type { ToolDeps } from "./types"
 
 export function register(deps: ToolDeps) {
@@ -14,6 +15,7 @@ export function register(deps: ToolDeps) {
 				prefill: z.string().optional().describe("Optional content to prefill"),
 			}),
 			_meta: appToolMeta(),
+			annotations: READ_ONLY_TOOL_ANNOTATIONS,
 		},
 		async (args) => {
 			try {

--- a/apps/mcp/src/server/tools/select-space.ts
+++ b/apps/mcp/src/server/tools/select-space.ts
@@ -2,6 +2,7 @@ import { z } from "zod"
 import type { ViewMessage } from "../../shared/types"
 import { appResultMeta, appToolMeta } from "../app-metadata"
 import { effectiveContainerTagAccess } from "../auth/rbac"
+import { READ_ONLY_TOOL_ANNOTATIONS } from "./annotations"
 import type { ToolDeps } from "./types"
 
 export function register(deps: ToolDeps) {
@@ -13,6 +14,7 @@ export function register(deps: ToolDeps) {
 				"Choose the active Supermemory space. Shows available spaces as interactive cards.",
 			inputSchema: z.object({}),
 			_meta: appToolMeta(),
+			annotations: READ_ONLY_TOOL_ANNOTATIONS,
 		},
 		async () => {
 			try {

--- a/apps/mcp/src/server/tools/set-active-tag.ts
+++ b/apps/mcp/src/server/tools/set-active-tag.ts
@@ -2,6 +2,7 @@ import { z } from "zod"
 import type { ViewMessage } from "../../shared/types"
 import { appResultMeta, appToolMeta } from "../app-metadata"
 import { containerTagSchema } from "../container-tag"
+import { SETTINGS_TOOL_ANNOTATIONS } from "./annotations"
 import type { ToolDeps } from "./types"
 
 export function register(deps: ToolDeps) {
@@ -14,6 +15,7 @@ export function register(deps: ToolDeps) {
 				viewId: z.string().uuid().optional(),
 			}),
 			_meta: appToolMeta(["app"]),
+			annotations: SETTINGS_TOOL_ANNOTATIONS,
 		},
 		async (args) => {
 			const { containerTag } = args

--- a/apps/mcp/src/server/tools/upload-file.ts
+++ b/apps/mcp/src/server/tools/upload-file.ts
@@ -2,6 +2,7 @@ import { z } from "zod"
 import type { ViewMessage } from "../../shared/types"
 import { appResultMeta, appToolMeta } from "../app-metadata"
 import { effectiveContainerTagAccess } from "../auth/rbac"
+import { READ_ONLY_TOOL_ANNOTATIONS } from "./annotations"
 import type { ToolDeps } from "./types"
 
 export function register(deps: ToolDeps) {
@@ -12,6 +13,7 @@ export function register(deps: ToolDeps) {
 			description: "Upload a file (PDF, text, image, video) to memory.",
 			inputSchema: z.object({}),
 			_meta: appToolMeta(),
+			annotations: READ_ONLY_TOOL_ANNOTATIONS,
 		},
 		async () => {
 			try {


### PR DESCRIPTION
## Summary
- `select-space`, `guided-save`, and `upload-file` only render an interactive view (no memory mutation), so they're annotated with the existing `READ_ONLY_TOOL_ANNOTATIONS`.
- `set-active-tag` mutates session state (active container tag) but isn't destructive/irreversible, so it gets a new `SETTINGS_TOOL_ANNOTATIONS` (`readOnlyHint: false`, `destructiveHint: false`, `idempotentHint: true`, `openWorldHint: false`).

## Test plan
- [ ] `bun test src/server` in `apps/mcp` (pre-existing unrelated failures in auth/client tests due to `vi.stubGlobal` not being supported by the bun test runner)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Metadata-only changes to tool registration; no runtime behavior or auth logic is modified.
> 
> **Overview**
> Adds **MCP tool annotation metadata** so hosts (e.g. ChatGPT) can classify tool risk correctly.
> 
> Introduces **`SETTINGS_TOOL_ANNOTATIONS`** for non-destructive session/account changes (`readOnlyHint: false`, `destructiveHint: false`, `idempotentHint: true`). **`set-active-tag`** uses this because it updates the active space without touching memory.
> 
> **`select-space`**, **`guided-save`**, and **`upload-file`** are wired to **`READ_ONLY_TOOL_ANNOTATIONS`** because they only open interactive views; persistence happens elsewhere.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1660ea3aa996e039a0e82f38662b221622f62791. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->