### PR TITLE
fix(web): drop stale category filters when the space changes

### DIFF
--- a/apps/web/components/memories-grid.tsx
+++ b/apps/web/components/memories-grid.tsx
@@ -395,6 +395,23 @@ export function MemoriesGrid({
 		}
 	}, [agentSourceCounts, selectedAgentSource, setSelectedAgentSource])
 
+	// Category filters are URL state that survives a space switch. Drop any that
+	// the current space's facets no longer contain, otherwise the grid stays
+	// filtered down to zero results with no visible pill to clear (the chip only
+	// renders for facets that exist here). Mirrors the agent-source reset above.
+	useEffect(() => {
+		if (!facetsData || selectedCategories.length === 0) return
+		const available = new Set<string>(
+			facetsData.facets.map((facet) => facet.category),
+		)
+		const stillValid = selectedCategories.filter((category) =>
+			available.has(category),
+		)
+		if (stillValid.length !== selectedCategories.length) {
+			void setSelectedCategories(stillValid.length > 0 ? stillValid : null)
+		}
+	}, [facetsData, selectedCategories, setSelectedCategories])
+
 	const {
 		data,
 		error,


### PR DESCRIPTION
### Bug

Category filter chips are stored in the URL (`?categories=`), so they survive a space switch. If the newly selected space has no documents in a selected category:

- the grid query keeps filtering by that category → **zero results**, and
- the category chip only renders for facets that exist in the current space, so **there's no visible control to clear it** — the user is stuck on an empty grid with no obvious cause.

The sibling agent-source filter already handles this (it resets when its count hits 0, added in #1354); categories were just missed.

### Fix

After the facets for the current space load, drop any selected categories they don't contain:

```ts
useEffect(() => {
  if (!facetsData || selectedCategories.length === 0) return
  const available = new Set<string>(facetsData.facets.map((f) => f.category))
  const stillValid = selectedCategories.filter((c) => available.has(c))
  if (stillValid.length !== selectedCategories.length) {
    void setSelectedCategories(stillValid.length > 0 ? stillValid : null)
  }
}, [facetsData, selectedCategories, setSelectedCategories])
```

Type-check and Biome clean.