### PR TITLE
fix: stop uploading Sentry sourcemaps after builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "dev:local": "turbo run dev:app",
     "format-lint": "bunx biome check --write",
     "check-types": "turbo run check-types",
-    "sentry:sourcemaps": "_SENTRY_RELEASE=$(sentry-cli releases propose-version) && sentry-cli releases new $_SENTRY_RELEASE --org=supermemory --project=consumer-app && sentry-cli sourcemaps upload --org=supermemory --project=consumer-app --release=$_SENTRY_RELEASE --strip-prefix 'dist/..' dist",
-    "postbuild": "bun run sentry:sourcemaps"
+    "sentry:sourcemaps": "_SENTRY_RELEASE=$(sentry-cli releases propose-version) && sentry-cli releases new $_SENTRY_RELEASE --org=supermemory --project=consumer-app && sentry-cli sourcemaps upload --org=supermemory --project=consumer-app --release=$_SENTRY_RELEASE --strip-prefix 'dist/..' dist"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
Closes #1444 

## Summary

- remove the root `postbuild` hook that automatically ran Sentry sourcemap publishing
- keep `bun run build` limited to `turbo run build`
- retain `bun run sentry:sourcemaps` as an explicit release-only command

## Why

Ordinary local and CI builds should not require Sentry credentials or attempt release creation/sourcemap uploads.

## Validation

- verified `package.json` parses successfully
- verified the diff has no whitespace errors

