### PR TITLE
feat(mcp): add deleteDocument tool for permanent deletion by ID

### DIFF
--- a/apps/docs/supermemory-mcp/mcp.mdx
+++ b/apps/docs/supermemory-mcp/mcp.mdx
@@ -50,6 +50,7 @@ Your assistant chooses these tools automatically. Use this table when you need t
 | `add_memory` | Save information or forget outdated information | `content` (required), `action` (`save` or `forget`), `containerTag` | Save or forget confirmation |
 | `listDocuments` | Browse stored source documents and their summaries | `page`, `limit`, `containerTag` | Document IDs, titles, types, status, dates, and summaries |
 | `getDocument` | Read the available content of one document | `documentId` (required) | Document metadata, summary, and available content |
+| `deleteDocument` | Permanently delete one document and the memories extracted from it | `documentId` (required) | Deletion confirmation |
 | `listMemories` | Browse recent extracted memory entries and their source document IDs | `page`, `limit`, `containerTag` | Memory IDs, text, versions, and source document IDs |
 | `listSpaces` | List accessible spaces and resolve a space name to its key | None | Formatted list plus structured `spaces` and `count` fields |
 | `whoAmI` | Inspect the authenticated account, permissions, scope, and active space | None | Account and access context |
@@ -69,6 +70,8 @@ Use the retrieval tools for different questions:
 ### Save or forget
 
 `add_memory` saves the supplied `content` by default. Set `action` to `forget` when a fact is outdated or should be removed. There is no separate forget tool.
+
+When the exact source is known, `deleteDocument` permanently removes that document and the memories extracted from it by `documentId` (from `listDocuments` or a memory result). Unlike `forget`, it does not rely on content matching, so it cannot remove the wrong memory. Deletion cannot be undone.
 
 If the content is already final, the assistant should use `add_memory`. If you want to review, edit, or choose a space before saving, it should open the `guided-save` widget instead.
 

--- a/apps/mcp/src/server/client/index.ts
+++ b/apps/mcp/src/server/client/index.ts
@@ -409,6 +409,15 @@ export class SupermemoryClient {
 		}
 	}
 
+	async deleteDocument(id: string): Promise<{ id: string }> {
+		try {
+			await this.client.documents.delete(id)
+			return { id }
+		} catch (error) {
+			this.handleOperationError("Delete document request", error)
+		}
+	}
+
 	async listMemoryEntries(
 		page = 1,
 		limit = 50,

--- a/apps/mcp/src/server/tools/delete-document.test.ts
+++ b/apps/mcp/src/server/tools/delete-document.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from "vitest"
+import type { SupermemoryClient } from "../client"
+import * as deleteDocument from "./delete-document"
+import { errorResult, type ToolDeps } from "./types"
+
+type ToolHandler = (args: { documentId: string }) => Promise<{
+	content: Array<{ type: string; text: string }>
+	structuredContent?: { success: boolean; id: string }
+	isError?: boolean
+}>
+
+function registerWithClient(client: Partial<SupermemoryClient>) {
+	let handler: ToolHandler | undefined
+	let config: Record<string, unknown> | undefined
+	const registerTool = vi.fn(
+		(_name: string, toolConfig: Record<string, unknown>, cb: ToolHandler) => {
+			config = toolConfig
+			handler = cb
+			return {}
+		},
+	)
+
+	const deps = {
+		server: { registerTool },
+		getClient: () => client as SupermemoryClient,
+		errorResult,
+	} as unknown as ToolDeps
+
+	deleteDocument.register(deps)
+	if (!handler || !config) throw new Error("Tool was not registered")
+	return { handler, config, registerTool }
+}
+
+describe("deleteDocument tool", () => {
+	it("deletes the document by id and reports success", async () => {
+		const deleteDocumentMock = vi.fn().mockResolvedValue({ id: "doc_123" })
+		const { handler } = registerWithClient({
+			deleteDocument: deleteDocumentMock,
+		})
+
+		const result = await handler({ documentId: "doc_123" })
+
+		expect(deleteDocumentMock).toHaveBeenCalledWith("doc_123")
+		expect(result.structuredContent).toEqual({ success: true, id: "doc_123" })
+		expect(result.isError).toBeUndefined()
+		expect(result.content[0]?.text).toContain("doc_123")
+	})
+
+	it("returns an error result when deletion fails", async () => {
+		const { handler } = registerWithClient({
+			deleteDocument: vi
+				.fn()
+				.mockRejectedValue(new Error("Document not found")),
+		})
+
+		const result = await handler({ documentId: "doc_missing" })
+
+		expect(result.isError).toBe(true)
+		expect(result.content[0]?.text).toContain("Document not found")
+	})
+
+	it("registers as a destructive, non-read-only tool", () => {
+		const { config, registerTool } = registerWithClient({
+			deleteDocument: vi.fn(),
+		})
+
+		expect(registerTool).toHaveBeenCalledWith(
+			"deleteDocument",
+			expect.anything(),
+			expect.any(Function),
+		)
+		expect(config?.annotations).toMatchObject({
+			readOnlyHint: false,
+			destructiveHint: true,
+		})
+	})
+})

--- a/apps/mcp/src/server/tools/delete-document.ts
+++ b/apps/mcp/src/server/tools/delete-document.ts
@@ -1,0 +1,47 @@
+import { z } from "zod"
+import { MEMORY_TOOL_ANNOTATIONS } from "./annotations"
+import {
+	deleteDocumentOutputSchema,
+	type DeleteDocumentOutput,
+} from "./output-schemas"
+import { textContent, type ToolDeps } from "./types"
+
+export function register(deps: ToolDeps) {
+	const inputSchema = z.object({
+		documentId: z
+			.string()
+			.min(1, "Document ID is required")
+			.max(255, "Document ID exceeds maximum length")
+			.describe("Document ID returned by listDocuments or a memory result"),
+	})
+
+	deps.server.registerTool(
+		"deleteDocument",
+		{
+			title: "Delete Document",
+			description:
+				"Permanently delete one stored document by ID, along with the memories extracted from it. This cannot be undone. Use listDocuments or getDocument first to confirm the target; prefer this over add_memory's forget action when the exact document is known.",
+			inputSchema,
+			outputSchema: deleteDocumentOutputSchema,
+			annotations: MEMORY_TOOL_ANNOTATIONS,
+		},
+		async (args) => {
+			try {
+				const client = deps.getClient()
+				await client.deleteDocument(args.documentId)
+				const structuredContent: DeleteDocumentOutput = {
+					success: true,
+					id: args.documentId,
+				}
+				return {
+					content: [
+						textContent(`Deleted document ${args.documentId} permanently.`),
+					],
+					structuredContent,
+				}
+			} catch (error) {
+				return deps.errorResult(error)
+			}
+		},
+	)
+}

--- a/apps/mcp/src/server/tools/index.ts
+++ b/apps/mcp/src/server/tools/index.ts
@@ -1,4 +1,5 @@
 import * as addMemory from "./add-memory"
+import * as deleteDocument from "./delete-document"
 import * as fetchGraphData from "./fetch-graph-data"
 import * as getDocument from "./get-document"
 import * as guidedSave from "./guided-save"
@@ -19,6 +20,7 @@ export function registerAllTools(deps: ToolDeps) {
 	searchMemory.register(deps)
 	listDocuments.register(deps)
 	getDocument.register(deps)
+	deleteDocument.register(deps)
 	listMemories.register(deps)
 	listContainerTags.register(deps)
 	whoAmI.register(deps)

--- a/apps/mcp/src/server/tools/output-schemas.ts
+++ b/apps/mcp/src/server/tools/output-schemas.ts
@@ -80,6 +80,13 @@ export const addMemoryOutputSchema = z.object({
 
 export type AddMemoryOutput = z.infer<typeof addMemoryOutputSchema>
 
+export const deleteDocumentOutputSchema = z.object({
+	success: z.boolean(),
+	id: z.string(),
+})
+
+export type DeleteDocumentOutput = z.infer<typeof deleteDocumentOutputSchema>
+
 export const getDocumentOutputSchema = z.object({
 	document: z.object({
 		id: z.string(),


### PR DESCRIPTION
Closes #1442

## What

Adds a `deleteDocument` MCP tool: permanent deletion of one document (and the memories extracted from it) by exact `documentId`.

## Why

The MCP server covers the full document lifecycle except deletion. The only removal path today is `add_memory`'s `forget` action, which resolves its target by content similarity (0.85 threshold) — it can delete the wrong memory when several are similar, and it can't act on the exact `documentId` that `listDocuments`/`getDocument`/`listMemories` already hand the assistant. A connector user who spots a stale document mid-conversation currently has to open the web app to remove it.

Exact-ID deletion is strictly safer than the existing similarity-based path, and the tool carries `MEMORY_TOOL_ANNOTATIONS` (`destructiveHint: true`) so hosts that surface MCP annotations prompt before running it.

## Changes

- `apps/mcp/src/server/tools/delete-document.ts` — new tool, modeled line-for-line on `get-document.ts` (same input constraints, output schema pattern, error handling via `deps.errorResult`)
- `apps/mcp/src/server/client/index.ts` — `deleteDocument(id)` wrapping the SDK's existing `documents.delete` (`DELETE /v3/documents/{id}`), with the client's standard operation-error handling
- `apps/mcp/src/server/tools/output-schemas.ts` — `deleteDocumentOutputSchema`
- `apps/mcp/src/server/tools/index.ts` — registration, next to the other document tools
- `apps/docs/supermemory-mcp/mcp.mdx` — tool table row + a paragraph in "Save or forget" distinguishing exact-ID deletion from similarity-based forgetting
- `apps/mcp/src/server/tools/delete-document.test.ts` — unit tests: happy path (client called with the right ID, structured output), error path (`errorResult` shape), and annotation contract (destructive, not read-only)

## Testing

- `bunx vitest run src/` in `apps/mcp`: 20/20 passing (3 new)
- `bunx tsc --noEmit`: clean
- `bunx biome check` on all touched files: clean

Not covered: no e2e test against a live MCP session — happy to add one to `apps/mcp/e2e/` if that's wanted for destructive tools.
