### PR TITLE
ci(docs): fail PRs on broken Mintlify internal links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,10 @@ jobs:
 
       - name: Run Biome CI (format & lint on changed files)
         run: bunx biome ci --changed --since=origin/main --no-errors-on-unmatched
+
+      # mintlify@4.2.x may exit 0 even when it prints broken links
+      - name: Check docs for broken internal links
+        working-directory: apps/docs
+        run: |
+          set -o pipefail
+          bun run check-links 2>&1 | tee /dev/stderr | grep -q "no broken links found"

--- a/apps/docs/package.json
+++ b/apps/docs/package.json
@@ -6,7 +6,8 @@
   "portless": { "name": "docs.dev.supermemory", "script": "dev:app", "appPort": 3003 },
   "scripts": {
     "dev": "portless",
-    "dev:app": "bunx mintlify@latest dev --no-open --port 3003"
+    "dev:app": "bunx mintlify@latest dev --no-open --port 3003",
+    "check-links": "mintlify broken-links"
   },
   "devDependencies": {
     "@types/bun": "latest",


### PR DESCRIPTION
## Summary
- Adds `apps/docs` script `check-links` (`mintlify broken-links`) as the local and CI entrypoint
- Runs that check in the existing `.github/workflows/ci.yml` Quality Checks job after install
- Asserts the `no broken links found` report because mintlify 4.2.x can exit 0 even when it prints broken links

Fixes #1365

## Test plan
- [x] `mintlify broken-links` / `bun run check-links` on Linux against `apps/docs` reports `success no broken links found`
- [ ] CI Quality Checks passes on this PR, including the docs link step
- [ ] Temporarily introduce a bad internal href and confirm CI fails