### PR TITLE
Filter browser extension TypeError: Failed to fetch errors in Sentry

### DIFF
--- a/apps/web/instrumentation-client.ts
+++ b/apps/web/instrumentation-client.ts
@@ -6,7 +6,13 @@ import * as Sentry from "@sentry/nextjs"
 
 function sentryShouldDropExpectedNonActionableError(event: {
 	message?: string
-	exception?: { values?: Array<{ type?: string; value?: string }> }
+	exception?: {
+		values?: Array<{
+			type?: string
+			value?: string
+			stacktrace?: { frames?: Array<{ filename?: string }> }
+		}>
+	}
 }): boolean {
 	const patterns = [
 		/user location is not supported/i,
@@ -18,6 +24,20 @@ function sentryShouldDropExpectedNonActionableError(event: {
 	if (matches(event.message)) return true
 	for (const ex of event.exception?.values ?? []) {
 		if (matches(ex.value)) return true
+
+		// Drop TypeError: Failed to fetch errors originating from browser extension
+		// content scripts (identified by app:/// URLs or frame_ant in stack frames).
+		if (
+			ex.type === "TypeError" &&
+			/Failed to fetch/i.test(ex.value ?? "") &&
+			ex.stacktrace?.frames?.some(
+				(f) =>
+					f.filename?.startsWith("app:///") ||
+					f.filename?.includes("frame_ant"),
+			)
+		) {
+			return true
+		}
 	}
 	return false
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Filters noisy Sentry events (issue CONSUMER-APP-8B) caused by `TypeError: Failed to fetch` errors originating from browser extension content scripts intercepting `window.fetch`.

## What changed

Extended `sentryShouldDropExpectedNonActionableError` in `apps/web/instrumentation-client.ts` to also drop `TypeError: Failed to fetch` events whose stack frames contain extension content-script filenames:
- Filenames starting with `app:///` (the browser extension content-script URL scheme)
- Filenames containing `frame_ant`

The check requires **all three** conditions to be true before dropping:
1. Exception type is `TypeError`
2. Exception value matches `/Failed to fetch/i`
3. At least one stack frame filename matches an extension origin pattern

This is intentionally narrow: generic `TypeError: Failed to fetch` errors from the app's own fetch calls are **not** filtered.

## Existing patterns preserved

The two pre-existing patterns remain unchanged:
- `/user location is not supported/i`
- `/this email domain is not allowed/i`

## Validation

- `biome check apps/web/instrumentation-client.ts` — ✅ no issues
- `tsc --noEmit` — ✅ no errors in `instrumentation-client.ts` (pre-existing errors in other files are unrelated to this change)

## Assumption

Stack frame filenames from the Sentry SDK accurately reflect the source URL of the script that initiated the failed fetch. Browser extensions loaded as content scripts consistently expose either `app:///`-prefixed URLs or filenames containing `frame_ant` in their stack traces, matching the patterns seen in the reported issue.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-182d1741-6d96-4529-8b8a-a1db05441ff7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-182d1741-6d96-4529-8b8a-a1db05441ff7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- polylane-attribution:fix_fc4eb3ec0002g0wmxc2k9avq -->

---

🟠 **Fixes:** [TypeError: Failed to fetch (api.supermemory.ai)](https://console.polylane.com/supermemory/issues/iss_fc4700c2c0015z6jl703lt32?ref=github.autofix-handoff-pr)
active for 2h 21m · occurrence #4

| Lineage | | Status |
| --- | --- | --- |
| ◉ Alert issue | [TypeError: Failed to fetch (api.supermemory.ai)](https://console.polylane.com/supermemory/issues/iss_fc4700c2c0015z6jl703lt32?ref=github.autofix-handoff-pr) | 🟠 active |
| 🗼 ↳ investigated in | [Investigation thread](https://console.polylane.com/supermemory/threads/thrd_fc4705d21001rasy2altuu69?ref=github.autofix-handoff-pr) | — |
| 🔧 ↳ kicked off | [Autofix `fix_fc4eb3…`](https://console.polylane.com/supermemory/autofixes/fix_fc4eb3ec0002g0wmxc2k9avq?ref=github.autofix-handoff-pr) | succeeded |
| 🔀 ↳ opened | this PR | open |

<a href="https://console.polylane.com/supermemory/autofixes/fix_fc4eb3ec0002g0wmxc2k9avq?ref=github.autofix-handoff-pr"><picture><source media="(prefers-color-scheme: dark)" srcset="https://badges.polylane.com/view-autofix/dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://badges.polylane.com/view-autofix/light.svg"><img alt="view-autofix" src="https://badges.polylane.com/view-autofix/light.svg"></picture></a> <a href="https://console.polylane.com/supermemory/threads/thrd_fc4705d21001rasy2altuu69?ref=github.autofix-handoff-pr"><picture><source media="(prefers-color-scheme: dark)" srcset="https://badges.polylane.com/view-investigation/dark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://badges.polylane.com/view-investigation/light.svg?v=2"><img alt="view-investigation" src="https://badges.polylane.com/view-investigation/light.svg?v=2"></picture></a> <a href="https://console.polylane.com/supermemory/issues/iss_fc4700c2c0015z6jl703lt32?ref=github.autofix-handoff-pr"><picture><source media="(prefers-color-scheme: dark)" srcset="https://badges.polylane.com/view-issue/dark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://badges.polylane.com/view-issue/light.svg?v=1"><img alt="view-issue" src="https://badges.polylane.com/view-issue/light.svg?v=1"></picture></a>

This pull request originated from a [Polylane](https://polylane.com/?ref=github.autofix-handoff-pr) autofix. Polylane investigated the issue and delegated the fix to Cursor, which authored this pull request.