### PR TITLE
fix(extension): restore global save shortcut

### DIFF
--- a/apps/browser-extension/entrypoints/content/shared.ts
+++ b/apps/browser-extension/entrypoints/content/shared.ts
@@ -1,4 +1,5 @@
 import { MESSAGE_TYPES } from "../../utils/constants"
+import { isSaveMemoryShortcut } from "../../utils/keyboard-shortcut"
 import { bearerToken, userData } from "../../utils/storage"
 import type { APIResponse } from "../../utils/types"
 import { DOMUtils } from "../../utils/ui-components"
@@ -94,11 +95,7 @@ export async function saveMemory(
 
 export function setupGlobalKeyboardShortcut() {
 	document.addEventListener("keydown", async (event) => {
-		if (
-			(event.ctrlKey || event.metaKey) &&
-			event.shiftKey &&
-			event.key === "m"
-		) {
+		if (isSaveMemoryShortcut(event)) {
 			event.preventDefault()
 			await saveMemory("keyboard_shortcut")
 		}

--- a/apps/browser-extension/utils/keyboard-shortcut.test.ts
+++ b/apps/browser-extension/utils/keyboard-shortcut.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "bun:test"
+import {
+	isSaveMemoryShortcut,
+	type SaveMemoryShortcutEvent,
+} from "./keyboard-shortcut"
+
+function shortcutEvent(
+	overrides: Partial<SaveMemoryShortcutEvent> = {},
+): SaveMemoryShortcutEvent {
+	return {
+		ctrlKey: false,
+		key: "M",
+		metaKey: false,
+		repeat: false,
+		shiftKey: true,
+		...overrides,
+	}
+}
+
+describe("isSaveMemoryShortcut", () => {
+	it("accepts uppercase M from Ctrl+Shift+M", () => {
+		expect(isSaveMemoryShortcut(shortcutEvent({ ctrlKey: true }))).toBeTrue()
+	})
+
+	it("accepts uppercase M from Command+Shift+M", () => {
+		expect(isSaveMemoryShortcut(shortcutEvent({ metaKey: true }))).toBeTrue()
+	})
+
+	it("accepts lowercase key representations", () => {
+		expect(
+			isSaveMemoryShortcut(shortcutEvent({ ctrlKey: true, key: "m" })),
+		).toBeTrue()
+	})
+
+	it("rejects missing modifiers and other keys", () => {
+		expect(isSaveMemoryShortcut(shortcutEvent())).toBeFalse()
+		expect(
+			isSaveMemoryShortcut(shortcutEvent({ ctrlKey: true, shiftKey: false })),
+		).toBeFalse()
+		expect(
+			isSaveMemoryShortcut(shortcutEvent({ ctrlKey: true, key: "N" })),
+		).toBeFalse()
+	})
+
+	it("rejects repeated keydown events", () => {
+		expect(
+			isSaveMemoryShortcut(shortcutEvent({ ctrlKey: true, repeat: true })),
+		).toBeFalse()
+	})
+})

--- a/apps/browser-extension/utils/keyboard-shortcut.ts
+++ b/apps/browser-extension/utils/keyboard-shortcut.ts
@@ -1,0 +1,13 @@
+export type SaveMemoryShortcutEvent = Pick<
+	KeyboardEvent,
+	"ctrlKey" | "key" | "metaKey" | "repeat" | "shiftKey"
+>
+
+export function isSaveMemoryShortcut(event: SaveMemoryShortcutEvent): boolean {
+	return (
+		!event.repeat &&
+		(event.ctrlKey || event.metaKey) &&
+		event.shiftKey &&
+		event.key.toLowerCase() === "m"
+	)
+}


### PR DESCRIPTION
## Summary

- restore the browser extension's Ctrl/Cmd+Shift+M global save shortcut
- normalize the shifted key value and ignore repeated keydown events
- add focused regression coverage for Ctrl, Command, casing, modifiers, and repeats

## Why

Browsers report `event.key` as uppercase `"M"` while Shift is held, but the handler compared it with lowercase `"m"`. As a result, the registered shortcut never reached the save flow.

## Validation

- `bun test utils` (17 passed)
- `bun run check-types`
- `bun run build`
- `bunx biome check entrypoints/content/shared.ts utils/keyboard-shortcut.ts utils/keyboard-shortcut.test.ts`
- `git diff --check`

The focused helper suite has 100% line and function coverage, and restoring the original lowercase-only comparison makes both uppercase shortcut regression cases fail.