### PR TITLE
ci: run Python package test suites on pull requests

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,69 @@
+name: Python Package Tests
+
+on:
+  pull_request:
+    paths:
+      - "packages/pipecat-sdk-python/**"
+      - "packages/cartesia-sdk-python/**"
+      - "packages/agent-framework-python/**"
+      - ".github/workflows/python-tests.yml"
+  push:
+    branches:
+      - main
+    paths:
+      - "packages/pipecat-sdk-python/**"
+      - "packages/cartesia-sdk-python/**"
+      - "packages/agent-framework-python/**"
+      - ".github/workflows/python-tests.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: pytest (${{ matrix.package }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # pipecat and cartesia stub their heavy runtime dependencies inside
+          # the test suite, so their suites run without installing them.
+          - package: pipecat-sdk-python
+            install: |
+              pip install --no-deps -e .
+              pip install pytest pytest-asyncio
+          - package: cartesia-sdk-python
+            install: |
+              pip install --no-deps -e .
+              pip install pytest pytest-asyncio
+          - package: agent-framework-python
+            # agent-framework-core releases after 1.0.0rc3 no longer export
+            # BaseContextProvider, which breaks this package's imports — pin
+            # the rc until the package supports current releases.
+            install: |
+              pip install -e . pytest pytest-asyncio python-dotenv
+              pip install agent-framework-core==1.0.0rc3
+    defaults:
+      run:
+        working-directory: ./packages/${{ matrix.package }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Install package and test dependencies
+        run: ${{ matrix.install }}
+
+      - name: Run tests
+        run: python -m pytest tests/ -v
+
+# openai-sdk-python also ships a test suite, but it currently fails to import
+# against recent `supermemory` releases (#1235). Add it to the matrix once
+# that is fixed.


### PR DESCRIPTION
Fixes #1417

## Problem

The Python packages ship real test suites (~108 test functions across four packages) and nothing runs them: `ci.yml` is TypeScript-only, and the `publish-*-python.yml` workflows build and publish to PyPI without ever invoking pytest. As the issue notes, #1235 shipped exactly this way — a broken import that the existing suite would have caught at the offending commit.

## Change

One path-filtered workflow, `python-tests.yml`, following the issue's proposal: it triggers on PRs (and pushes to `main`) touching any of the three packages whose suites currently pass, and runs each suite as a matrix job with `fail-fast: false`.

Per-package install recipes match how each suite is designed to run:

- **pipecat / cartesia** — `pip install --no-deps -e .` + pytest. Their tests stub the heavy runtime dependencies (pipecat-ai, loguru, pydantic), so installing them would only add minutes of CI time without testing anything extra.
- **agent-framework** — full install, with `agent-framework-core` pinned to `1.0.0rc3`: releases after the rc series no longer export `BaseContextProvider`, which breaks the package's imports entirely. The pin is commented in the workflow and should be removed once the package supports current releases (that incompatibility deserves its own fix, per the issue's closing note).

Known limitation, stated rather than silent: any change to one of the three packages runs all three suites. They complete in seconds, so per-package path filtering wasn't worth the extra machinery.

**openai-sdk-python is excluded** — its suite cannot currently be collected against recent `supermemory` releases (#1235). A comment in the workflow marks it for inclusion once that's fixed.

## Verification

Each matrix job was reproduced locally in a fresh Python 3.12 venv using the exact install commands from the workflow, against current `main`:

- pipecat: 1 passed
- cartesia: 1 passed
- agent-framework: 54 passed

This PR also makes the regression tests added in #1438 enforceable — today they would merge without ever being executed by CI.
