### PR TITLE
fix(web): open Slack install in new window

### DIFF
--- a/apps/web/components/onboarding-brain/research-action-rail.tsx
+++ b/apps/web/components/onboarding-brain/research-action-rail.tsx
@@ -525,6 +525,8 @@ function SlackStepBody({
 		<div>
 			<a
 				href={`${BACKEND}/brain/slack/oauth/install`}
+				target="_blank"
+				rel="noopener noreferrer"
 				className={cn(
 					"inline-flex w-full items-center justify-center gap-2 rounded-full bg-white px-4 py-2.5 text-[13px] font-semibold text-[#1D1C1D] transition-opacity hover:opacity-90",
 					dmSans125ClassName(),


### PR DESCRIPTION
<!-- VORFLUX_AGENT_PR_BODY_BEGIN -->
Keeps the existing Slack installation destination while opening it separately so users do not lose onboarding progress.

## Changes
- Open the onboarding “Add to Slack” link in a new browser window/tab.
- Prevent the new page from accessing the onboarding window through `window.opener`.

## Testing
- `./node_modules/.bin/biome check apps/web/components/onboarding-brain/research-action-rail.tsx` — passed.
- `git diff --check` — passed.
- Source assertion for `target="_blank"` and `rel="noopener noreferrer"` on the Slack OAuth link — passed.
- Public preview HTTP check — passed with status 200 at https://4csl2zor8tvt.preview.us1.vorflux.com.
- Browser verification was limited because the onboarding route requires authentication; the public preview redirected to login.

---
**Attached Images**

![slack-new-window-preview.png](https://api.us1.vorflux.com/assets/artifacts/c3VwZXJtZW1vcnk6Zjo3OTY3.-GI7LqzmFzV-4JBauIv0OVM7almvmM81pECiy4He18g.png)
<!-- VORFLUX_AGENT_PR_BODY_END -->

---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/34b5425b-fe7f-4b4b-b3b4-081c23311d5e)
- Requested by: Dhravya Shah (dhravya@supermemory.com)
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single link attribute change in onboarding UI; no changes to OAuth endpoints or auth logic.
> 
> **Overview**
> The onboarding **Add to Slack** link in `SlackStepBody` now opens the Slack OAuth install URL in a **new tab** instead of navigating the current page, so users can finish Slack setup without losing onboarding progress on the research rail.
> 
> The anchor uses `target="_blank"` with `rel="noopener noreferrer"` so the OAuth page cannot access the onboarding window via `window.opener`—consistent with how app connections already use `window.open(..., "_blank", "noopener")` in the same component.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 16d7915df362814837a74ce14bebcd5777f20746. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->