### PR TITLE
fix(openai-sdk): migrate to supermemory 3.x api so a fresh install imports

### DIFF
--- a/packages/openai-sdk-python/pyproject.toml
+++ b/packages/openai-sdk-python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "supermemory-openai-sdk"
-version = "1.0.4"
+version = "1.0.5"
 description = "Memory tools for OpenAI function calling with supermemory"
 readme = "README.md"
 license = "MIT"
@@ -26,7 +26,7 @@ classifiers = [
 requires-python = ">=3.8.1"
 dependencies = [
     "openai>=1.102.0",
-    "supermemory>=3.1.0",
+    "supermemory>=3.5.0",
     "typing-extensions>=4.0.0",
     "requests>=2.25.0",
 ]

--- a/packages/openai-sdk-python/pyproject.toml
+++ b/packages/openai-sdk-python/pyproject.toml
@@ -26,7 +26,7 @@ classifiers = [
 requires-python = ">=3.8.1"
 dependencies = [
     "openai>=1.102.0",
-    "supermemory>=3.5.0",
+    "supermemory>=3.7.0",
     "typing-extensions>=4.0.0",
     "requests>=2.25.0",
 ]

--- a/packages/openai-sdk-python/src/supermemory_openai/middleware.py
+++ b/packages/openai-sdk-python/src/supermemory_openai/middleware.py
@@ -230,7 +230,7 @@ async def add_memory_tool(
             add_params["custom_id"] = custom_id
 
         # Handle both sync and async supermemory clients
-        result = client.memories.add(**add_params)
+        result = client.add(**add_params)
         if inspect.isawaitable(result):
             response = await result
         else:

--- a/packages/openai-sdk-python/src/supermemory_openai/tools.py
+++ b/packages/openai-sdk-python/src/supermemory_openai/tools.py
@@ -10,8 +10,8 @@ from openai.types.chat import (
     ChatCompletionToolMessageParam,
 )
 from supermemory.types import (
-    MemoryAddResponse,
-    MemoryGetResponse,
+    AddResponse,
+    DocumentGetResponse,
     SearchExecuteResponse,
 )
 from supermemory.types.search_execute_response import Result
@@ -35,7 +35,7 @@ class SupermemoryToolsConfig(TypedDict, total=False):
 
 
 # Type aliases using inferred types from supermemory package
-MemoryObject = Union[MemoryGetResponse, MemoryAddResponse]
+MemoryObject = Union[DocumentGetResponse, AddResponse]
 
 
 class MemorySearchResult(TypedDict, total=False):
@@ -51,7 +51,7 @@ class MemoryAddResult(TypedDict, total=False):
     """Result type for memory add operations."""
 
     success: bool
-    memory: Optional[MemoryAddResponse]
+    memory: Optional[AddResponse]
     error: Optional[str]
 
 
@@ -226,7 +226,7 @@ class SupermemoryTools:
                 "container_tags": self.container_tags,
             }
 
-            response: MemoryAddResponse = await self.client.memories.add(**add_params)
+            response: AddResponse = await self.client.add(**add_params)
 
             return MemoryAddResult(
                 success=True,


### PR DESCRIPTION
fixes #1235.

a fresh pip install supermemory-openai-sdk pulls the latest supermemory and the import fails. supermemory 3.x renamed the types the sdk imports and moved add off client.memories.

this moves the sdk onto the 3.x api:

- imports: MemoryAddResponse -> AddResponse, MemoryGetResponse -> DocumentGetResponse
- calls: client.memories.add(...) -> client.add(...) in tools.py and middleware.py
- deps: supermemory>=3.7.0, version 1.0.5

verified the package imports on the declared floor supermemory 3.7.0 (the first release with client.add and AddResponse; 3.5.0 and 3.6.0 do not have them) and on the 3.50.0 line, and the test suite runs again (24 passed, 11 skipped) where it could not even be collected before.
