### PR TITLE
fix(web): reset image and PDF preview when the modal switches documents

### DIFF
--- a/apps/web/components/document-modal/content/index.tsx
+++ b/apps/web/components/document-modal/content/index.tsx
@@ -90,6 +90,7 @@ export function DocumentContent({
 		case "image":
 			return (
 				<ImagePreview
+					key={document.id}
 					url={document.url ?? ""}
 					title={document.title}
 					documentId={document.id}
@@ -109,7 +110,13 @@ export function DocumentContent({
 			return <TextEditorContent {...textEditorProps} />
 
 		case "pdf":
-			return <PdfViewer url={document.url} documentId={document.id} />
+			return (
+				<PdfViewer
+					key={document.id}
+					url={document.url}
+					documentId={document.id}
+				/>
+			)
 
 		case "notion":
 			return <NotionDoc content={document.content ?? ""} />


### PR DESCRIPTION
### Problem

`DocumentContent` renders `ImagePreview` and `PdfViewer` without a `key`. When the open document modal moves to another document (clicking a different card keeps the modal mounted and just swaps the `document` prop), React reuses the same preview instance. Both components seed internal state from props on mount and never resync it:

- **ImagePreview** stores the source in `const [activeSrc] = useState(url)`. There is no effect syncing `activeSrc` to a changed `url`, so opening a second image keeps showing the first one. A prior `imageError` also sticks, so a good image can render as "Failed to load image".
- **PdfViewer** keeps `cachedUrl` from the previous document. Its cache effect revokes the old object URL when `documentId` changes, but the `cachedUrl` state still points at the now-revoked blob URL, and `fileSource` returns `cachedUrl` first, so the next PDF fails to render.

For comparison, `fullscreen-note-modal.tsx` handles the same situation correctly with a `useEffect` that resyncs its state when the incoming content changes.

### Fix

Key both previews by `document.id`. Switching documents now mounts a fresh instance with clean state, and the components' existing unmount cleanup revokes the stale object URLs. This is the minimal, idiomatic way to reset state that is derived entirely from a document identity, and it also covers PdfViewer's several interdependent state fields (`cachedUrl`, `cacheChecked`, `failedSources`, `numPages`, `loading`, `error`) without threading a reset through each one.

### Testing

Verified by reading the render/state flow; this is a remount-on-identity change with no pure logic to unit test. Biome clean.