### PR TITLE
fix(web): drop debug console.log that logged note content on every keystroke

### DIFF
--- a/apps/web/components/fullscreen-note-modal.tsx
+++ b/apps/web/components/fullscreen-note-modal.tsx
@@ -61,7 +61,6 @@ export function FullscreenNoteModal({
 
 	const handleContentChange = useCallback(
 		(newContent: string) => {
-			console.log("handleContentChange", newContent)
 			setContent(newContent)
 			setDraft(newContent)
 		},


### PR DESCRIPTION
`FullscreenNoteModal`'s `handleContentChange` ran `console.log("handleContentChange", newContent)` on every change, so the full note body was written to the production console on every keystroke. Removed the leftover debug line; the surrounding `setContent` / `setDraft` behavior is unchanged.

Minor, but it is noisy and needlessly puts user note content in the console.