### PR TITLE
fix(extension): import visibility-wrapped X bookmarks

### DIFF
--- a/apps/browser-extension/utils/twitter-utils.ts
+++ b/apps/browser-extension/utils/twitter-utils.ts
@@ -46,6 +46,11 @@ interface TwitterAPITweet {
 	}
 }
 
+interface TwitterAPIVisibilityResult {
+	__typename: "TweetWithVisibilityResults"
+	tweet?: TwitterAPITweet
+}
+
 interface MediaEntity {
 	type: string
 	media_url_https: string
@@ -270,9 +275,13 @@ export function transformTweetData(
 			return null
 		}
 
-		const tweet = tweetData as TwitterAPITweet
+		const visibilityResult = tweetData as TwitterAPIVisibilityResult
+		const tweet =
+			visibilityResult.__typename === "TweetWithVisibilityResults"
+				? visibilityResult.tweet
+				: (tweetData as TwitterAPITweet)
 
-		if (!tweet.legacy) {
+		if (!tweet?.legacy) {
 			return null
 		}
 

--- a/apps/browser-extension/utils/twitter-visibility-result.test.ts
+++ b/apps/browser-extension/utils/twitter-visibility-result.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from "bun:test"
+import { getAllTweets, type TwitterAPIResponse } from "./twitter-utils"
+
+const apiTweet = (id: string) => ({
+	__typename: "Tweet",
+	legacy: {
+		favorite_count: 0,
+		created_at: "Wed Oct 10 20:19:24 +0000 2018",
+		id_str: id,
+		full_text: `Tweet ${id}`,
+	},
+})
+
+const timelineEntry = (id: string, result: unknown) => ({
+	entryId: `tweet-${id}`,
+	sortIndex: id,
+	content: { itemContent: { tweet_results: { result } } },
+})
+
+describe("getAllTweets", () => {
+	it("extracts visibility-wrapped results and skips unavailable tweets", () => {
+		const response: TwitterAPIResponse = {
+			data: {
+				bookmark_timeline_v2: {
+					timeline: {
+						instructions: [
+							{
+								type: "TimelineAddEntries",
+								entries: [
+									timelineEntry("100", apiTweet("100")),
+									timelineEntry("200", {
+										__typename: "TweetWithVisibilityResults",
+										limitedActionResults: {},
+										tweet: apiTweet("200"),
+									}),
+									timelineEntry("300", {
+										__typename: "TweetTombstone",
+									}),
+									timelineEntry("400", {
+										__typename: "TweetWithVisibilityResults",
+									}),
+								],
+							},
+						],
+					},
+				},
+			},
+		}
+
+		expect(getAllTweets(response).map((tweet) => tweet.id_str)).toEqual([
+			"100",
+			"200",
+		])
+	})
+})


### PR DESCRIPTION
## What changed
- unwrap `TweetWithVisibilityResults` before transforming bookmark data
- preserve existing handling for direct tweets, tombstones, and malformed results
- add a mixed-timeline regression covering direct, wrapped, tombstone, and missing-inner results

## Why
The enabled X GraphQL visibility policy can return the actual tweet under `result.tweet`. The importer currently checks the wrapper for `legacy`, treats it as unavailable, and silently drops that bookmark.

## Validation
- browser-extension utility suite: 13 passed
- browser-extension TypeScript check passed
- Chrome MV3 production build passed
- Biome and `git diff --check` passed