### PR TITLE
fix: add type checks for TypeScript workspaces

### DIFF
--- a/apps/browser-extension/package.json
+++ b/apps/browser-extension/package.json
@@ -9,6 +9,7 @@
 		"dev:firefox": "wxt -b firefox",
 		"build": "wxt build",
 		"build:firefox": "wxt build -b firefox",
+		"check-types": "bun run compile",
 		"zip": "wxt zip",
 		"zip:firefox": "wxt zip -b firefox",
 		"compile": "tsc --noEmit",

--- a/apps/memory-graph-playground/package.json
+++ b/apps/memory-graph-playground/package.json
@@ -7,6 +7,7 @@
     "dev": "portless",
     "dev:app": "next dev --port ${PORT:-3004}",
     "build": "next build",
+    "check-types": "tsc --noEmit",
     "start": "next start"
   },
   "dependencies": {

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,6 +10,7 @@
     "dev": "portless",
     "dev:app": "next dev --port ${PORT:-3000}",
     "build": "next build",
+    "check-types": "tsc --noEmit",
     "start": "next start",
     "lint": "biome check --write",
     "preview": "opennextjs-cloudflare build && opennextjs-cloudflare preview",

--- a/packages/hooks/package.json
+++ b/packages/hooks/package.json
@@ -1,5 +1,8 @@
 {
 	"name": "@repo/hooks",
 	"version": "0.0.0",
-	"private": true
+	"private": true,
+	"scripts": {
+		"check-types": "tsc --noEmit"
+	}
 }

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -3,6 +3,9 @@
 	"version": "0.0.0",
 	"private": true,
 	"type": "module",
+	"scripts": {
+		"check-types": "tsc --noEmit"
+	},
 	"exports": {
 		"./*": "./*"
 	},

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -3,6 +3,9 @@
 	"version": "0.0.0",
 	"private": true,
 	"type": "module",
+	"scripts": {
+		"check-types": "tsc --noEmit"
+	},
 	"exports": {
 		"./*": "./*"
 	},

--- a/packages/validation/package.json
+++ b/packages/validation/package.json
@@ -2,5 +2,8 @@
 	"name": "@repo/validation",
 	"version": "0.0.0",
 	"private": true,
-	"type": "module"
+	"type": "module",
+	"scripts": {
+		"check-types": "tsc --noEmit"
+	}
 }


### PR DESCRIPTION
Closes #1446 

## Summary

- add `check-types` scripts to the web app, browser extension, and memory graph playground
- add `check-types` scripts to the UI, hooks, lib, and validation packages
- reuse the browser extension’s existing `compile` command for type checking

## Notes

The docs workspaces remain excluded because they do not contain a TypeScript configuration or TypeScript source to check.

## Validation

- confirmed Turbo now resolves executable `check-types` commands for all affected TypeScript workspaces
- ran `bun run check-types`

The expanded check currently exposes pre-existing type errors in `@repo/ui/other/anonymous-auth.tsx`. This is the intended coverage change; those errors were previously skipped and should be fixed separately before requiring the expanded command to pass in CI.