### PR TITLE
fix(docs-test): fail rejected TypeScript examples

### DIFF
--- a/packages/docs-test/entrypoint-exit.test.ts
+++ b/packages/docs-test/entrypoint-exit.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test"
+import path from "node:path"
+
+const asyncEntrypoints = [
+	"tests/typescript/quickstart.ts",
+	"tests/typescript/sdk.ts",
+	"tests/typescript/search.ts",
+	"tests/typescript/user-profiles.ts",
+	"tests/integrations/ai-sdk.ts",
+	"tests/integrations/claude-memory.ts",
+	"tests/integrations/openai-sdk.ts",
+]
+
+describe("TypeScript docs test entrypoints", () => {
+	it("exits unsuccessfully when an async test rejects", async () => {
+		const child = Bun.spawn(
+			[
+				process.execPath,
+				"run",
+				path.join(import.meta.dir, "tests/typescript/quickstart.ts"),
+			],
+			{
+				cwd: import.meta.dir,
+				env: {
+					...Bun.env,
+					SUPERMEMORY_API_KEY: "offline-test-key",
+					SUPERMEMORY_BASE_URL: "http://127.0.0.1:65536",
+				},
+				stdout: "ignore",
+				stderr: "pipe",
+			},
+		)
+
+		const [exitCode, stderr] = await Promise.all([
+			child.exited,
+			new Response(child.stderr).text(),
+		])
+
+		expect(exitCode).toBe(1)
+		expect(stderr).toContain("ERR_INVALID_URL")
+	})
+
+	it("marks every registered async entrypoint failure as unsuccessful", async () => {
+		for (const relativePath of asyncEntrypoints) {
+			const source = await Bun.file(
+				path.join(import.meta.dir, relativePath),
+			).text()
+
+			expect(source).not.toContain("main().catch(console.error)")
+			expect(source).toContain("process.exitCode = 1")
+		}
+	})
+})

--- a/packages/docs-test/tests/integrations/ai-sdk.ts
+++ b/packages/docs-test/tests/integrations/ai-sdk.ts
@@ -118,4 +118,7 @@ async function main() {
 	console.log("✅ All AI SDK tests passed!")
 }
 
-main().catch(console.error)
+main().catch((error) => {
+	console.error(error)
+	process.exitCode = 1
+})

--- a/packages/docs-test/tests/integrations/claude-memory.ts
+++ b/packages/docs-test/tests/integrations/claude-memory.ts
@@ -102,4 +102,7 @@ async function main() {
 	console.log("✅ All Claude Memory tests passed!")
 }
 
-main().catch(console.error)
+main().catch((error) => {
+	console.error(error)
+	process.exitCode = 1
+})

--- a/packages/docs-test/tests/integrations/openai-sdk.ts
+++ b/packages/docs-test/tests/integrations/openai-sdk.ts
@@ -83,4 +83,7 @@ async function main() {
 	console.log("✅ All OpenAI SDK tests passed!")
 }
 
-main().catch(console.error)
+main().catch((error) => {
+	console.error(error)
+	process.exitCode = 1
+})

--- a/packages/docs-test/tests/typescript/quickstart.ts
+++ b/packages/docs-test/tests/typescript/quickstart.ts
@@ -54,4 +54,7 @@ ${profile.searchResults?.results.map((r) => r.content).join("\n")}`
 	console.log("\n✅ Quickstart TypeScript test passed!")
 }
 
-main().catch(console.error)
+main().catch((error) => {
+	console.error(error)
+	process.exitCode = 1
+})

--- a/packages/docs-test/tests/typescript/sdk.ts
+++ b/packages/docs-test/tests/typescript/sdk.ts
@@ -148,4 +148,7 @@ async function main() {
 	console.log("✅ All TypeScript SDK tests passed!")
 }
 
-main().catch(console.error)
+main().catch((error) => {
+	console.error(error)
+	process.exitCode = 1
+})

--- a/packages/docs-test/tests/typescript/search.ts
+++ b/packages/docs-test/tests/typescript/search.ts
@@ -115,4 +115,7 @@ async function main() {
 	console.log("✅ All search tests passed!")
 }
 
-main().catch(console.error)
+main().catch((error) => {
+	console.error(error)
+	process.exitCode = 1
+})

--- a/packages/docs-test/tests/typescript/user-profiles.ts
+++ b/packages/docs-test/tests/typescript/user-profiles.ts
@@ -90,4 +90,7 @@ async function main() {
 	console.log("✅ All user profile tests passed!")
 }
 
-main().catch(console.error)
+main().catch((error) => {
+	console.error(error)
+	process.exitCode = 1
+})


### PR DESCRIPTION
## Summary

- make all seven registered async TypeScript docs/integration entrypoints exit unsuccessfully when `main()` rejects
- preserve graceful error logging with `process.exitCode = 1`
- add an offline subprocess regression plus coverage for every affected entrypoint

## Problem

Each entrypoint ended with `main().catch(console.error)`. That handled and printed rejected SDK calls but left the child process exit status at 0. Since the docs runner trusts the child status, broken examples were reported as passed.

With an intentionally invalid offline base URL, the current quickstart printed `ERR_INVALID_URL` and the runner reported 1 passed. It now reports 0 passed / 1 failed and exits 1.

## Scope

This is complementary to #1487, which fixes Python executable selection and the runner's own startup/error handling. This PR only changes child test entrypoints and a uniquely named regression test, so it has no file overlap with #1487.

## Validation

- `bun test packages/docs-test` — 2 passed
- real `run.ts typescript/quickstart` failure fixture — exit 1
- targeted TypeScript compile for the new test
- Biome check — no errors (existing example warnings remain)
- `git diff --check`