### PR TITLE
fix(tools): bound memory forget requests

### DIFF
--- a/packages/tools/src/shared/forget-memory.ts
+++ b/packages/tools/src/shared/forget-memory.ts
@@ -1,10 +1,15 @@
 const DEFAULT_BASE_URL = "https://api.supermemory.ai"
+const FETCH_TIMEOUT_MS = 30_000
 
 export interface ForgetMemoryParams {
 	containerTag: string
 	id?: string
 	content?: string
 	reason?: string
+}
+
+export interface ForgetMemoryRequestOptions {
+	signal?: AbortSignal
 }
 
 /**
@@ -19,6 +24,7 @@ export async function forgetMemoryRequest(
 	apiKey: string,
 	params: ForgetMemoryParams,
 	baseUrl: string = DEFAULT_BASE_URL,
+	options?: ForgetMemoryRequestOptions,
 ): Promise<void> {
 	const response = await fetch(`${baseUrl}/v4/memories`, {
 		method: "DELETE",
@@ -27,6 +33,7 @@ export async function forgetMemoryRequest(
 			Authorization: `Bearer ${apiKey}`,
 		},
 		body: JSON.stringify(params),
+		signal: options?.signal ?? AbortSignal.timeout(FETCH_TIMEOUT_MS),
 	})
 
 	if (!response.ok) {

--- a/packages/tools/src/tool-operations.test.ts
+++ b/packages/tools/src/tool-operations.test.ts
@@ -109,6 +109,22 @@ describe("memoryForget", () => {
 			id: "mem_1",
 			reason: "outdated",
 		})
+		expect(init.signal).toBeInstanceOf(AbortSignal)
+	})
+
+	it("uses a caller-provided signal instead of creating a timeout", async () => {
+		const fetchMock = stubFetch()
+		const controller = new AbortController()
+
+		await forgetMemoryRequest(
+			API_KEY,
+			{ containerTag: "user_1", id: "mem_1" },
+			undefined,
+			{ signal: controller.signal },
+		)
+
+		const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+		expect(init.signal).toBe(controller.signal)
 	})
 
 	it("throws a descriptive error on non-2xx responses", async () => {


### PR DESCRIPTION
## Summary

- Add a 30-second default timeout to the shared DELETE /v4/memories helper.
- Allow callers to provide an AbortSignal for cancellation.
- Add regression coverage for both the default timeout signal and caller-provided signals.

This prevents AI SDK and OpenAI tool memory-forget calls from remaining pending indefinitely when the API or network stalls.

Fixes #1452

## Testing

- bunx vitest run packages/tools/src/tool-operations.test.ts — 14 passed
- bun run --cwd packages/tools build — passed
- bunx biome check packages/tools/src/shared/forget-memory.ts packages/tools/src/tool-operations.test.ts — passed

The full tools test command still has two pre-existing failures requiring SUPERMEMORY_API_KEY and a missing test/claude-memory module. Package type-checking also reports existing dependency/test errors unrelated to this change.

## Checklist

- [x] Minimal targeted change
- [x] Tests added for default timeout and explicit cancellation
- [x] No unrelated files included