### PR TITLE
fix(web): clear document selection when the active space changes

### DIFF
--- a/apps/web/components/app-experience.tsx
+++ b/apps/web/components/app-experience.tsx
@@ -294,6 +294,17 @@ export function AppExperience() {
 	)
 	const [isSelectionMode, setIsSelectionMode] = useState(false)
 
+	// Selection is scoped to the documents currently on screen. When the active
+	// space changes the previous selection points at documents from another
+	// space that are no longer visible, so clear it — otherwise "Delete selected"
+	// would delete documents the user can't see anymore.
+	const activeSpaceKey = selectedProjects.join("|")
+	// biome-ignore lint/correctness/useExhaustiveDependencies: reset only when the space changes, not on selection edits
+	useEffect(() => {
+		setSelectedDocumentIds((prev) => (prev.size === 0 ? prev : new Set()))
+		setIsSelectionMode((prev) => (prev ? false : prev))
+	}, [activeSpaceKey])
+
 	const handleToggleSelection = useCallback((documentId: string) => {
 		setSelectedDocumentIds((prev) => {
 			const next = new Set(prev)


### PR DESCRIPTION
### Bug

The bulk-selection set (`selectedDocumentIds`) lives in `AppExperience` and was only reset on explicit *Clear*, or after a successful bulk delete — never when the underlying document set changed.

So this sequence deletes an invisible document:
1. Enter selection mode in **Space A**, tick a document.
2. Switch to **Space B** from the space selector (the grid now shows B's documents, but selection mode and the selected id from A are still active).
3. Click **Delete selected** → `handleBulkDelete` permanently deletes the Space-A document that is no longer on screen.

`handleSelectAllVisible` makes it worse: it unions B's visible ids onto the stale A id, so a "select all + delete" wipes the hidden A document too.

### Fix

Clear the selection and exit selection mode whenever the active space (`selectedProjects`) changes:

```ts
const activeSpaceKey = selectedProjects.join("|")
useEffect(() => {
  setSelectedDocumentIds((prev) => (prev.size === 0 ? prev : new Set()))
  setIsSelectionMode((prev) => (prev ? false : prev))
}, [activeSpaceKey])
```

The functional updates return the previous reference when there's nothing to clear, so the initial mount doesn't trigger needless re-renders.

Type-check (the 5 `string | undefined` errors in this file are pre-existing, from the strict local tsconfig, and unrelated) and Biome are clean.