### PR TITLE
fix(tools): handle malformed OpenAI tool arguments

### DIFF
--- a/packages/tools/src/openai/tools.test.ts
+++ b/packages/tools/src/openai/tools.test.ts
@@ -1,0 +1,58 @@
+import type OpenAI from "openai"
+import { describe, expect, it } from "vitest"
+import { createToolCallExecutor, createToolCallsExecutor } from "./tools"
+
+function toolCall(
+	name: string,
+	args: string,
+	id: string,
+): OpenAI.Chat.Completions.ChatCompletionMessageToolCall {
+	return {
+		id,
+		type: "function",
+		function: { name, arguments: args },
+	}
+}
+
+describe("OpenAI tool call execution", () => {
+	it("returns a structured error for malformed JSON arguments", async () => {
+		const execute = createToolCallExecutor("test-api-key")
+
+		const result = JSON.parse(
+			await execute(toolCall("searchMemories", '{"informationToGet":', "bad")),
+		)
+
+		expect(result).toEqual({
+			success: false,
+			error: "Invalid JSON arguments for searchMemories",
+		})
+	})
+
+	it("keeps malformed calls from rejecting an entire batch", async () => {
+		const execute = createToolCallsExecutor("test-api-key")
+
+		const results = await execute([
+			toolCall("searchMemories", "{broken", "bad"),
+			toolCall("unknownTool", "{}", "unknown"),
+		])
+
+		expect(results).toEqual([
+			{
+				tool_call_id: "bad",
+				role: "tool",
+				content: JSON.stringify({
+					success: false,
+					error: "Invalid JSON arguments for searchMemories",
+				}),
+			},
+			{
+				tool_call_id: "unknown",
+				role: "tool",
+				content: JSON.stringify({
+					success: false,
+					error: "Unknown function: unknownTool",
+				}),
+			},
+		])
+	})
+})

--- a/packages/tools/src/openai/tools.ts
+++ b/packages/tools/src/openai/tools.ts
@@ -552,6 +552,14 @@ export function getToolDefinitions(): OpenAI.Chat.Completions.ChatCompletionTool
 	]
 }
 
+function parseToolArguments(argumentsJson: string) {
+	try {
+		return { success: true as const, value: JSON.parse(argumentsJson) }
+	} catch {
+		return { success: false as const }
+	}
+}
+
 /**
  * Execute a tool call based on the function name and arguments
  */
@@ -565,7 +573,14 @@ export function createToolCallExecutor(
 		toolCall: OpenAI.Chat.Completions.ChatCompletionMessageToolCall,
 	): Promise<string> {
 		const functionName = toolCall.function.name
-		const args = JSON.parse(toolCall.function.arguments)
+		const parsed = parseToolArguments(toolCall.function.arguments)
+		if (!parsed.success) {
+			return JSON.stringify({
+				success: false,
+				error: `Invalid JSON arguments for ${functionName}`,
+			})
+		}
+		const args = parsed.value
 
 		switch (functionName) {
 			case "searchMemories":


### PR DESCRIPTION
## What changed

- return the existing structured error shape when OpenAI tool arguments contain malformed JSON
- keep one malformed call from rejecting an entire tool-call batch
- add focused offline regression coverage

## Why

OpenAI-compatible models can emit partial or invalid JSON in function arguments. The executor previously parsed outside its result flow, so a `SyntaxError` escaped and `Promise.all` discarded sibling results.

## Validation

- `bunx vitest run src/openai/tools.test.ts src/tool-operations.test.ts --testTimeout 100000` (16 passed)
- `bun run build`
- `bunx biome check packages/tools/src/openai/tools.ts packages/tools/src/openai/tools.test.ts`
- `git diff --check`

The package-wide TypeScript command remains red on unrelated pre-existing dependency and example errors; it reports no errors in the new test or changed lines.