### PR TITLE
fix(web): pin Turbopack root to monorepo to stop dev RAM blowups

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -1,7 +1,16 @@
+import path from "node:path"
+import { fileURLToPath } from "node:url"
 import { withSentryConfig } from "@sentry/nextjs"
 import type { NextConfig } from "next"
 
+const appDir = path.dirname(fileURLToPath(import.meta.url))
+const monorepoRoot = path.join(appDir, "../..")
+
 const nextConfig: NextConfig = {
+	turbopack: {
+		root: monorepoRoot,
+	},
+	outputFileTracingRoot: monorepoRoot,
 	typescript: {
 		ignoreBuildErrors: true,
 	},


### PR DESCRIPTION
## Why?

`bun run dev` / `next dev` in `apps/web` was blowing RAM and freezing the machine. Next.js 16 Turbopack infers the workspace root from lockfiles walking up from the app. On developer machines with stray `package.json` / lockfiles in parent dirs (e.g. `~/code`, `~`), it can treat dozens of unrelated repos as part of the project and unbounded-watch/compile them.

This is a known Next 16 failure mode (multiple lockfiles → wrong workspace root → multi‑GB RSS / stuck “Compiling…”).

## What?

- Pin `turbopack.root` and `outputFileTracingRoot` to the monorepo root (`apps/web/../..`) in `apps/web/next.config.ts`.
- Keeps Turbopack file watching and resolution inside the supermemory monorepo only.

## Test plan

- [ ] From `apps/web`, run `bun run dev:app` (or `bun run dev`)
- [ ] Confirm no “inferred workspace root” warning on startup
- [ ] Confirm Ready in a few seconds and `/` compiles/loads without RAM climbing without bound
- [ ] Optional: if you still have parent `package.json` under `~/` or `~/code`, rename them aside and clear `apps/web/.next` once

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev/build configuration only; no runtime auth, data, or API behavior changes.
> 
> **Overview**
> **Fixes runaway RAM and stuck compiles** when running `next dev` in `apps/web` by explicitly setting Turbopack’s workspace root instead of letting Next.js 16 infer it from lockfiles up the filesystem tree.
> 
> `next.config.ts` now resolves the app directory via `import.meta.url`, sets `monorepoRoot` to `apps/web/../..`, and applies that path to **`turbopack.root`** and **`outputFileTracingRoot`**. Dev file watching and dependency tracing stay inside the supermemory monorepo, which avoids pulling in stray `package.json`/lockfiles in parent folders (e.g. `~/code` or `~`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a909d9b2838531751d4aa28aa1187da512027d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->