### PR TITLE
Fix TypeError: guard e.key before toLowerCase in chat keydown handler

### DIFF
--- a/apps/web/components/chat/index.tsx
+++ b/apps/web/components/chat/index.tsx
@@ -1229,7 +1229,7 @@ export function ChatSidebar({
 				activeElement?.closest('[contenteditable="true"]')
 
 			if (
-				e.key.toLowerCase() === "t" &&
+				e.key?.toLowerCase() === "t" &&
 				!e.metaKey &&
 				!e.ctrlKey &&
 				!e.altKey &&


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes an unhandled `TypeError: Cannot read properties of undefined (reading 'toLowerCase')` in the global `keydown` handler inside `ChatSidebar`.

**Sentry issue:** CONSUMER-APP-19V

## Root Cause

In `apps/web/components/chat/index.tsx`, the `handleKeyDown` function registered via `window.addEventListener("keydown", handleKeyDown)` called `e.key.toLowerCase()` without checking that `e.key` is defined. The `KeyboardEvent.key` property can be `undefined` for synthetic keyboard events fired by browser extensions, accessibility tools, or IME composition events.

## Fix

Changed `e.key.toLowerCase()` to `e.key?.toLowerCase()` (optional chaining). When `e.key` is `undefined`, the optional chain short-circuits to `undefined`, causing the condition `undefined === "t"` to be `false` — the handler returns silently instead of throwing.

```diff
- e.key.toLowerCase() === "t" &&
+ e.key?.toLowerCase() === "t" &&
```

## Validation

- The changed line introduces no new TypeScript errors (all pre-existing type errors in the file are caused by missing `node_modules` in the CI environment, not by this change).
- Biome formatter applied its auto-fix (indentation normalization around the modified block); no new lint violations were introduced by this change — the remaining biome errors (`useHookAtTopLevel`, `useOptionalChain`) are pre-existing and unrelated.

## Assumptions

- The intent of the handler is to trigger `handleNewChat()` only when the literal key `"t"` is pressed (without modifiers). Skipping events with `e.key === undefined` preserves that intent exactly.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-25b0a527-cf00-42ab-9ffc-898bab159f09?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-25b0a527-cf00-42ab-9ffc-898bab159f09&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- polylane-attribution:fix_fc53d8e97002fz5hho5aam5y -->

---

🟠 **Fixes:** [TypeError: Cannot read properties of undefined (reading 'toLowerCase')](https://console.polylane.com/supermemory/issues/iss_fc53953a90011dx0w1jlvxwe?ref=github.autofix-handoff-pr)
active for 10m · occurrence #2

| Lineage | | Status |
| --- | --- | --- |
| ◉ Alert issue | [TypeError: Cannot read properties of undefined (reading 'toLowerCase')](https://console.polylane.com/supermemory/issues/iss_fc53953a90011dx0w1jlvxwe?ref=github.autofix-handoff-pr) | 🟠 active |
| 🗼 ↳ investigated in | [Investigation thread](https://console.polylane.com/supermemory/threads/thrd_fc539a2920016vxjstmx3y9x?ref=github.autofix-handoff-pr) | — |
| 🔧 ↳ kicked off | [Autofix `fix_fc53d8…`](https://console.polylane.com/supermemory/autofixes/fix_fc53d8e97002fz5hho5aam5y?ref=github.autofix-handoff-pr) | succeeded |
| 🔀 ↳ opened | this PR | open |

<a href="https://console.polylane.com/supermemory/autofixes/fix_fc53d8e97002fz5hho5aam5y?ref=github.autofix-handoff-pr"><picture><source media="(prefers-color-scheme: dark)" srcset="https://badges.polylane.com/view-autofix/dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://badges.polylane.com/view-autofix/light.svg"><img alt="view-autofix" src="https://badges.polylane.com/view-autofix/light.svg"></picture></a> <a href="https://console.polylane.com/supermemory/threads/thrd_fc539a2920016vxjstmx3y9x?ref=github.autofix-handoff-pr"><picture><source media="(prefers-color-scheme: dark)" srcset="https://badges.polylane.com/view-investigation/dark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://badges.polylane.com/view-investigation/light.svg?v=2"><img alt="view-investigation" src="https://badges.polylane.com/view-investigation/light.svg?v=2"></picture></a> <a href="https://console.polylane.com/supermemory/issues/iss_fc53953a90011dx0w1jlvxwe?ref=github.autofix-handoff-pr"><picture><source media="(prefers-color-scheme: dark)" srcset="https://badges.polylane.com/view-issue/dark.svg?v=1"><source media="(prefers-color-scheme: light)" srcset="https://badges.polylane.com/view-issue/light.svg?v=1"><img alt="view-issue" src="https://badges.polylane.com/view-issue/light.svg?v=1"></picture></a>

This pull request originated from a [Polylane](https://polylane.com/?ref=github.autofix-handoff-pr) autofix. Polylane investigated the issue and delegated the fix to Cursor, which authored this pull request.