### PR TITLE
Upgrade Nova model picker to current runtime models

### DIFF
--- a/apps/web/components/chat/home-chat-composer.tsx
+++ b/apps/web/components/chat/home-chat-composer.tsx
@@ -36,9 +36,9 @@ export function HomeChatComposer({
 	const [attachmentDrafts, setAttachmentDrafts] = useState<
 		ChatAttachmentDraft[]
 	>([])
-	const [selectedModel, setSelectedModel] = useState<ModelId>("grok-4.3")
+	const [selectedModel, setSelectedModel] = useState<ModelId>("grok-4.5")
 	const [reasoningEffort, setReasoningEffort] = useState<ReasoningEffort>(
-		getDefaultReasoningEffort("grok-4.3"),
+		getDefaultReasoningEffort("grok-4.5"),
 	)
 	const { selectedProject } = useProject()
 	const [chatSpaceProjects, setChatSpaceProjects] = useState<string[]>([

--- a/apps/web/components/chat/index.tsx
+++ b/apps/web/components/chat/index.tsx
@@ -206,11 +206,11 @@ export function ChatSidebar({
 	>([])
 	const [isChatDraggingFiles, setIsChatDraggingFiles] = useState(false)
 	const [selectedModel, setSelectedModel] = useState<ModelId>(
-		initialSelectedModel ?? "grok-4.3",
+		initialSelectedModel ?? "grok-4.5",
 	)
 	const [reasoningEffort, setReasoningEffort] = useState<ReasoningEffort>(
 		initialReasoningEffort ??
-			getDefaultReasoningEffort(initialSelectedModel ?? "grok-4.3"),
+			getDefaultReasoningEffort(initialSelectedModel ?? "grok-4.5"),
 	)
 	const selectedModelRef = useRef(selectedModel)
 	selectedModelRef.current = selectedModel

--- a/apps/web/components/chat/model-selector.tsx
+++ b/apps/web/components/chat/model-selector.tsx
@@ -23,8 +23,7 @@ export default function ChatModelSelector({
 	minimal = false,
 	dropdownDirection = "up",
 }: ChatModelSelectorProps = {}) {
-	const [internalModel, setInternalModel] =
-		useState<ModelId>("claude-sonnet-4.6")
+	const [internalModel, setInternalModel] = useState<ModelId>("claude-sonnet-5")
 	const [isOpen, setIsOpen] = useState(false)
 	const containerRef = useRef<HTMLDivElement>(null)
 

--- a/apps/web/lib/chat-stream-error.ts
+++ b/apps/web/lib/chat-stream-error.ts
@@ -1,9 +1,9 @@
 import type { ModelId } from "@/lib/models"
 
 const OTHER_MODELS: ModelId[] = [
-	"gpt-5.1",
-	"claude-sonnet-4.6",
-	"gemini-2.5-pro",
+	"gpt-5.6-terra",
+	"claude-sonnet-5",
+	"gemini-3.1-pro-preview",
 ]
 
 function flattenError(e: unknown): string {

--- a/apps/web/lib/models.tsx
+++ b/apps/web/lib/models.tsx
@@ -1,22 +1,22 @@
 export const models = [
 	{
-		id: "grok-4.3",
-		name: "Grok 4.3",
+		id: "grok-4.5",
+		name: "Grok 4.5",
 		description: "xAI's latest model",
 	},
 	{
-		id: "gpt-5.1",
-		name: "GPT 5.1",
+		id: "gpt-5.6-terra",
+		name: "GPT 5.6 Terra",
 		description: "OpenAI's latest model",
 	},
 	{
-		id: "claude-sonnet-4.6",
-		name: "Claude Sonnet 4.6",
+		id: "claude-sonnet-5",
+		name: "Claude Sonnet 5",
 		description: "Anthropic's advanced model",
 	},
 	{
-		id: "gemini-2.5-pro",
-		name: "Gemini 3 Pro",
+		id: "gemini-3.1-pro-preview",
+		name: "Gemini 3.1 Pro",
 		description: "Google's most capable model",
 	},
 ] as const
@@ -25,10 +25,10 @@ export type ModelId = (typeof models)[number]["id"]
 export type ReasoningEffort = "instant" | "thinking"
 
 export const modelNames: Record<ModelId, { name: string; version: string }> = {
-	"grok-4.3": { name: "Grok", version: "4.3" },
-	"gpt-5.1": { name: "GPT", version: "5.1" },
-	"claude-sonnet-4.6": { name: "Claude", version: "4.6" },
-	"gemini-2.5-pro": { name: "Gemini", version: "3 Pro" },
+	"grok-4.5": { name: "Grok", version: "4.5" },
+	"gpt-5.6-terra": { name: "GPT", version: "5.6 Terra" },
+	"claude-sonnet-5": { name: "Claude", version: "Sonnet 5" },
+	"gemini-3.1-pro-preview": { name: "Gemini", version: "3.1 Pro" },
 }
 
 export const reasoningOptions: Array<{

--- a/apps/web/lib/models.tsx
+++ b/apps/web/lib/models.tsx
@@ -6,7 +6,7 @@ export const models = [
 	},
 	{
 		id: "gpt-5.6-terra",
-		name: "GPT 5.6 Terra",
+		name: "GPT 5.6",
 		description: "OpenAI's latest model",
 	},
 	{
@@ -26,7 +26,7 @@ export type ReasoningEffort = "instant" | "thinking"
 
 export const modelNames: Record<ModelId, { name: string; version: string }> = {
 	"grok-4.5": { name: "Grok", version: "4.5" },
-	"gpt-5.6-terra": { name: "GPT", version: "5.6 Terra" },
+	"gpt-5.6-terra": { name: "GPT", version: "5.6" },
 	"claude-sonnet-5": { name: "Claude", version: "Sonnet 5" },
 	"gemini-3.1-pro-preview": { name: "Gemini", version: "3.1 Pro" },
 }


### PR DESCRIPTION
## Summary
- replace the display-only renames with the actual provider model IDs
- offer Grok 4.5, GPT 5.6 Terra, Claude Sonnet 5, and Gemini 3.1 Pro
- default new Nova chats to Grok 4.5
- update model retry choices and response labels to the same IDs

## Dependency
Merge and deploy supermemoryai/mono#2852 first. It adds the new backend IDs and upgrades requests from older saved Nova selections.

## Validation
- Biome passes on all five touched files
- full Web TypeScript check still reports existing errors outside this change; no model-ID type errors were introduced