### PR TITLE
ci: run the Python SDK test suites on pull requests

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -1,0 +1,56 @@
+name: CI - Python SDK Tests
+
+on:
+  pull_request:
+    paths:
+      - "packages/agent-framework-python/**"
+      - "packages/cartesia-sdk-python/**"
+      - "packages/pipecat-sdk-python/**"
+      - ".github/workflows/ci-python.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: ${{ matrix.package }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      # Report every package, rather than masking the rest behind the first failure.
+      fail-fast: false
+      matrix:
+        include:
+          # Has a pytest suite and needs its runtime dependencies installed.
+          - package: agent-framework-python
+            install: pip install -e . pytest pytest-asyncio
+            test: pytest
+          # These suites stub their heavy runtime dependencies (cartesia-line,
+          # pipecat-ai, loguru) at import time, so they run against the sources
+          # with nothing installed and need no install step.
+          - package: cartesia-sdk-python
+            test: PYTHONPATH=src python -m unittest discover -s tests -v
+          - package: pipecat-sdk-python
+            test: PYTHONPATH=src python -m unittest discover -s tests -v
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          # The lowest version these packages declare support for, so a change
+          # that only works on newer Python is caught here.
+          python-version: "3.10"
+          cache: pip
+          cache-dependency-path: packages/${{ matrix.package }}/pyproject.toml
+
+      - name: Install dependencies
+        if: matrix.install
+        working-directory: packages/${{ matrix.package }}
+        run: ${{ matrix.install }}
+
+      - name: Run tests
+        working-directory: packages/${{ matrix.package }}
+        run: ${{ matrix.test }}

--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     paths:
       - "packages/agent-framework-python/**"
+      - "packages/openai-sdk-python/**"
       - "packages/cartesia-sdk-python/**"
       - "packages/pipecat-sdk-python/**"
       - ".github/workflows/ci-python.yml"
@@ -25,6 +26,11 @@ jobs:
           # Has a pytest suite and needs its runtime dependencies installed.
           - package: agent-framework-python
             install: pip install -e . pytest pytest-asyncio
+            test: pytest
+          # python-dotenv is a dev-group dependency the test modules import at
+          # module scope, so it has to be installed alongside pytest.
+          - package: openai-sdk-python
+            install: pip install -e . pytest pytest-asyncio python-dotenv
             test: pytest
           # These suites stub their heavy runtime dependencies (cartesia-line,
           # pipecat-ai, loguru) at import time, so they run against the sources


### PR DESCRIPTION
Closes #1417.

## What and why

The Python packages ship real test suites that nothing executes. `ci.yml` covers only TypeScript (Bun, `turbo run check-types`, Biome), and the four `publish-*-python.yml` workflows publish to PyPI without running any tests. These packages are released on the strength of local runs alone.

The cost of that is already on the record: `openai-sdk-python` spent a month unimportable on `main` — its suite could not be collected against the `supermemory` release of the day (`ImportError: cannot import name 'MemoryAddResponse'`). That is #1235, reported by an outside user on Jul 11 and fixed on Aug 12 by #1236. Any CI run of the tests that already existed would have caught it the day it broke.

## The workflow

Path-filtered, so it only fires on PRs touching these packages or the workflow itself. Matrix over all four packages:

| Package | How it runs |
|---|---|
| `agent-framework-python` | `pip install -e . pytest pytest-asyncio`, then `pytest` |
| `openai-sdk-python` | `pip install -e . pytest pytest-asyncio python-dotenv`, then `pytest` |
| `cartesia-sdk-python` | `PYTHONPATH=src python -m unittest`, no install |
| `pipecat-sdk-python` | `PYTHONPATH=src python -m unittest`, no install |

`cartesia-sdk-python` and `pipecat-sdk-python` stub their heavy runtime dependencies (`cartesia-line`, `pipecat-ai`, `loguru`) at import time, so they need nothing installed and finish in well under a second. The two pytest suites pay an install cost.

`python-dotenv` is called out explicitly because `openai-sdk-python` imports it at module scope in both test modules, but declares it only in its dev dependency group, so `pip install -e .` alone leaves the suite uncollectable.

Two deliberate choices:

- **Python 3.10**, the lowest version these packages declare (`requires-python = ">=3.10"` for three of them, `>=3.8.1` for `openai-sdk-python`, and `agent-framework-core` agrees), so a change that only works on a newer interpreter fails here rather than at a user's install.
- **`fail-fast: false`**, so one package failing still reports the others instead of masking them.

## Verification

All four commands run green against current `main`:

| Package | Result |
|---|---|
| `agent-framework-python` | 54 passed |
| `openai-sdk-python` | 24 passed, 11 skipped |
| `cartesia-sdk-python` | 1 passed |
| `pipecat-sdk-python` | 1 passed |

The 11 skips in `openai-sdk-python` are gated on `SUPERMEMORY_API_KEY` and skip in CI too — that suite's real coverage in this workflow is the 24.

This workflow is in its own path filter, so it will run against itself on this PR — but as a fork PR from a first-time contributor it needs a maintainer to approve workflow runs before that can happen. Until someone does, the results above are local runs, and the checks on this PR are only Graphite and Socket.

One note on scope: this only wires up the suites that exist. `cartesia-sdk-python` and `pipecat-sdk-python` have a single test each, so a green check on those means very little coverage today. Getting them running is the prerequisite for that being worth improving.
