### PR TITLE
feat(web): add memory button to company brain navbar

### DIFF
--- a/apps/web/components/company-brain-header.tsx
+++ b/apps/web/components/company-brain-header.tsx
@@ -21,6 +21,7 @@ import {
 	LifeBuoy,
 	LayoutGrid,
 	MenuIcon,
+	Plus,
 	SearchIcon,
 	Settings,
 	Settings2,
@@ -55,6 +56,7 @@ const BACKEND =
 type SlackStatus = { connected: boolean; teamName: string | null }
 
 interface CompanyBrainHeaderProps {
+	onAddMemory?: () => void
 	onOpenSearch?: () => void
 }
 
@@ -108,7 +110,10 @@ function useSlackStatus() {
 	})
 }
 
-export function CompanyBrainHeader({ onOpenSearch }: CompanyBrainHeaderProps) {
+export function CompanyBrainHeader({
+	onAddMemory,
+	onOpenSearch,
+}: CompanyBrainHeaderProps) {
 	const { user, org, organizations, setActiveOrg } = useAuth()
 	const autumn = useCustomer()
 	const { currentPlan } = useTokenUsage(autumn)
@@ -412,6 +417,18 @@ export function CompanyBrainHeader({ onOpenSearch }: CompanyBrainHeaderProps) {
 										"linear-gradient(180deg, #0A0E14 0%, #05070A 100%)",
 								}}
 							>
+								{onAddMemory && (
+									<>
+										<DropdownMenuItem
+											onClick={onAddMemory}
+											className={menuItemClass}
+										>
+											<Plus className="size-4 text-[#737373]" />
+											Add memory
+										</DropdownMenuItem>
+										<DropdownMenuSeparator className="bg-[#2E3033]" />
+									</>
+								)}
 								<DropdownMenuItem
 									onClick={goOverview}
 									className={menuItemClass}
@@ -498,6 +515,29 @@ export function CompanyBrainHeader({ onOpenSearch }: CompanyBrainHeaderProps) {
 				) : (
 					<>
 						<BrainTrialPill className="h-9 px-3" />
+						{onAddMemory && (
+							<Tooltip>
+								<TooltipTrigger asChild>
+									<Button
+										variant="headers"
+										className={cn(
+											"rounded-full! h-9! min-h-9 shrink-0",
+											"max-lg:w-9 max-lg:min-w-9 max-lg:justify-center max-lg:gap-0 max-lg:px-0",
+											"lg:min-w-0 lg:gap-1.5 lg:px-3 lg:font-medium",
+											dmSansClassName(),
+										)}
+										onClick={onAddMemory}
+										aria-label="Add memory"
+									>
+										<Plus className="size-3.5 shrink-0 lg:size-4" />
+										<span className="max-lg:sr-only">Add</span>
+									</Button>
+								</TooltipTrigger>
+								<TooltipContent side="bottom" className={dmSansClassName()}>
+									Add memory (C)
+								</TooltipContent>
+							</Tooltip>
+						)}
 						{canInvite && (
 							<Tooltip>
 								<TooltipTrigger asChild>

--- a/apps/web/components/header.tsx
+++ b/apps/web/components/header.tsx
@@ -70,7 +70,12 @@ const brainTileClass = (active: boolean) =>
 export function Header(props: HeaderProps) {
 	const hasCompanyBrain = useHasCompanyBrain()
 	if (hasCompanyBrain) {
-		return <CompanyBrainHeader onOpenSearch={props.onOpenSearch} />
+		return (
+			<CompanyBrainHeader
+				onAddMemory={props.onAddMemory}
+				onOpenSearch={props.onOpenSearch}
+			/>
+		)
 	}
 	return <PersonalBrainHeader {...props} />
 }


### PR DESCRIPTION
The company brain header previously had no Add button — only Invite and Search — unlike the personal-brain header. This wires the existing `onAddMemory` callback (which opens the Add Document modal) through `Header` into `CompanyBrainHeader`, which was dropping it before. Adds an "Add" button to the desktop action cluster (full label on `lg+`, icon-only below, matching the personal header) and an "Add memory" item pinned to the top of the mobile hamburger menu. Works on phone via both the top-bar menu item and the existing bottom-nav Add tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only header wiring and conditional rendering; no auth, API, or data-path changes.
> 
> **Overview**
> **Company Brain** now exposes the same **Add memory** entry points as the personal brain header, using the existing `onAddMemory` callback (opens the Add Document modal).
> 
> `Header` forwards `onAddMemory` into `CompanyBrainHeader` instead of only passing `onOpenSearch`. On **desktop**, an Add button sits in the action cluster (full “Add” label on large screens, icon-only on smaller widths, tooltip “Add memory (C)”). On **mobile**, an **Add memory** item is pinned at the top of the hamburger menu when the callback is provided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d0f6c950f62b5cf98ef993b9ffe208e2121445a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->