### PR TITLE
fix(build): do not run the Sentry release upload as a root postbuild hook

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,7 @@
     "dev:local": "turbo run dev:app",
     "format-lint": "bunx biome check --write",
     "check-types": "turbo run check-types",
-    "sentry:sourcemaps": "_SENTRY_RELEASE=$(sentry-cli releases propose-version) && sentry-cli releases new $_SENTRY_RELEASE --org=supermemory --project=consumer-app && sentry-cli sourcemaps upload --org=supermemory --project=consumer-app --release=$_SENTRY_RELEASE --strip-prefix 'dist/..' dist",
-    "postbuild": "bun run sentry:sourcemaps"
+    "sentry:sourcemaps": "_SENTRY_RELEASE=$(sentry-cli releases propose-version) && sentry-cli releases new $_SENTRY_RELEASE --org=supermemory --project=consumer-app && sentry-cli sourcemaps upload --org=supermemory --project=consumer-app --release=$_SENTRY_RELEASE --strip-prefix 'dist/..' dist"
   },
   "engines": {
     "node": ">=20"


### PR DESCRIPTION
Fixes #1444.

The root `package.json` had:

```json
"build": "turbo run build",
"sentry:sourcemaps": "... sentry-cli releases new ... sentry-cli sourcemaps upload ... dist",
"postbuild": "bun run sentry:sourcemaps"
```

so every `bun run build` — local or CI — chained a Sentry release creation and sourcemap upload onto the build. That needs deploy-only credentials to succeed, and it targets a root `dist/` that the Turbo build doesn't produce (`apps/web` emits `.next`).

## Change

Remove the root `postbuild` hook. Nothing else moves:

- `sentry:sourcemaps` stays at the root as an explicit, manually-invocable command.
- The real release path is untouched — `apps/web` already carries its own identical `sentry:sourcemaps` plus `"postdeploy": "bun run sentry:sourcemaps"`, which fires on `deploy`, after the app build, which is where it belongs.

That last point is why this is a safe deletion rather than a behaviour change: the root hook was a duplicate of the web app's, firing at build time instead of deploy time.

## Acceptance criteria

- **`bun run build` succeeds without `SENTRY_AUTH_TOKEN`** — verified: `7 successful, 7 total`, exit 0, with no Sentry configuration present.
- **No Sentry release/upload attempted during ordinary builds** — verified: no `sentry-cli` invocation in the build output. (The `[@sentry/nextjs]` deprecation warnings that remain come from the Next.js build plugin, not the CLI upload.)
- **Production deployment still creates the release** — unchanged; it runs from `apps/web`'s `postdeploy`.

I did not run the *pre*-change build to demonstrate the failure, because with credentials present that command creates a real release in the `supermemory` org — not something to trigger from a contributor's machine.

## Left alone

#1444 also suggests correcting the `dist` path / `--strip-prefix` and replacing the POSIX `_SENTRY_RELEASE=$(...)` syntax with something cross-platform. Both apply to the `apps/web` deploy command and depend on how your deploy pipeline is wired, which I can't see from here — so this PR sticks to removing the hook. Happy to follow up on either if you say what the deployed output layout is.
