### PR TITLE
fix docs image pipeline

### DIFF
--- a/apps/docs/company-brain/automations.mdx
+++ b/apps/docs/company-brain/automations.mdx
@@ -14,10 +14,12 @@ Company Brain doesn't only answer when you @mention it. It can run recurring wor
 An automation is a prompt that runs on a schedule and posts the result somewhere. You write it once, in plain language:
 
 <SlackThread channel="#product">
-  <SlackMessage self time="9:03 AM">
+  <SlackMessage self hasAvatar time="9:03 AM">
+    <img src="/images/company-brain/dhravya-slack-icon.jpg" alt="" />
     <Mention>supermemory</Mention> every Monday at 9am, post a digest of what shipped last week and what's still open, to <ChannelRef>product</ChannelRef>.
   </SlackMessage>
-  <SlackMessage bot time="9:03 AM">
+  <SlackMessage bot hasAvatar time="9:03 AM">
+    <img src="/images/company-brain/supermemory-slack-icon.png" alt="" />
     Got it — scheduled. First digest posts Monday, 9:00 AM, to <ChannelRef>product</ChannelRef>.
   </SlackMessage>
 </SlackThread>

--- a/apps/docs/company-brain/overview.mdx
+++ b/apps/docs/company-brain/overview.mdx
@@ -25,10 +25,12 @@ It'll answer a question, actually go do the work, or just jump into a conversati
 ### Ask it anything
 
 <SlackThread channel="#product">
-  <SlackMessage self time="10:42 AM">
+  <SlackMessage self hasAvatar time="10:42 AM">
+    <img src="/images/company-brain/dhravya-slack-icon.jpg" alt="" />
     <Mention>supermemory</Mention> what did we decide about pricing for the company brain
   </SlackMessage>
-  <SlackMessage bot time="10:42 AM">
+  <SlackMessage bot hasAvatar time="10:42 AM">
+    <img src="/images/company-brain/supermemory-slack-icon.png" alt="" />
     You and mahesh decided yesterday that it stays at **$400/mo**, usage based only. we landed on that in a <ChannelRef>product</ChannelRef> huddle
   </SlackMessage>
 </SlackThread>
@@ -36,10 +38,12 @@ It'll answer a question, actually go do the work, or just jump into a conversati
 ### Put it to work
 
 <SlackThread channel="#eng">
-  <SlackMessage self time="3:24 PM">
+  <SlackMessage self hasAvatar time="3:24 PM">
+    <img src="/images/company-brain/dhravya-slack-icon.jpg" alt="" />
     <Mention>supermemory</Mention> is the Stripe webhook timeout from Sentry already tracked anywhere?
   </SlackMessage>
-  <SlackMessage bot time="3:25 PM">
+  <SlackMessage bot hasAvatar time="3:25 PM">
+    <img src="/images/company-brain/supermemory-slack-icon.png" alt="" />
     nope, nothing yet — just opened **ENG-847** for it, added the sentry issue to it, and put it on <Mention>Sam</Mention> since they were the last one in `webhooks/stripe.ts` and their beautiful code broke it ☠️. <AgentLink href="https://linear.app">here you go</AgentLink>, should probably fix it asap.
   </SlackMessage>
 </SlackThread>
@@ -50,7 +54,8 @@ It'll answer a question, actually go do the work, or just jump into a conversati
   <SlackMessage name="Alex" color="#E01E5A" time="11:03 AM">
     is prod down? a couple of customers are pinging me
   </SlackMessage>
-  <SlackMessage bot time="11:03 AM">
+  <SlackMessage bot hasAvatar time="11:03 AM">
+    <img src="/images/company-brain/supermemory-slack-icon.png" alt="" />
     not fully down — `api/search` is just elevated, 42 errors in the last 15 min (SM-2041), and <Mention>Kush</Mention> is on it. probably that deploy from this morning. Only one user has complained on support and i already replied to them saying it's being investigated.
   </SlackMessage>
 </SlackThread>

--- a/apps/docs/company-brain/use-cases/acting-in-tools.mdx
+++ b/apps/docs/company-brain/use-cases/acting-in-tools.mdx
@@ -16,10 +16,12 @@ You don't just want to *know* something — you want Company Brain to do the nex
 ### Read from a tool
 
 <SlackThread channel="#eng">
-  <SlackMessage self time="3:22 PM">
+  <SlackMessage self hasAvatar time="3:22 PM">
+    <img src="/images/company-brain/dhravya-slack-icon.jpg" alt="" />
     <Mention>supermemory</Mention> what are my open PRs in the web repo?
   </SlackMessage>
-  <SlackMessage bot time="3:22 PM">
+  <SlackMessage bot hasAvatar time="3:22 PM">
+    <img src="/images/company-brain/supermemory-slack-icon.png" alt="" />
     You have **3 open PRs** on `supermemory/web`:
     - `#1199` staff custom MCP connection cards — review requested
     - `#1197` company brain onboarding research UI — changes requested
@@ -30,10 +32,12 @@ You don't just want to *know* something — you want Company Brain to do the nex
 ### Write to a tool
 
 <SlackThread channel="#eng">
-  <SlackMessage self time="3:24 PM">
+  <SlackMessage self hasAvatar time="3:24 PM">
+    <img src="/images/company-brain/dhravya-slack-icon.jpg" alt="" />
     <Mention>supermemory</Mention> create a Linear issue: fix the onboarding redirect
   </SlackMessage>
-  <SlackMessage bot time="3:24 PM">
+  <SlackMessage bot hasAvatar time="3:24 PM">
+    <img src="/images/company-brain/supermemory-slack-icon.png" alt="" />
     Created **ENG-842** — *Fix the onboarding redirect* in Engineering, assigned to you. <AgentLink href="https://linear.app">Open in Linear</AgentLink>
   </SlackMessage>
 </SlackThread>

--- a/apps/docs/company-brain/use-cases/greeting.mdx
+++ b/apps/docs/company-brain/use-cases/greeting.mdx
@@ -5,7 +5,7 @@ description: "Connect card, welcome DM, and first answer — activation on day o
 icon: "user-plus"
 ---
 
-import { SlackThread, SlackMessage, BOT_AVATAR } from "/snippets/slack-message.mdx";
+import { SlackThread, SlackMessage } from "/snippets/slack-message.mdx";
 
 ## The scenario
 
@@ -15,8 +15,10 @@ A new hire joins the Slack workspace. They shouldn't need a web signup form or a
 
 They get a connect card, tap **Connect me**, and receive a welcome DM:
 
-<SlackThread type="dm" dmWith={{ name: "supermemory", avatar: BOT_AVATAR }}>
-  <SlackMessage bot time="9:02 AM">
+<SlackThread type="dm" dmWith={{ name: "supermemory" }} hasAvatar>
+  <img src="/images/company-brain/supermemory-slack-icon.png" alt="" />
+  <SlackMessage bot hasAvatar time="9:02 AM">
+    <img src="/images/company-brain/supermemory-slack-icon.png" alt="" />
     Welcome to **Acme**. Here's what I know, what I can access, and what I keep private.
 
     Try one of these:
@@ -27,7 +29,8 @@ They get a connect card, tap **Connect me**, and receive a welcome DM:
   <SlackMessage name="Sam" color="#36C5F0" time="9:03 AM">
     What does Acme do?
   </SlackMessage>
-  <SlackMessage bot time="9:03 AM">
+  <SlackMessage bot hasAvatar time="9:03 AM">
+    <img src="/images/company-brain/supermemory-slack-icon.png" alt="" />
     Acme builds memory infrastructure for AI apps — shared context for teams and agents. *(from the company profile your admin seeded at setup)*
   </SlackMessage>
 </SlackThread>

--- a/apps/docs/company-brain/use-cases/incidents.mdx
+++ b/apps/docs/company-brain/use-cases/incidents.mdx
@@ -17,7 +17,8 @@ Someone drops a vague "is prod down?" in `#eng`. Company Brain correlates it wit
   <SlackMessage name="Alex" color="#E01E5A" time="11:03 AM">
     is prod down? a couple of customers are pinging me
   </SlackMessage>
-  <SlackMessage bot time="11:03 AM">
+  <SlackMessage bot hasAvatar time="11:03 AM">
+    <img src="/images/company-brain/supermemory-slack-icon.png" alt="" />
     Not a full outage — **`api/search` is elevated** (42 errors in the last 15m, mostly `timeout on vectorize`). Sentry issue <AgentLink href="https://example.com">SM-2041</AgentLink>. Deploy from this morning is the likely culprit; rollback candidate is `af61880`.
   </SlackMessage>
 </SlackThread>
@@ -25,7 +26,8 @@ Someone drops a vague "is prod down?" in `#eng`. Company Brain correlates it wit
 Or, without anyone asking, a scheduled automation posts every morning:
 
 <SlackThread channel="#eng">
-  <SlackMessage bot time="9:00 AM">
+  <SlackMessage bot hasAvatar time="9:00 AM">
+    <img src="/images/company-brain/supermemory-slack-icon.png" alt="" />
     **Daily error digest** — 3 issues new since yesterday, 1 still spiking (`api/search` timeout). Full list in Sentry.
   </SlackMessage>
 </SlackThread>

--- a/apps/docs/company-brain/use-cases/knowledge-recall.mdx
+++ b/apps/docs/company-brain/use-cases/knowledge-recall.mdx
@@ -14,10 +14,12 @@ The Q2 roadmap lives in Notion. Nobody wants to dig for the link mid-conversatio
 ## What happens
 
 <SlackThread channel="#product">
-  <SlackMessage self time="10:18 AM">
+  <SlackMessage self hasAvatar time="10:18 AM">
+    <img src="/images/company-brain/dhravya-slack-icon.jpg" alt="" />
     <Mention>supermemory</Mention> what's in our Q2 roadmap?
   </SlackMessage>
-  <SlackMessage bot time="10:18 AM">
+  <SlackMessage bot hasAvatar time="10:18 AM">
+    <img src="/images/company-brain/supermemory-slack-icon.png" alt="" />
     Three themes for Q2:
     1. **Company Brain GA** — Slack bot, connectors, automations
     2. **Memory Router v2** — lower latency, better multi-tenant isolation

--- a/apps/docs/company-brain/use-cases/long-horizon-research.mdx
+++ b/apps/docs/company-brain/use-cases/long-horizon-research.mdx
@@ -14,10 +14,12 @@ Some questions aren't a quick lookup. They need pulling information from a lot o
 ## What it will look like
 
 <SlackThread channel="#product">
-  <SlackMessage self time="11:10 AM">
+  <SlackMessage self hasAvatar time="11:10 AM">
+    <img src="/images/company-brain/dhravya-slack-icon.jpg" alt="" />
     <Mention>supermemory</Mention> prepare a brief on how we've handled enterprise SSO requests over the last two quarters — who asked, what we promised, what's still open, and what engineering thinks the real effort is
   </SlackMessage>
-  <SlackMessage bot time="11:14 AM">
+  <SlackMessage bot hasAvatar time="11:14 AM">
+    <img src="/images/company-brain/supermemory-slack-icon.png" alt="" />
     **Enterprise SSO — two-quarter brief**
 
     - **Demand:** 6 serious asks (Acme, Globex, Initech, …). Three converted to paid pilots.

--- a/apps/docs/company-brain/use-cases/meeting-recall.mdx
+++ b/apps/docs/company-brain/use-cases/meeting-recall.mdx
@@ -14,10 +14,12 @@ Someone missed the Acme call — or was there and forgot the outcome. They ask i
 ## What happens
 
 <SlackThread channel="#sales">
-  <SlackMessage self time="4:05 PM">
+  <SlackMessage self hasAvatar time="4:05 PM">
+    <img src="/images/company-brain/dhravya-slack-icon.jpg" alt="" />
     <Mention>supermemory</Mention> what did we decide in the meeting with Acme?
   </SlackMessage>
-  <SlackMessage bot time="4:05 PM">
+  <SlackMessage bot hasAvatar time="4:05 PM">
+    <img src="/images/company-brain/supermemory-slack-icon.png" alt="" />
     Acme is moving to annual billing at the current rate, with a 90-day pilot on the enterprise SSO add-on. Follow-up owned by **Priya**, due Friday. *(from Granola notes, Acme QBR — Jun 11)*
   </SlackMessage>
 </SlackThread>

--- a/apps/docs/company-brain/use-cases/meeting-scheduling.mdx
+++ b/apps/docs/company-brain/use-cases/meeting-scheduling.mdx
@@ -21,7 +21,8 @@ A teammate needs help and doesn't want to play calendar ping-pong. They ask in S
   <SlackMessage name="Sam" color="#36C5F0" time="1:12 PM">
     Dhravya are you free this afternoon? need some help with dev setup
   </SlackMessage>
-  <SlackMessage bot time="1:12 PM">
+  <SlackMessage bot hasAvatar time="1:12 PM">
+    <img src="/images/company-brain/supermemory-slack-icon.png" alt="" />
     Dhravya is free at **2:00 PM**. Sending an invite to block **20 mins** on both your calendars.
   </SlackMessage>
 </SlackThread>

--- a/apps/docs/company-brain/use-cases/sandbox-debugging.mdx
+++ b/apps/docs/company-brain/use-cases/sandbox-debugging.mdx
@@ -14,10 +14,12 @@ A test is failing and the stack trace alone isn't enough. You want Company Brain
 ## What happens
 
 <SlackThread channel="#eng">
-  <SlackMessage self time="5:41 PM">
+  <SlackMessage self hasAvatar time="5:41 PM">
+    <img src="/images/company-brain/dhravya-slack-icon.jpg" alt="" />
     <Mention>supermemory</Mention> the `permissions.lease` unit test is failing on main — can you reproduce and tell me why?
   </SlackMessage>
-  <SlackMessage bot time="5:42 PM">
+  <SlackMessage bot hasAvatar time="5:42 PM">
+    <img src="/images/company-brain/supermemory-slack-icon.png" alt="" />
     Reproduced in a sandbox against `main`.
 
     **Failure:** `permissions.lease` expects temporary access to expire in 15 minutes, but the fixture still asserts 30.

--- a/apps/docs/company-brain/use-cases/support-escalation.mdx
+++ b/apps/docs/company-brain/use-cases/support-escalation.mdx
@@ -14,7 +14,13 @@ A customer files a ticket through Plain. It lands in `#support`, gets triaged wi
 ## What happens
 
 <SlackThread channel="#support" members={24}>
-  <SlackMessage name="Plain" badges={["APP"]} avatar="/images/company-brain/plain-icon.png" time="10:12 AM">
+  <SlackMessage
+    name="Plain"
+    badges={["APP"]}
+    hasAvatar
+    time="10:12 AM"
+  >
+    <img src="/images/company-brain/plain-icon.png" alt="" />
     New conversation: <AgentLink href="#">rewriteQuery param not working</AgentLink>
     <br />
     **Jordan Alvarez** (acme-corp.io) sent a **new message**.
@@ -22,7 +28,8 @@ A customer files a ticket through Plain. It lands in `#support`, gets triaged wi
       hi team, just tried the `rewriteQuery` param on the v3 search endpoint and it doesn't seem to actually do anything — tried a few different values, results look identical either way. can someone take a look
     </SlackUnfurl>
   </SlackMessage>
-  <SlackMessage bot time="10:13 AM">
+  <SlackMessage bot hasAvatar time="10:13 AM">
+    <img src="/images/company-brain/supermemory-slack-icon.png" alt="" />
     Confirmed, this is a real one — a couple of people have also flagged it on GitHub over the last week.
     <br />
     <br />
@@ -34,12 +41,24 @@ A customer files a ticket through Plain. It lands in `#support`, gets triaged wi
     <br />
     <FileAttachment name="Context.md" />
   </SlackMessage>
-  <SlackMessage name="Cursor" badges={["AGENT"]} avatar="/images/company-brain/cursor-icon.png" time="10:14 AM">
+  <SlackMessage
+    name="Cursor"
+    badges={["AGENT"]}
+    hasAvatar
+    time="10:14 AM"
+  >
+    <img src="/images/company-brain/cursor-icon.png" alt="" />
     <AgentLink href="#">Agent thread started</AgentLink>
     <br />
     Reproducing against the v3 search test suite now.
   </SlackMessage>
-  <SlackMessage name="Cursor" badges={["AGENT"]} avatar="/images/company-brain/cursor-icon.png" time="10:19 AM">
+  <SlackMessage
+    name="Cursor"
+    badges={["AGENT"]}
+    hasAvatar
+    time="10:19 AM"
+  >
+    <img src="/images/company-brain/cursor-icon.png" alt="" />
     Fixed — `rewriteQuery` was getting skipped by the new cost short-circuit whenever a query was already cached. Pushed on <AgentLink href="#">#2312</AgentLink>.
     <br />
     <br />
@@ -56,7 +75,8 @@ A customer files a ticket through Plain. It lands in `#support`, gets triaged wi
     <SlackButton variant="primary">Open in Web</SlackButton>
     <SlackButton>Open in Desktop</SlackButton>
   </SlackMessage>
-  <SlackMessage bot time="10:20 AM">
+  <SlackMessage bot hasAvatar time="10:20 AM">
+    <img src="/images/company-brain/supermemory-slack-icon.png" alt="" />
     <Mention self>Dhravya</Mention> I'll let you review that and let the customer know we have a fix ready.
     <br />
     Please do it ASAP — it's an enterprise customer!

--- a/apps/docs/company-brain/use-cases/support.mdx
+++ b/apps/docs/company-brain/use-cases/support.mdx
@@ -17,7 +17,8 @@ A customer question lands in `#support`. Nobody has to @mention the bot — it a
   <SlackMessage name="Maya" color="#2BAC76" time="2:14 PM">
     customer on the Pro plan is asking if they can export their full memory graph as CSV — do we support that?
   </SlackMessage>
-  <SlackMessage bot time="2:14 PM">
+  <SlackMessage bot hasAvatar time="2:14 PM">
+    <img src="/images/company-brain/supermemory-slack-icon.png" alt="" />
     Yes — **Settings → Export → Full graph (CSV)**. Available on Pro and above. Same answer went out on ticket PLN-1842 last week if you want the exact wording.
   </SlackMessage>
 </SlackThread>

--- a/apps/docs/index.mdx
+++ b/apps/docs/index.mdx
@@ -4,18 +4,14 @@ description: "Context infrastructure for AI agents"
 mode: "custom"
 ---
 
-export const HeroCard = ({ imageUrl, title, description, href }) => {
+export const HeroCard = ({ title, description, href, children }) => {
   return (
     <a
       className="group flex flex-col h-full rounded-2xl overflow-hidden bg-white dark:bg-zinc-950 border border-gray-200/80 dark:border-zinc-800 hover:border-gray-300 dark:hover:border-zinc-700 hover:shadow-md transition-all duration-300"
       href={href}
     >
       <div className="overflow-hidden bg-gray-50 dark:bg-zinc-900 border-b border-gray-100 dark:border-zinc-800">
-        <img
-          src={imageUrl}
-          className="w-full h-56 sm:h-64 object-cover transform group-hover:scale-[1.03] transition-transform duration-500"
-          alt={title}
-        />
+        {children}
       </div>
       <div className="flex flex-col gap-2 p-6 sm:p-7">
         <h3 className="text-lg sm:text-xl font-semibold text-gray-900 dark:text-zinc-50 tracking-tight">
@@ -62,29 +58,49 @@ export const HeroCard = ({ imageUrl, title, description, href }) => {
 
     <div className="mt-12 sm:mt-14 grid sm:grid-cols-2 gap-5 sm:gap-6">
       <HeroCard
-        imageUrl="/images/intro-company-brain.jpg"
         title="Developer platform"
         description="API reference, concepts, and SDKs"
         href="/overview/what-is-supermemory"
-      />
+      >
+        <img
+          src="/images/intro-company-brain.jpg"
+          className="w-full h-56 sm:h-64 object-cover transform group-hover:scale-[1.03] transition-transform duration-500"
+          alt="Developer platform"
+        />
+      </HeroCard>
       <HeroCard
-        imageUrl="/images/intro-company-brain-card.jpg"
         title="Company brain"
         description="Team knowledge on the same engine"
         href="/company-brain/overview"
-      />
+      >
+        <img
+          src="/images/intro-company-brain-card.jpg"
+          className="w-full h-56 sm:h-64 object-cover transform group-hover:scale-[1.03] transition-transform duration-500"
+          alt="Company brain"
+        />
+      </HeroCard>
       <HeroCard
-        imageUrl="/images/intro-plugins.jpg"
         title="Plugins and MCP"
         description="Drop memory into Claude and coding agents"
         href="/supermemory-mcp/mcp"
-      />
+      >
+        <img
+          src="/images/intro-plugins.jpg"
+          className="w-full h-56 sm:h-64 object-cover transform group-hover:scale-[1.03] transition-transform duration-500"
+          alt="Plugins and MCP"
+        />
+      </HeroCard>
       <HeroCard
-        imageUrl="/images/intro-developer-platform.png"
         title="Self-hosting"
         description="Run it locally with zero config"
         href="/self-hosting/overview"
-      />
+      >
+        <img
+          src="/images/intro-developer-platform.png"
+          className="w-full h-56 sm:h-64 object-cover transform group-hover:scale-[1.03] transition-transform duration-500"
+          alt="Self-hosting"
+        />
+      </HeroCard>
     </div>
   </div>
 </div>

--- a/apps/docs/overview/what-is-supermemory.mdx
+++ b/apps/docs/overview/what-is-supermemory.mdx
@@ -6,17 +6,13 @@ icon: "book-open"
 mode: "wide"
 ---
 
-export const BuildingBlock = ({ icon, title, href }) => {
+export const BuildingBlock = ({ title, href, children }) => {
   return (
     <a
       href={href}
       className="group flex flex-row items-center gap-4 rounded-xl border border-gray-200 dark:border-zinc-800 bg-white dark:bg-zinc-900/40 p-4 no-underline transition-all duration-200 hover:border-gray-300 dark:hover:border-zinc-600 hover:shadow-sm"
     >
-      <img
-        src={icon}
-        alt=""
-        className="h-16 w-16 shrink-0 object-contain"
-      />
+      {children}
       <span className="text-sm font-medium leading-snug text-gray-900 dark:text-zinc-100 group-hover:text-blue-600 dark:group-hover:text-blue-400">
         {title}
       </span>
@@ -30,50 +26,69 @@ It provides all the building blocks — Memory, Retrieval, Profiles, Connectors,
 
 <div className="not-prose my-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
   <BuildingBlock
-    icon="/images/building-blocks/memory-router.svg"
     title="Memory & Continual Learning"
     href="/concepts/graph-memory"
-  />
+  >
+    <img src="/images/building-blocks/memory-router.svg" alt="" className="h-16 w-16 shrink-0 object-contain" />
+  </BuildingBlock>
   <BuildingBlock
-    icon="/images/building-blocks/document-retrieval.svg"
     title="SuperRAG (Retrieval)"
     href="/concepts/super-rag"
-  />
+  >
+    <img src="/images/building-blocks/document-retrieval.svg" alt="" className="h-16 w-16 shrink-0 object-contain" />
+  </BuildingBlock>
   <BuildingBlock
-    icon="/images/building-blocks/file-systems.svg"
     title="Filesystems"
     href="/smfs/overview"
-  />
+  >
+    <img src="/images/building-blocks/file-systems.svg" alt="" className="h-16 w-16 shrink-0 object-contain" />
+  </BuildingBlock>
   <BuildingBlock
-    icon="/images/building-blocks/user-profiles.svg"
     title="Profiles"
     href="/concepts/user-profiles"
-  />
+  >
+    <img src="/images/building-blocks/user-profiles.svg" alt="" className="h-16 w-16 shrink-0 object-contain" />
+  </BuildingBlock>
   <BuildingBlock
-    icon="/images/building-blocks/connectors.svg"
     title="Connectors"
     href="/connectors/overview"
-  />
+  >
+    <img src="/images/building-blocks/connectors.svg" alt="" className="h-16 w-16 shrink-0 object-contain" />
+  </BuildingBlock>
   <BuildingBlock
-    icon="/images/building-blocks/extractor.svg"
     title="Extractors"
     href="/concepts/content-types"
-  />
+  >
+    <img src="/images/building-blocks/extractor.svg" alt="" className="h-16 w-16 shrink-0 object-contain" />
+  </BuildingBlock>
   <BuildingBlock
-    icon="/images/building-blocks/qualitative-analysis.svg"
     title="Qualitative Analysis"
     href="https://supermemory.ai/research"
-  />
+  >
+    <img src="/images/building-blocks/qualitative-analysis.svg" alt="" className="h-16 w-16 shrink-0 object-contain" />
+  </BuildingBlock>
   <BuildingBlock
-    icon="/images/building-blocks/hermes.svg"
     title="Plugins"
     href="/supermemory-mcp/mcp"
-  />
+  >
+    <img
+      src="/images/building-blocks/hermes.svg"
+      alt=""
+      className="h-16 w-16 shrink-0 object-contain"
+      style={{ transform: "scale(0.85)" }}
+    />
+  </BuildingBlock>
   <BuildingBlock
-    icon="/images/building-blocks/brain-head.png"
     title="Company Brain"
     href="/company-brain/overview"
-  />
+  >
+    <img
+      src="/images/building-blocks/brain-head.png"
+      alt=""
+      className="h-16 w-16 shrink-0 object-contain"
+      style={{ transform: "scale(1.3)" }}
+    />
+  </BuildingBlock>
 </div>
 
 With supermemory, developers can provide perfect recall about their users to build AI agents that are more intelligent, more personalized, and more consistent.

--- a/apps/docs/snippets/slack-message.mdx
+++ b/apps/docs/snippets/slack-message.mdx
@@ -1,10 +1,3 @@
-export const DHRAVYA = {
-  name: "Dhravya Shah",
-  avatar: "/images/company-brain/dhravya-slack-icon.jpg",
-};
-
-export const BOT_AVATAR = "/images/company-brain/supermemory-slack-icon.png";
-
 export const Mention = ({ children, self = false }) => (
   <span
     className="rounded px-1 py-px font-medium"
@@ -53,9 +46,13 @@ export const SlackThread = ({
   private: isPrivate = false,
   members,
   dmWith,
+  hasAvatar = false,
   maxHeight = "70vh",
   children,
 }) => {
+  const childItems = Array.isArray(children) ? children : [children];
+  const dmAvatar = hasAvatar ? childItems[0] : null;
+  const threadMessages = hasAvatar ? childItems.slice(1) : children;
   const composerLabel =
     type === "dm"
       ? `Message ${dmWith?.name || "someone"}`
@@ -91,11 +88,9 @@ export const SlackThread = ({
       ) : type === "dm" ? (
         <div className="flex items-center gap-2 border-b border-black/10 px-4 py-3 dark:border-white/10">
           <div className="relative h-6 w-6 flex-none">
-            <img
-              src={dmWith?.avatar || "/images/company-brain/supermemory-slack-icon.png"}
-              alt={dmWith?.name || "DM"}
-              className="h-6 w-6 rounded-md object-cover"
-            />
+            <span className="block h-full w-full overflow-hidden rounded-md [&_img]:h-full [&_img]:w-full [&_img]:object-cover">
+              {dmAvatar}
+            </span>
             <span className="absolute -bottom-0.5 -right-0.5 h-2.5 w-2.5 rounded-full border-2 border-white bg-[#2BAC76] dark:border-[#1A1D21]" />
           </div>
           <span className="truncate text-[15px] font-bold text-gray-900 dark:text-zinc-50">
@@ -149,7 +144,7 @@ export const SlackThread = ({
           className="overflow-y-auto bg-white dark:bg-[#1A1D21]"
           style={maxHeight ? { maxHeight } : undefined}
         >
-          {children}
+          {threadMessages}
         </div>
         {maxHeight ? (
           <div
@@ -213,7 +208,7 @@ export const SlackMessage = ({
   bot = false,
   time,
   color = "#611f69",
-  avatar,
+  hasAvatar = false,
   badges,
   reactions,
   highlighted = false,
@@ -221,11 +216,11 @@ export const SlackMessage = ({
   children,
 }) => {
   const SELF_NAME = "Dhravya Shah";
-  const SELF_AVATAR = "/images/company-brain/dhravya-slack-icon.jpg";
-  const BOT_AVATAR = "/images/company-brain/supermemory-slack-icon.png";
 
+  const childItems = Array.isArray(children) ? children : [children];
+  const resolvedAvatar = hasAvatar ? childItems[0] : null;
+  const messageBody = hasAvatar ? childItems.slice(1) : children;
   const resolvedName = bot ? "supermemory" : self ? SELF_NAME : name || SELF_NAME;
-  const resolvedAvatar = bot ? BOT_AVATAR : self ? SELF_AVATAR : avatar;
   const resolvedBadges = badges || (bot ? ["AGENT"] : null);
 
   return (
@@ -248,11 +243,9 @@ export const SlackMessage = ({
         ))}
       </div>
       {resolvedAvatar ? (
-        <img
-          src={resolvedAvatar}
-          alt={resolvedName}
-          className="mt-0.5 h-9 w-9 flex-none rounded-md object-cover"
-        />
+        <span className="mt-0.5 h-9 w-9 flex-none overflow-hidden rounded-md [&_img]:h-full [&_img]:w-full [&_img]:object-cover">
+          {resolvedAvatar}
+        </span>
       ) : (
         <div
           className="mt-0.5 flex h-9 w-9 flex-none items-center justify-center rounded-md text-sm font-bold text-white"
@@ -286,7 +279,7 @@ export const SlackMessage = ({
           ) : null}
         </div>
         <div className="text-[15px] leading-normal text-gray-800 dark:text-zinc-200 [&_p]:m-0 [&_strong]:font-bold [&_strong]:text-gray-900 dark:[&_strong]:text-zinc-50 [&_code]:rounded [&_code]:bg-black/5 [&_code]:px-1 [&_code]:py-0.5 [&_code]:text-[0.9em] dark:[&_code]:bg-white/10">
-          {children}
+          {messageBody}
         </div>
         {reactions ? (
           <div className="mt-1.5 flex flex-wrap gap-1">


### PR DESCRIPTION
Keep docs asset URLs repo-root-relative and pass images as literal MDX children so Mintlify can compile them through OptimizedImage under the /docs mount.

Mintlify's official guidance says: “Image paths are root-relative from your docs repository.” It also says relative paths such as `./screenshot.png` are unsupported. See [Image embeds](https://www.mintlify.com/docs/create/image-embeds).

The existing `/images/...` paths were correct. The failure came from passing them through custom-component string props, which kept Mintlify from seeing those images during its MDX transform.

- fix hero, building-block, and Slack avatar images
- preserve Slack avatar clipping
- normalize Hermes and Company Brain icon sizing

Tested with Mintlify validation, broken-link checks, and browser checks across every changed route.