### PR TITLE
fix(web): stop NEXT_PUBLIC_*_AUTH_ENABLED from hiding the provider it names

### DIFF
--- a/apps/web/.env.example
+++ b/apps/web/.env.example
@@ -2,3 +2,8 @@ NEXT_PUBLIC_BACKEND_URL=https://api.supermemory.ai
 NEXT_PUBLIC_POSTHOG_KEY=
 EXA_API_KEY=
 XAI_API_KEY=
+
+# Social sign-in providers. Both are shown by default; set a flag to "false" to
+# hide that provider's button on self-hosted deployments.
+NEXT_PUBLIC_GOOGLE_AUTH_ENABLED=
+NEXT_PUBLIC_GITHUB_AUTH_ENABLED=

--- a/apps/web/app/(auth)/login/page.tsx
+++ b/apps/web/app/(auth)/login/page.tsx
@@ -25,6 +25,25 @@ import {
 	shouldUseReviewerPasswordLogin,
 } from "@/lib/reviewer-password-login"
 
+/**
+ * `NEXT_PUBLIC_<PROVIDER>_AUTH_ENABLED` is an opt-out switch, not an opt-in one:
+ * self-hosted deployments show every social provider by default, and an operator
+ * turns one off by setting the flag to a falsy value. Treating any other value as
+ * "enabled" keeps `..._AUTH_ENABLED=true` from hiding the provider it names.
+ */
+function isSocialProviderEnabled(flag: string | undefined): boolean {
+	if (flag === undefined || flag === "") return true
+	return flag !== "false" && flag !== "0"
+}
+
+const isGoogleAuthEnabled =
+	process.env.NEXT_PUBLIC_HOST_ID === "supermemory" ||
+	isSocialProviderEnabled(process.env.NEXT_PUBLIC_GOOGLE_AUTH_ENABLED)
+
+const isGithubAuthEnabled =
+	process.env.NEXT_PUBLIC_HOST_ID === "supermemory" ||
+	isSocialProviderEnabled(process.env.NEXT_PUBLIC_GITHUB_AUTH_ENABLED)
+
 function isMcpOAuthAuthorizeContext(sp: Pick<URLSearchParams, "get">): boolean {
 	return sp.get("response_type") === "code" && Boolean(sp.get("client_id"))
 }
@@ -475,8 +494,7 @@ export default function LoginPage() {
 										)}
 
 										<div className="flex flex-col gap-3">
-											{process.env.NEXT_PUBLIC_HOST_ID === "supermemory" ||
-											!process.env.NEXT_PUBLIC_GOOGLE_AUTH_ENABLED ? (
+											{isGoogleAuthEnabled ? (
 												<div className="w-full">
 													<LastUsedBadge show={lastUsedMethod === "google"} />
 													<ExternalAuthButton
@@ -532,8 +550,7 @@ export default function LoginPage() {
 													/>
 												</div>
 											) : null}
-											{process.env.NEXT_PUBLIC_HOST_ID === "supermemory" ||
-											!process.env.NEXT_PUBLIC_GITHUB_AUTH_ENABLED ? (
+											{isGithubAuthEnabled ? (
 												<div className="w-full">
 													<LastUsedBadge show={lastUsedMethod === "github"} />
 													<ExternalAuthButton


### PR DESCRIPTION
Fixes #1278.

## The bug

The Google and GitHub buttons on the login page were gated like this:

```tsx
{process.env.NEXT_PUBLIC_HOST_ID === "supermemory" ||
 !process.env.NEXT_PUBLIC_GOOGLE_AUTH_ENABLED ? ( /* Google button */ )
```

Because of the `!`, a self-hosted deployment that set `NEXT_PUBLIC_GOOGLE_AUTH_ENABLED=true` to turn Google on got the opposite result — the button disappeared. Same for GitHub.

## Why not just drop the `!`

#1278 deliberately stopped short of a patch, because the two readings imply different defaults and the right one is a product call:

- **Drop the `!`** (opt-in): matches the name, but the buttons vanish for every existing self-hoster who never set the flag. Breaking.
- **Keep current behaviour** (opt-out): the default is fine, but the variable is misnamed and setting it to `true` does the wrong thing.

This PR takes the second reading and makes the implementation honest, so no existing deployment changes behaviour:

| flag value | before | after |
|---|---|---|
| unset | shown | shown (unchanged) |
| `true` | **hidden** ← the bug | shown |
| `false` / `0` | shown | hidden (new — a real off-switch) |

Only the previously broken case changes. The flag now never hides the provider it names, and self-hosters get an actual way to turn a provider off, which the old logic couldn't express either.

If you'd rather have true opt-in semantics (unset = hidden), say so and I'll flip it — it's a two-line change to `isSocialProviderEnabled`, though it would want a changelog note for self-hosters.

## Also

Both variables are now in `apps/web/.env.example`. #1278 notes the two gating lines were their only references anywhere in the repo — no example entry, no docs.

## Verification

- `biome check` passes on both changed files.
- `tsc --noEmit` on `apps/web`: 84 errors before, 84 after, **0 in the login page**. (Those 84 are pre-existing — CI only type-checks `@supermemory/ai-sdk` and `@supermemory/memory-graph`, which is the subject of #1249 / #1446.)
