### PR TITLE
feat(web): sell Company Brain on Max as well as Scale

### DIFF
--- a/apps/web/components/onboarding-brain/step-sources.tsx
+++ b/apps/web/components/onboarding-brain/step-sources.tsx
@@ -97,7 +97,7 @@ type SourceId =
 	| "raycast"
 type SourceState = "idle" | "connecting" | "connected" | "waitlist"
 type DriveScope = "selective" | "full"
-type RequiredPlan = "pro" | "max"
+type RequiredPlan = "pro" | "max" | "scale"
 
 const PROVIDER_TO_SOURCE: Record<string, SourceId> = {
 	"google-drive": "drive",
@@ -116,6 +116,7 @@ const SOURCE_LABEL: Partial<Record<SourceId, string>> = {
 const PLAN_LABELS: Record<RequiredPlan, string> = {
 	pro: "Pro",
 	max: "Max",
+	scale: "Scale",
 }
 
 const BOOK_CALL_HREF = "https://cal.com/maheshthedev/15min"
@@ -277,7 +278,12 @@ export function StepSources({
 	const [granolaOpen, setGranolaOpen] = useState(false)
 	const [requestedPlan, setRequestedPlan] = useState<RequiredPlan>("pro")
 	const [requestedConnector, setRequestedConnector] = useState("This connector")
-	const { hasMax, connectorAccess, loading: planLoading } = useConnectorAccess()
+	const {
+		hasMax,
+		hasScale,
+		connectorAccess,
+		loading: planLoading,
+	} = useConnectorAccess()
 	const { org, isRestoring } = useAuth()
 
 	useEffect(() => {
@@ -362,10 +368,12 @@ export function StepSources({
 		}
 	}, [connectedParam])
 
-	// company_brain unlocks pro connectors; max stays gated
+	// company_brain unlocks pro connectors; max and scale stay gated, and a
+	// higher tier satisfies a lower requirement.
 	const isLocked = (plan?: RequiredPlan) => {
 		if (!plan || planLoading) return false
-		if (plan === "max") return !hasMax
+		if (plan === "scale") return !hasScale
+		if (plan === "max") return !(hasMax || hasScale)
 		return !connectorAccess
 	}
 
@@ -1185,14 +1193,14 @@ function MoreSourcesGrid({
 				icon={<Github className="size-6 text-[#fafafa]" />}
 				state={values.connected.github ?? "idle"}
 				ctaLabel="Connect"
-				locked={isLocked("max")}
-				requiredPlan="max"
+				locked={isLocked("scale")}
+				requiredPlan="scale"
 				perks={[
 					"PRs and issues parsed",
 					"READMEs and docs indexed",
 					"Stays in sync with new activity",
 				]}
-				onConnect={guard("max", "GitHub", () => requestWaitlist("github"))}
+				onConnect={guard("scale", "GitHub", () => requestWaitlist("github"))}
 			/>
 			{mode === "personal" ? (
 				<GranolaSourceCard

--- a/apps/web/components/settings/billing.tsx
+++ b/apps/web/components/settings/billing.tsx
@@ -203,8 +203,24 @@ const ADVANCED_PLAN_CARDS: PlanCardDefinition[] = [
 	},
 ]
 
-// Company Brain workspaces only sell Scale / Enterprise (no Free, Pro, Max).
+// Company Brain workspaces sell Max / Scale / Enterprise (no Free, Pro).
 const COMPANY_BRAIN_PLAN_CARDS: PlanCardDefinition[] = [
+	{
+		id: "max",
+		name: "Max",
+		price: "$100",
+		period: "/mo",
+		credits: "$130",
+		productId: "api_max",
+		description: "Company Brain for teams with everyday usage",
+		mostPopular: true,
+		features: [
+			"Company Brain Slack agent & shared memory",
+			"$130 monthly usage credits",
+			"Unlimited seats",
+			"Auto top-up & spend caps",
+		],
+	},
 	{
 		id: "scale",
 		name: "Scale",
@@ -212,13 +228,13 @@ const COMPANY_BRAIN_PLAN_CARDS: PlanCardDefinition[] = [
 		period: "/mo",
 		credits: "$600",
 		productId: "api_scale",
-		description: "Company Brain for your team, with production usage",
-		mostPopular: true,
+		description: "Company Brain for production workloads",
+		includesFrom: "Max",
 		features: [
-			"Company Brain Slack agent & shared memory",
-			"$600 monthly usage credits when paid",
-			"Auto top-up & spend caps",
-			"Team connectors & dedicated support",
+			"$600 monthly usage credits",
+			"GitHub, S3 & Web Crawler connectors",
+			"Restricted access, container tags & User Insights",
+			"Dedicated support",
 		],
 	},
 	{
@@ -914,6 +930,27 @@ export default function Billing() {
 			)
 		}
 
+		// The trial runs on api_scale, so Max ranks below the current plan and would
+		// otherwise render as a dead "Included with Scale" button. Trial users are
+		// exactly who we want on Max, so it needs its own actionable path.
+		if (plan.id === "max" && (isOnTrial || isBrainTrialEnded)) {
+			return (
+				<button
+					type="button"
+					onClick={() => handleUpgrade("api_max")}
+					disabled={disabled}
+					className={cn(
+						dmSans125ClassName(),
+						PLAN_CARD_ACTION_CLASS,
+						"bg-[#0054AD] text-[#FAFAFA] hover:bg-[#0B65C9]",
+					)}
+				>
+					{disabled ? <LoaderIcon className="size-4 animate-spin" /> : null}
+					Activate Max
+				</button>
+			)
+		}
+
 		// Trial Scale: primary CTA is activate paid Scale (not a dead "current" state).
 		if (plan.id === "scale" && (isOnTrial || isBrainTrialEnded)) {
 			return (
@@ -1471,6 +1508,20 @@ export default function Billing() {
 								}
 							/>
 						))}
+						<div className="md:col-span-2 space-y-2 rounded-lg border border-white/[0.08] bg-white/[0.02] p-4 text-[13px] leading-relaxed text-[#A3A3A3]">
+							{isOnTrial ? (
+								<p>
+									Your trial runs on Scale. Moving to Max keeps the agent,
+									shared memory and unlimited seats, and drops the GitHub, S3
+									and Web Crawler connectors, restricted access and container
+									tags, and User Insights.
+								</p>
+							) : null}
+							<p>
+								Using more than about $400 of credits a month? Scale works out
+								cheaper than Max plus top-ups.
+							</p>
+						</div>
 					</div>
 				) : (
 					<>

--- a/apps/web/hooks/use-connector-access.ts
+++ b/apps/web/hooks/use-connector-access.ts
@@ -9,9 +9,12 @@ export function useConnectorAccess(opts?: { enabled?: boolean }) {
 	const hasCompanyBrain = useHasCompanyBrain()
 	const hasPro = enabled && hasActivePlan(autumn.data?.subscriptions, "api_pro")
 	const hasMax = enabled && hasActivePlan(autumn.data?.subscriptions, "api_max")
+	const hasScale =
+		enabled && hasActivePlan(autumn.data?.subscriptions, "api_scale")
 	return {
 		hasPro,
 		hasMax,
+		hasScale,
 		hasCompanyBrain,
 		connectorAccess: hasPro || hasCompanyBrain,
 		loading: enabled && autumn.isLoading,


### PR DESCRIPTION
Company Brain workspaces could only buy Scale at $399/mo, which is roughly eight times what the median team uses. Adds the $100/mo Max card to the Company Brain plan picker, notes what a Scale trial loses on the way down, and flags that Scale is cheaper above about $400/mo of credits.