### PR TITLE
fix(extension): stabilize X bookmark import lifecycle

### DIFF
--- a/apps/browser-extension/entrypoints/background.ts
+++ b/apps/browser-extension/entrypoints/background.ts
@@ -15,6 +15,7 @@ import {
 	type TwitterImportConfig,
 	TwitterImporter,
 } from "../utils/twitter-import"
+import { createTwitterImportNotifications } from "../utils/twitter-import-notifications"
 import type {
 	ExtensionMessage,
 	MemoryData,
@@ -89,36 +90,6 @@ export default defineBackground(() => {
 		{ urls: ["*://x.com/*", "*://twitter.com/*"] },
 		["requestHeaders", "extraHeaders"],
 	)
-
-	// Send message to current active tab.
-	const sendMessageToCurrentTab = async (message: string) => {
-		const tabs = await browser.tabs.query({
-			active: true,
-			currentWindow: true,
-		})
-		if (tabs.length > 0 && tabs[0].id) {
-			await browser.tabs.sendMessage(tabs[0].id, {
-				type: MESSAGE_TYPES.IMPORT_UPDATE,
-				importedMessage: message,
-			})
-		}
-	}
-
-	/**
-	 * Send import completion message
-	 */
-	const sendImportDoneMessage = async (totalImported: number) => {
-		const tabs = await browser.tabs.query({
-			active: true,
-			currentWindow: true,
-		})
-		if (tabs.length > 0 && tabs[0].id) {
-			await browser.tabs.sendMessage(tabs[0].id, {
-				type: MESSAGE_TYPES.IMPORT_DONE,
-				totalImported,
-			})
-		}
-	}
 
 	/**
 	 * Save memory to supermemory API
@@ -246,18 +217,21 @@ export default defineBackground(() => {
 	 * Handle extension messages
 	 */
 	browser.runtime.onMessage.addListener(
-		(message: ExtensionMessage, _sender, sendResponse) => {
+		(message: ExtensionMessage, sender, sendResponse) => {
 			// Handle Twitter import request
 			if (message.type === MESSAGE_TYPES.BATCH_IMPORT_ALL) {
+				const notifications = createTwitterImportNotifications(
+					sender.tab?.id,
+					(tabId, notification) =>
+						browser.tabs.sendMessage(tabId, notification),
+				)
 				const importConfig: TwitterImportConfig = {
 					isFolderImport: message.isFolderImport,
 					bookmarkCollectionId: message.bookmarkCollectionId,
 					selectedProject: message.selectedProject,
-					onProgress: sendMessageToCurrentTab,
-					onComplete: sendImportDoneMessage,
-					onError: async (error: Error) => {
-						await sendMessageToCurrentTab(`Error: ${error.message}`)
-					},
+					onProgress: notifications.onProgress,
+					onComplete: notifications.onComplete,
+					onError: notifications.onError,
 				}
 
 				twitterImporter = new TwitterImporter(importConfig)
@@ -351,3 +325,4 @@ export default defineBackground(() => {
 		},
 	)
 })
+

--- a/apps/browser-extension/entrypoints/background.ts
+++ b/apps/browser-extension/entrypoints/background.ts
@@ -325,4 +325,3 @@ export default defineBackground(() => {
 		},
 	)
 })
-

--- a/apps/browser-extension/entrypoints/background.ts
+++ b/apps/browser-extension/entrypoints/background.ts
@@ -15,6 +15,7 @@ import {
 	type TwitterImportConfig,
 	TwitterImporter,
 } from "../utils/twitter-import"
+import { createTwitterImportController } from "../utils/twitter-import-controller"
 import { createTwitterImportNotifications } from "../utils/twitter-import-notifications"
 import type {
 	ExtensionMessage,
@@ -67,7 +68,9 @@ function inferPlatformFromUrl(url?: string): string | undefined {
 }
 
 export default defineBackground(() => {
-	let twitterImporter: TwitterImporter | null = null
+	const twitterImports = createTwitterImportController(
+		(config: TwitterImportConfig) => new TwitterImporter(config),
+	)
 
 	browser.runtime.onInstalled.addListener(async (details) => {
 		if (details.reason === "install" || details.reason === "update") {
@@ -234,8 +237,18 @@ export default defineBackground(() => {
 					onError: notifications.onError,
 				}
 
-				twitterImporter = new TwitterImporter(importConfig)
-				twitterImporter.startImport().catch(console.error)
+				const importTask = twitterImports.start(importConfig)
+				if (!importTask) {
+					const error = "An X bookmark import is already in progress"
+					void notifications.onError(new Error(error))
+					sendResponse({
+						success: false,
+						error,
+					})
+					return true
+				}
+
+				importTask.catch(console.error)
 				sendResponse({ success: true })
 				return true
 			}

--- a/apps/browser-extension/entrypoints/content/index.ts
+++ b/apps/browser-extension/entrypoints/content/index.ts
@@ -1,4 +1,5 @@
 import { DOMAINS, MESSAGE_TYPES } from "../../utils/constants"
+import { isTwitterImportNotification } from "../../utils/twitter-import-notifications"
 import { DOMUtils } from "../../utils/ui-components"
 import { initializeChatGPT } from "./chatgpt"
 import { initializeClaude } from "./claude"
@@ -28,9 +29,7 @@ export default defineContentScript({
 				return saveMemory(message.actionSource || "content_script")
 			} else if (message.action === MESSAGE_TYPES.TWITTER_IMPORT_OPEN_MODAL) {
 				return openImportModal()
-			} else if (message.type === MESSAGE_TYPES.IMPORT_UPDATE) {
-				updateTwitterImportUI(message)
-			} else if (message.type === MESSAGE_TYPES.IMPORT_DONE) {
+			} else if (isTwitterImportNotification(message)) {
 				updateTwitterImportUI(message)
 			}
 		})

--- a/apps/browser-extension/entrypoints/content/twitter.ts
+++ b/apps/browser-extension/entrypoints/content/twitter.ts
@@ -132,608 +132,59 @@ export async function openImportModal() {
 			action: MESSAGE_TYPES.FETCH_PROJECTS,
 		})
 
-		const projects = response.success && response.data ? response.data : []
+		const projects = response.success && response.data ? response.data : xëOm¢G§²ÚîÆ­yÚYˆ
+Ú[™İË›ØØ][Û‹œ]˜[YHOOH‹ÚKØ›ÛÚÛX\šÜÈŠHÂ‚B\™]\›‚‚_B‚‚XÛÛœİ\™Ù][[Y[ÈHØİ[Y[œ]Y\TÙ[XİÜ[
+‚BH‹˜ÜÜËLMÍ[ÚLœ‹œ‹L]İŒ\œ‹LMY\ÍKœ‹L[[XYLÛ‹œ‹[ÍŞ[œXËœ‹MM™YËœ‹L[MÛœ‹L[Ü]ŒH‹‚JB‚‚]\™Ù][[Y[Ë™›Ü‘XXÚ
 
-		if (projects.length === 0) {
-			await browser.runtime.sendMessage({
-				type: MESSAGE_TYPES.BATCH_IMPORT_ALL,
-			})
-			await trackEvent(POSTHOG_EVENT_KEY.TWITTER_IMPORT_STARTED, {
-				source: `${POSTHOG_EVENT_KEY.SOURCE}_content_script`,
-			})
-		} else {
-			await showAllBookmarksProjectModal(projects)
-		}
-	} catch (error) {
-		console.error("Error opening import modal:", error)
-		await browser.runtime.sendMessage({
-			type: MESSAGE_TYPES.BATCH_IMPORT_ALL,
-		})
-	}
-}
+[[Y[
+HOˆÂ‚BXY]Û•Ñ[[Y[
+[[Y[\ÈS[[Y[
+B‚_JBŸB‚‹ÊŠ‚ˆ
+ˆYÈ[ˆ[\Ü]ÛˆÈH›ÛÚÛX\šÈ›Û\ˆ[[Y[ˆ
+‹Â™[˜İ[ÛˆY]Û•Ñ[[Y[
+[[Y[ˆS[[Y[
+HÂ‚ZYˆ
+[[Y[œ]Y\TÙ[XİÜŠ–Ù]K\İ\\›Y[[ÜKX]Û—HŠJHÂ‚B\™]\›‚‚_B‚‚[ØYÜXÙQÜ›İ\ÚÑ›ÛÊ
+B‚‚XÛÛœİ]ÛˆHÜ™X]TØ]™UÙY][[Y[
+\Ş[˜È
 
-async function showAllBookmarksProjectModal(
-	projects: Array<{ id: string; name: string; containerTag: string }>,
-) {
-	await loadSpaceGroteskFonts()
+HOˆÂ‚BXÛÛœİ\›H[[Y[™Ù]]šX]Jš™YˆŠB‚BXÛÛœİ›ÛÚÛX\šĞÛÛXİ[Û’YH\›ËœÜ]
+‹ÈŠKœÜ
 
-	const modal = createProjectSelectionModal(
-		projects,
-		async (selectedProject) => {
-			modal.remove()
+B‚BZYˆ
+›ÛÚÛX\šĞÛÛXİ[Û’Y
+HÂ‚BBX]ØZ]ÚİÑ›Û\”›Ú™XİÙ[Xİ[Û“[Ù[
+›ÛÚÛX\šĞÛÛXİ[Û’Y
+B‚B_B‚_JB‚‚X]Û‹œÙ]]šX]J™]K\İ\\›Y[[ÜKX]Ûˆ‹YHŠB‚‚Y[[Y[˜\[™Ú[
+]ÛŠB‚Y[[Y[œİ[K™›^\™Xİ[ÛˆHœ›İÈ‚‚Y[[Y[œİ[K˜[YÛ’][\ÈH˜Ù[\ˆ‚‚Y[[Y[œİ[Kš\İYPÛÛ[H˜Ù[\ˆ‚‚Y[[Y[œİ[K™Ø\HŒL‚‚Y[[Y[œİ[KœY[™ÈHŒL‚ŸB‚‹ÊŠ‚ˆ
+ˆÚİÜÈH›Ú™XİÙ[Xİ[Ûˆ[Ù[›Üˆ›Û\ˆ[\ÜÂˆ
+‹Â˜\Ş[˜È[˜İ[ÛˆÚİÑ›Û\”›Ú™XİÙ[Xİ[Û“[Ù[
+›ÛÚÛX\šĞÛÛXİ[Û’Yˆİš[™ÊHÂ‚X]ØZ]ØYÜXÙQÜ›İ\ÚÑ›ÛÊ
+B‚‚XÛÛœİ[Ù[HÜ™X]T›Ú™XİÙ[Xİ[Û“[Ù[
+‚BV×K‚BX\Ş[˜È
+Ù[XİY›Ú™Xİ
+HOˆÂ‚BB[[Ù[œ™[[İ™J
+B‚‚BB]HÂ‚BBBX]ØZ]œ›İÜÙ\‹œ[[YKœÙ[™Y\ÜØYÙJÂ‚BBBB]\NˆQTÔĞQÑWÕTTËUÒÒSTÔ•ĞS‚BBBBZ\Ñ›Û\’[\ÜˆYK‚BBBBX›ÛÚÛX\šĞÛÛXİ[Û’Yˆ›ÛÚÛX\šĞÛÛXİ[Û’Y‚BBBB\Ù[XİY›Ú™XİˆÙ[XİY›Ú™Xİ‚BBB_JB‚BB_HØ]Ú
+\œ›ÜŠHÂ‚BBBXÛÛœÛÛK™\œ›ÜŠ‘\œ›Üˆ[\Ü[™È›ÛÚÛX\šÜÎˆ‹\œ›ÜŠB‚BB_B‚B_K‚BJ
+HOˆÂ‚BB[[Ù[œ™[[İ™J
+B‚B_K‚JB‚‚YØİ[Y[˜›ÙK˜\[™Ú[
+[Ù[
+B‚‚]HÂ‚BXÛÛœİ™\ÜÛœÙHH]ØZ]œ›İÜÙ\‹œ[[YKœÙ[™Y\ÜØYÙJÂ‚BBXXİ[ÛˆQTÔĞQÑWÕTTË‘‘UÒÔ“Ò‘PÕË‚B_JB‚‚BZYˆ
+™\ÜÛœÙKœİXØÙ\ÜÈ	‰ˆ™\ÜÛœÙK™]JHÂ‚BBXÛÛœİ›Ú™XİÈH™\ÜÛœÙK™]B‚BB]\]S[Ù[Ú]›Ú™XİÊ[Ù[›Ú™XİÊB‚B_H[ÙHÂ‚BBXÛÛœÛÛK™\œ›ÜŠ‘˜Z[YÈ™]Ú›Ú™XİÎˆ‹™\ÜÛœÙK™\œ›ÜŠB‚BB]\]S[Ù[Ú]›Ú™XİÊ[Ù[×JB‚B_B‚_HØ]Ú
+\œ›ÜŠHÂ‚BXÛÛœÛÛK™\œ›ÜŠ‘\œ›Üˆ™]Ú[™È›Ú™XİÎˆ‹\œ›ÜŠB‚B]\]S[Ù[Ú]›Ú™XİÊ[Ù[×JB‚_BŸB‚‹ÊŠ‚ˆ
+ˆ\]\ÈH[Ù[Ú]™]ÚY›Ú™XİÂˆ
+‹Â™[˜İ[Ûˆ\]S[Ù[Ú]›Ú™XİÊ‚[[Ù[ˆS[[Y[‚\›Ú™XİÎˆ\œ˜^OÈYˆİš[™ÎÈ˜[YNˆİš[™ÎÈÛÛZ[™\•YÎˆİš[™ÈO‹ŠHÂ‚XÛÛœİÙ[XİH[Ù[œ]Y\TÙ[XİÜŠˆÜ›Ú™Xİ\Ù[XİŠH\ÈSÙ[Xİ[[Y[‚ZYˆ
+\Ù[Xİ
+H™]\›‚‚‚]Ú[H
+Ù[Xİ˜Ú[™[‹›[™İˆJHÂ‚B\Ù[Xİœ™[[İ™PÚ[
+Ù[Xİ˜Ú[™[–ÌWJB‚_B‚‚ZYˆ
+›Ú™XİË›[™İOOH
+HÂ‚BXÛÛœİ›Ô›Ú™XİÓÜ[ÛˆHØİ[Y[˜Ü™X]Q[[Y[
+›Ü[ÛˆŠB‚B[›Ô›Ú™XİÓÜ[Û‹˜[YHHˆ‚‚B[›Ô›Ú™XİÓÜ[Û‹^ÛÛ[H“›È›Ú™XİÈ]˜Z[X›H‚‚B[›Ô›Ú™XİÓÜ[Û‹™\ØX›YHYB‚B\Ù[Xİ˜\[™Ú[
+›Ô›Ú™XİÓÜ[ÛŠB‚‚BXÛÛœİ[\Ü]ÛˆH[Ù[œ]Y\TÙ[XİÜŠ‚BBH˜]Û›\İXÚ[‹‚BJH\ÈS]Û‘[[Y[‚BZYˆ
+[\Ü]ÛŠHÂ‚BBZ[\Ü]Û‹™\ØX›YHYB‚BBZ[\Ü]Û‹œİ[K˜ÜÜÕ^H‚BBB\Y[™ÎˆLMœÂ‚BBBX›Ü™\ˆ\ÛÛY™Ø˜JMKMKMKŒJNÂ‚BBBX›Ü™\‹\˜Y]\ÎˆLœÂ‚BBBX˜XÚÙÜ›İ[™ˆ™Ø˜JMKMKMKŒJNÂ‚BBBXÛÛÜˆ™Ø˜JMKMKMKŒÊNÂ‚BBBY›Û\Ú^™NˆMÂ‚BBBY›Û]ÙZYÚˆLÂ‚BBBXİ\œÛÜˆ›İX[İÙYÂ‚BBB]˜[œÚ][Ûˆ[ŒœÈX\ÙNÂ‚BBX‚B_B‚_H[ÙHÂ‚B\›Ú™XİË™›Ü‘XXÚ
 
-			try {
-				await browser.runtime.sendMessage({
-					type: MESSAGE_TYPES.BATCH_IMPORT_ALL,
-					selectedProject: selectedProject,
-				})
-				await trackEvent(POSTHOG_EVENT_KEY.TWITTER_IMPORT_STARTED, {
-					source: `${POSTHOG_EVENT_KEY.SOURCE}_content_script`,
-					project_selected: true,
-				})
-			} catch (error) {
-				console.error("Error importing all bookmarks:", error)
-			}
-		},
-		() => {
-			modal.remove()
-		},
-	)
-
-	document.body.appendChild(modal)
-}
-
-/**
- * Shows the one-time onboarding toast with progress bar
- */
-async function showOnboardingToast() {
-	await loadSpaceGroteskFonts()
-
-	// Remove any existing toast
-	const existingToast = document.getElementById(
-		ELEMENT_IDS.TWITTER_ONBOARDING_TOAST,
-	)
-	if (existingToast) {
-		existingToast.remove()
-	}
-
-	const duration = UI_CONFIG.ONBOARDING_TOAST_DURATION
-
-	// Create toast container
-	const toast = document.createElement("div")
-	toast.id = ELEMENT_IDS.TWITTER_ONBOARDING_TOAST
-	toast.style.cssText = `
-		position: fixed;
-		bottom: 20px;
-		right: 20px;
-		z-index: 2147483647;
-		background: #ffffff;
-		border-radius: 12px;
-		padding: 16px;
-		display: flex;
-		flex-direction: column;
-		gap: 12px;
-		font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-		font-size: 14px;
-		color: #374151;
-		min-width: 320px;
-		max-width: 380px;
-		box-shadow: 0 4px 24px 0 rgba(0,0,0,0.18), 0 1.5px 6px 0 rgba(0,0,0,0.12);
-		animation: smSlideInUp 0.3s ease-out;
-		overflow: hidden;
-	`
-
-	// Add keyframe animations if not already present
-	if (!document.getElementById("supermemory-onboarding-toast-styles")) {
-		const style = document.createElement("style")
-		style.id = "supermemory-onboarding-toast-styles"
-		style.textContent = `
-			@keyframes smSlideInUp {
-				from { transform: translateY(100%); opacity: 0; }
-				to { transform: translateY(0); opacity: 1; }
-			}
-			@keyframes smFadeOut {
-				from { transform: translateY(0); opacity: 1; }
-				to { transform: translateY(100%); opacity: 0; }
-			}
-			@keyframes smProgressGrow {
-				from { transform: scaleX(0); }
-				to { transform: scaleX(1); }
-			}
-			@keyframes smPulse {
-				0%, 100% { opacity: 1; }
-				50% { opacity: 0.4; }
-			}
-		`
-		document.head.appendChild(style)
-	}
-
-	// Header with icon, text and close button
-	const header = document.createElement("div")
-	header.style.cssText =
-		"display: flex; align-items: flex-start; gap: 12px; position: relative;"
-
-	const iconUrl = browser.runtime.getURL("/new_logo.png")
-	const icon = document.createElement("img")
-	icon.src = iconUrl
-	icon.alt = "Supermemory"
-	icon.style.cssText =
-		"width: 24px; height: 24px; border-radius: 4px; flex-shrink: 0; margin-top: 2px;"
-
-	const textContainer = document.createElement("div")
-	textContainer.style.cssText =
-		"display: flex; flex-direction: column; gap: 4px; flex: 1;"
-
-	const title = document.createElement("span")
-	title.style.cssText = "font-weight: 600; font-size: 14px; color: #111827;"
-	title.textContent = "Import X/Twitter Bookmarks"
-
-	const description = document.createElement("span")
-	description.style.cssText =
-		"font-size: 13px; color: #6b7280; line-height: 1.4;"
-	description.textContent =
-		"You can import all your Twitter bookmarks to Supermemory with one click."
-
-	textContainer.appendChild(title)
-	textContainer.appendChild(description)
-
-	// Close button
-	const closeButton = document.createElement("button")
-	closeButton.setAttribute("aria-label", "Close onboarding toast")
-	closeButton.style.cssText = `
-		position: absolute;
-		top: 0;
-		right: 0;
-		background: transparent;
-		border: none;
-		cursor: pointer;
-		padding: 4px;
-		color: #9ca3af;
-		display: flex;
-		align-items: center;
-		justify-content: center;
-		border-radius: 4px;
-		transition: background-color 0.2s;
-	`
-	closeButton.innerHTML = `
-		<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-			<line x1="18" y1="6" x2="6" y2="18"></line>
-			<line x1="6" y1="6" x2="18" y2="18"></line>
-		</svg>
-	`
-	closeButton.addEventListener("mouseenter", () => {
-		closeButton.style.backgroundColor = "#f3f4f6"
-	})
-	closeButton.addEventListener("mouseleave", () => {
-		closeButton.style.backgroundColor = "transparent"
-	})
-	closeButton.addEventListener("click", () => {
-		dismissToast(toast)
-	})
-
-	header.appendChild(icon)
-	header.appendChild(textContainer)
-	header.appendChild(closeButton)
-
-	// Action buttons
-	const buttonsContainer = document.createElement("div")
-	buttonsContainer.style.cssText = "display: flex; gap: 8px; margin-top: 4px;"
-
-	const importButton = document.createElement("button")
-	importButton.style.cssText = `
-		padding: 8px 16px;
-		border: none;
-		border-radius: 8px;
-		background: linear-gradient(182.37deg, #0ff0d2 -91.53%, #5bd3fb -67.8%, #1e0ff0 95.17%);
-		color: white;
-		font-size: 13px;
-		font-weight: 500;
-		cursor: pointer;
-		transition: opacity 0.2s;
-		font-family: inherit;
-	`
-	importButton.textContent = "Import now"
-	importButton.addEventListener("mouseenter", () => {
-		importButton.style.opacity = "0.9"
-	})
-	importButton.addEventListener("mouseleave", () => {
-		importButton.style.opacity = "1"
-	})
-	importButton.addEventListener("click", async () => {
-		dismissToast(toast)
-		await openImportModal()
-	})
-
-	const learnMoreButton = document.createElement("button")
-	learnMoreButton.style.cssText = `
-		padding: 8px 16px;
-		border: 1px solid #e5e7eb;
-		border-radius: 8px;
-		background: transparent;
-		color: #374151;
-		font-size: 13px;
-		font-weight: 500;
-		cursor: pointer;
-		transition: background-color 0.2s;
-		font-family: inherit;
-	`
-	learnMoreButton.textContent = "Learn more"
-	learnMoreButton.addEventListener("mouseenter", () => {
-		learnMoreButton.style.backgroundColor = "#f9fafb"
-	})
-	learnMoreButton.addEventListener("mouseleave", () => {
-		learnMoreButton.style.backgroundColor = "transparent"
-	})
-	learnMoreButton.addEventListener("click", () => {
-		window.open("https://docs.supermemory.ai/connectors/twitter", "_blank")
-	})
-
-	buttonsContainer.appendChild(importButton)
-	buttonsContainer.appendChild(learnMoreButton)
-
-	// Progress bar container
-	const progressBarContainer = document.createElement("div")
-	progressBarContainer.setAttribute("role", "progressbar")
-	progressBarContainer.setAttribute("aria-valuemin", "0")
-	progressBarContainer.setAttribute("aria-valuemax", "100")
-	progressBarContainer.setAttribute("aria-valuenow", "0")
-	progressBarContainer.setAttribute(
-		"aria-label",
-		"Onboarding toast auto-dismiss progress",
-	)
-	progressBarContainer.style.cssText = `
-		position: absolute;
-		bottom: 0;
-		left: 0;
-		right: 0;
-		height: 3px;
-		background: #e5e7eb;
-	`
-
-	const progressBar = document.createElement("div")
-	progressBar.style.cssText = `
-		height: 100%;
-		background: linear-gradient(90deg, #0ff0d2, #5bd3fb, #1e0ff0);
-		transform-origin: left;
-		animation: smProgressGrow ${duration}ms linear forwards;
-	`
-
-	// Update progress bar ARIA value as animation progresses
-	const startTime = Date.now()
-	const updateProgress = () => {
-		const elapsed = Date.now() - startTime
-		const progress = Math.min(100, Math.round((elapsed / duration) * 100))
-		progressBarContainer.setAttribute("aria-valuenow", String(progress))
-		if (progress < 100) {
-			requestAnimationFrame(updateProgress)
-		}
-	}
-	requestAnimationFrame(updateProgress)
-
-	progressBarContainer.appendChild(progressBar)
-
-	// Assemble toast
-	toast.appendChild(header)
-	toast.appendChild(buttonsContainer)
-	toast.appendChild(progressBarContainer)
-
-	document.body.appendChild(toast)
-
-	// Auto-dismiss after duration
-	setTimeout(() => {
-		if (document.body.contains(toast)) {
-			dismissToast(toast)
-		}
-	}, duration)
-}
-
-/**
- * Dismiss the toast with animation
- */
-function dismissToast(toast: HTMLElement) {
-	toast.style.animation = "smFadeOut 0.3s ease-out forwards"
-	setTimeout(() => {
-		if (document.body.contains(toast)) {
-			toast.remove()
-		}
-	}, 300)
-}
-
-/**
- * Remove all Twitter-specific injected UI
- */
-function removeAllTwitterUI() {
-	// Remove import button (legacy)
-	if (DOMUtils.elementExists(ELEMENT_IDS.TWITTER_IMPORT_BUTTON)) {
-		DOMUtils.removeElement(ELEMENT_IDS.TWITTER_IMPORT_BUTTON)
-	}
-	// Remove onboarding toast
-	if (DOMUtils.elementExists(ELEMENT_IDS.TWITTER_ONBOARDING_TOAST)) {
-		DOMUtils.removeElement(ELEMENT_IDS.TWITTER_ONBOARDING_TOAST)
-	}
-	// Remove import progress toast
-	if (DOMUtils.elementExists(ELEMENT_IDS.TWITTER_IMPORT_PROGRESS_TOAST)) {
-		DOMUtils.removeElement(ELEMENT_IDS.TWITTER_IMPORT_PROGRESS_TOAST)
-	}
-	// Remove any folder buttons
-	document.querySelectorAll("[data-supermemory-button]").forEach((button) => {
-		button.remove()
-	})
-}
-
-/**
- * Shows or updates the import progress toast in the bottom-right
- */
-function showOrUpdateImportProgressToast(message: string, isComplete = false) {
-	let toast = document.getElementById(ELEMENT_IDS.TWITTER_IMPORT_PROGRESS_TOAST)
-
-	if (!toast) {
-		// Ensure animation styles are available
-		if (!document.getElementById("supermemory-onboarding-toast-styles")) {
-			const style = document.createElement("style")
-			style.id = "supermemory-onboarding-toast-styles"
-			style.textContent = `
-				@keyframes smSlideInUp {
-					from { transform: translateY(100%); opacity: 0; }
-					to { transform: translateY(0); opacity: 1; }
-				}
-				@keyframes smFadeOut {
-					from { transform: translateY(0); opacity: 1; }
-					to { transform: translateY(100%); opacity: 0; }
-				}
-				@keyframes smPulse {
-					0%, 100% { opacity: 1; }
-					50% { opacity: 0.4; }
-				}
-			`
-			document.head.appendChild(style)
-		}
-
-		// Create new toast
-		toast = document.createElement("div")
-		toast.id = ELEMENT_IDS.TWITTER_IMPORT_PROGRESS_TOAST
-		toast.style.cssText = `
-			position: fixed;
-			bottom: 20px;
-			right: 20px;
-			z-index: 2147483647;
-			background: #ffffff;
-			border-radius: 12px;
-			padding: 14px 16px;
-			display: flex;
-			align-items: center;
-			gap: 12px;
-			font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
-			font-size: 14px;
-			color: #374151;
-			min-width: 280px;
-			max-width: 360px;
-			box-shadow: 0 4px 24px 0 rgba(0,0,0,0.18), 0 1.5px 6px 0 rgba(0,0,0,0.12);
-			animation: smSlideInUp 0.3s ease-out;
-		`
-
-		const iconUrl = browser.runtime.getURL("/new_logo.png")
-		const icon = document.createElement("img")
-		icon.src = iconUrl
-		icon.alt = "Supermemory"
-		icon.id = "sm-import-progress-icon"
-		icon.style.cssText =
-			"width: 20px; height: 20px; border-radius: 4px; flex-shrink: 0; animation: smPulse 1.5s ease-in-out infinite;"
-
-		const textSpan = document.createElement("span")
-		textSpan.id = "sm-import-progress-text"
-		textSpan.style.cssText = "font-weight: 500; flex: 1;"
-		textSpan.textContent = message
-
-		toast.appendChild(icon)
-		toast.appendChild(textSpan)
-		document.body.appendChild(toast)
-	} else {
-		// Update existing toast
-		const textSpan = toast.querySelector(
-			"#sm-import-progress-text",
-		) as HTMLSpanElement
-		if (textSpan) {
-			textSpan.textContent = message
-		}
-	}
-
-	// Style for completion
-	if (isComplete) {
-		const icon = toast.querySelector(
-			"#sm-import-progress-icon",
-		) as HTMLImageElement
-		if (icon) {
-			icon.style.animation = "none"
-			icon.style.opacity = "1"
-		}
-
-		const textSpan = toast.querySelector(
-			"#sm-import-progress-text",
-		) as HTMLSpanElement
-		if (textSpan) {
-			textSpan.style.color = "#059669"
-		}
-
-		// Auto-dismiss after 4 seconds on completion
-		setTimeout(() => {
-			const existingToast = document.getElementById(
-				ELEMENT_IDS.TWITTER_IMPORT_PROGRESS_TOAST,
-			)
-			if (existingToast) {
-				dismissToast(existingToast)
-			}
-		}, 4000)
-	}
-}
-
-export function updateTwitterImportUI(message: {
-	type: string
-	importedMessage?: string
-	totalImported?: number
-}) {
-	if (message.type === MESSAGE_TYPES.IMPORT_UPDATE && message.importedMessage) {
-		showOrUpdateImportProgressToast(message.importedMessage, false)
-	}
-
-	if (message.type === MESSAGE_TYPES.IMPORT_DONE) {
-		showOrUpdateImportProgressToast(
-			`âœ“ Imported ${message.totalImported} tweets!`,
-			true,
-		)
-	}
-}
-
-export async function handleTwitterNavigation() {
-	if (!DOMUtils.isOnDomain(DOMAINS.TWITTER)) {
-		return
-	}
-
-	if (window.location.pathname === "/i/bookmarks") {
-		addTwitterImportButtonForFolders()
-		await handleBookmarksPageLoad()
-	} else {
-		removeAllTwitterUI()
-	}
-}
-
-/**
- * Adds import buttons to bookmark folders
- */
-function addTwitterImportButtonForFolders() {
-	if (window.location.pathname !== "/i/bookmarks") {
-		return
-	}
-
-	const targetElements = document.querySelectorAll(
-		".css-175oi2r.r-1wtj0ep.r-16x9es5.r-1mmae3n.r-o7ynqc.r-6416eg.r-1ny4l3l.r-1loqt21",
-	)
-
-	targetElements.forEach((element) => {
-		addButtonToElement(element as HTMLElement)
-	})
-}
-
-/**
- * Adds an import button to a bookmark folder element
- */
-function addButtonToElement(element: HTMLElement) {
-	if (element.querySelector("[data-supermemory-button]")) {
-		return
-	}
-
-	loadSpaceGroteskFonts()
-
-	const button = createSaveTweetElement(async () => {
-		const url = element.getAttribute("href")
-		const bookmarkCollectionId = url?.split("/").pop()
-		if (bookmarkCollectionId) {
-			await showFolderProjectSelectionModal(bookmarkCollectionId)
-		}
-	})
-
-	button.setAttribute("data-supermemory-button", "true")
-
-	element.appendChild(button)
-	element.style.flexDirection = "row"
-	element.style.alignItems = "center"
-	element.style.justifyContent = "center"
-	element.style.gap = "10px"
-	element.style.padding = "10px"
-}
-
-/**
- * Shows the project selection modal for folder imports
- */
-async function showFolderProjectSelectionModal(bookmarkCollectionId: string) {
-	await loadSpaceGroteskFonts()
-
-	const modal = createProjectSelectionModal(
-		[],
-		async (selectedProject) => {
-			modal.remove()
-
-			try {
-				await browser.runtime.sendMessage({
-					type: MESSAGE_TYPES.BATCH_IMPORT_ALL,
-					isFolderImport: true,
-					bookmarkCollectionId: bookmarkCollectionId,
-					selectedProject: selectedProject,
-				})
-			} catch (error) {
-				console.error("Error importing bookmarks:", error)
-			}
-		},
-		() => {
-			modal.remove()
-		},
-	)
-
-	document.body.appendChild(modal)
-
-	try {
-		const response = await browser.runtime.sendMessage({
-			action: MESSAGE_TYPES.FETCH_PROJECTS,
-		})
-
-		if (response.success && response.data) {
-			const projects = response.data
-			updateModalWithProjects(modal, projects)
-		} else {
-			console.error("Failed to fetch projects:", response.error)
-			updateModalWithProjects(modal, [])
-		}
-	} catch (error) {
-		console.error("Error fetching projects:", error)
-		updateModalWithProjects(modal, [])
-	}
-}
-
-/**
- * Updates the modal with fetched projects
- */
-function updateModalWithProjects(
-	modal: HTMLElement,
-	projects: Array<{ id: string; name: string; containerTag: string }>,
-) {
-	const select = modal.querySelector("#project-select") as HTMLSelectElement
-	if (!select) return
-
-	while (select.children.length > 1) {
-		select.removeChild(select.children[1])
-	}
-
-	if (projects.length === 0) {
-		const noProjectsOption = document.createElement("option")
-		noProjectsOption.value = ""
-		noProjectsOption.textContent = "No projects available"
-		noProjectsOption.disabled = true
-		select.appendChild(noProjectsOption)
-
-		const importButton = modal.querySelector(
-			"button:last-child",
-		) as HTMLButtonElement
-		if (importButton) {
-			importButton.disabled = true
-			importButton.style.cssText = `
-				padding: 10px 16px;
-				border: 1px solid rgba(255, 255, 255, 0.1);
-				border-radius: 12px;
-				background: rgba(255, 255, 255, 0.05);
-				color: rgba(255, 255, 255, 0.3);
-				font-size: 14px;
-				font-weight: 500;
-				cursor: not-allowed;
-				transition: all 0.2s ease;
-			`
-		}
-	} else {
-		projects.forEach((project) => {
-			const option = document.createElement("option")
-			option.value = project.id
-			option.textContent = project.name
-			option.dataset.containerTag = project.containerTag
-			select.appendChild(option)
-		})
-	}
-}
+›Ú™Xİ
+HOˆÂ‚BBXÛÛœİÜ[ÛˆHØİ[Y[˜Ü™X]Q[[Y[
+›Ü[ÛˆŠB‚BB[Ü[Û‹˜[YHH›Ú™XİšY‚BB[Ü[Û‹^ÛÛ[H›Ú™Xİ›˜[YB‚BB[Ü[Û‹™]\Ù]˜ÛÛZ[™\•YÈH›Ú™Xİ˜ÛÛZ[™\•YÂ‚BB\Ù[Xİ˜\[™Ú[
+Ü[ÛŠB‚B_JB‚_BŸB

--- a/apps/browser-extension/entrypoints/content/twitter.ts
+++ b/apps/browser-extension/entrypoints/content/twitter.ts
@@ -132,59 +132,631 @@ export async function openImportModal() {
 			action: MESSAGE_TYPES.FETCH_PROJECTS,
 		})
 
-		const projects = response.success && response.data ? response.data : xÎOm¢Gß≤⁄Óù∆≠y⁄Yà
-⁄[ô›Àõÿÿ][€ãú]ò[YHOOHã⁄Kÿõ€⁄€X\ö‹»äH¬ÇB\ô]\õÇÇ_BÇÇX€€ú›\ôŸ][[Y[ù»Hÿ›[Y[ùú]Y\ûTŸ[X›‹ê[
-ÇBHãò‹‹ÀLMÕ[⁄LúãúãL]›å\úãLMûY\ÕKúãL[[XYL€ãúã[Õﬁ[úXÀúãMçMôYÀúãL[ûM€úãL[‹]åHãÇJBÇÇ]\ôŸ][[Y[ùÀôõ‹ëXX⁄
+		const projects = response.success && response.data ? response.data : []
 
-[[Y[ù
-HOà¬ÇBXYù]€ï—[[Y[ù
-[[Y[ù\»S[[Y[ù
-BÇ_JBüBÇã äÇà
-àY»[à[\‹ùù]€à»Hõ€⁄€X\ö»õ€\à[[Y[ùà
-ã¬ôù[ò›[€àYù]€ï—[[Y[ù
-[[Y[ùàS[[Y[ù
-H¬ÇZYà
-[[Y[ùú]Y\ûTŸ[X›‹äñŸ]K\›\\õY[[‹ûKXù]€óHäJH¬ÇB\ô]\õÇÇ_BÇÇ[ÿY‹XŸQ‹õ›\⁄—õ€ù 
-BÇÇX€€ú›ù]€àH‹ôX]Tÿ]ôUŸY][[Y[ù
-\ﬁ[ò»
+		if (projects.length === 0) {
+			const importResponse = await browser.runtime.sendMessage({
+				type: MESSAGE_TYPES.BATCH_IMPORT_ALL,
+			})
+			if (importResponse?.success) {
+				await trackEvent(POSTHOG_EVENT_KEY.TWITTER_IMPORT_STARTED, {
+					source: `${POSTHOG_EVENT_KEY.SOURCE}_content_script`,
+				})
+			}
+		} else {
+			await showAllBookmarksProjectModal(projects)
+		}
+	} catch (error) {
+		console.error("Error opening import modal:", error)
+		await browser.runtime.sendMessage({
+			type: MESSAGE_TYPES.BATCH_IMPORT_ALL,
+		})
+	}
+}
 
-HOà¬ÇBX€€ú›\õH[[Y[ùôŸ]]öXù]JöôYàäBÇBX€€ú›õ€⁄€X\ö–€€X›[€íYH\õÀú‹]
-ã»äKú‹
+async function showAllBookmarksProjectModal(
+	projects: Array<{ id: string; name: string; containerTag: string }>,
+) {
+	await loadSpaceGroteskFonts()
 
-BÇBZYà
-õ€⁄€X\ö–€€X›[€íY
-H¬ÇBBX]ÿZ]⁄›—õ€\îõ⁄ôX›Ÿ[X›[€ì[Ÿ[
-õ€⁄€X\ö–€€X›[€íY
-BÇB_BÇ_JBÇÇXù]€ãúŸ]]öXù]Jô]K\›\\õY[[‹ûKXù]€àãùùYHäBÇÇY[[Y[ùò\[ô⁄[
-ù]€äBÇY[[Y[ùú›[Kôõ^\ôX›[€àHúõ›»ÇÇY[[Y[ùú›[Kò[Y€í][\»HòŸ[ù\àÇÇY[[Y[ùú›[Köù\›YûP€€ù[ùHòŸ[ù\àÇÇY[[Y[ùú›[Kôÿ\HåLÇÇY[[Y[ùú›[KúY[ô»HåLÇüBÇã äÇà
-à⁄›‹»Hõ⁄ôX›Ÿ[X›[€à[Ÿ[õ‹àõ€\à[\‹ù¬à
-ã¬ò\ﬁ[ò»ù[ò›[€à⁄›—õ€\îõ⁄ôX›Ÿ[X›[€ì[Ÿ[
-õ€⁄€X\ö–€€X›[€íYà›ö[ô H¬ÇX]ÿZ]ÿY‹XŸQ‹õ›\⁄—õ€ù 
-BÇÇX€€ú›[Ÿ[H‹ôX]Tõ⁄ôX›Ÿ[X›[€ì[Ÿ[
-ÇBV◊KÇBX\ﬁ[ò»
-Ÿ[X›Yõ⁄ôX›
-HOà¬ÇBB[[Ÿ[úô[[›ôJ
-BÇÇBB]ûH¬ÇBBBX]ÿZ]úõ›‹Ÿ\ãúù[ù[YKúŸ[ôY\‹ÿYŸJ¬ÇBBBB]\NàQT‘–Q—W’TTÀêêU““ST‘ï–SÇBBBBZ\—õ€\í[\‹ùàùYKÇBBBBXõ€⁄€X\ö–€€X›[€íYàõ€⁄€X\ö–€€X›[€íYÇBBBB\Ÿ[X›Yõ⁄ôX›àŸ[X›Yõ⁄ôX›ÇBBB_JBÇBB_Hÿ]⁄
-\úõ‹äH¬ÇBBBX€€ú€€Kô\úõ‹äë\úõ‹à[\‹ù[ô»õ€⁄€X\ö‹Œàã\úõ‹äBÇBB_BÇB_KÇBJ
-HOà¬ÇBB[[Ÿ[úô[[›ôJ
-BÇB_KÇJBÇÇYÿ›[Y[ùòõŸKò\[ô⁄[
-[Ÿ[
-BÇÇ]ûH¬ÇBX€€ú›ô\‹€úŸHH]ÿZ]úõ›‹Ÿ\ãúù[ù[YKúŸ[ôY\‹ÿYŸJ¬ÇBBXX›[€éàQT‘–Q—W’TTÀëëU“‘ì“ëP’ÀÇB_JBÇÇBZYà
-ô\‹€úŸKú›XÿŸ\‹»	âàô\‹€úŸKô]JH¬ÇBBX€€ú›õ⁄ôX›»Hô\‹€úŸKô]BÇBB]\]S[Ÿ[⁄]õ⁄ôX› [Ÿ[õ⁄ôX› BÇB_H[ŸH¬ÇBBX€€ú€€Kô\úõ‹äëòZ[Y»ô]⁄õ⁄ôX›Œàãô\‹€úŸKô\úõ‹äBÇBB]\]S[Ÿ[⁄]õ⁄ôX› [Ÿ[◊JBÇB_BÇ_Hÿ]⁄
-\úõ‹äH¬ÇBX€€ú€€Kô\úõ‹äë\úõ‹àô]⁄[ô»õ⁄ôX›Œàã\úõ‹äBÇB]\]S[Ÿ[⁄]õ⁄ôX› [Ÿ[◊JBÇ_BüBÇã äÇà
-à\]\»H[Ÿ[⁄]ô]⁄Yõ⁄ôX›¬à
-ã¬ôù[ò›[€à\]S[Ÿ[⁄]õ⁄ôX› Ç[[Ÿ[àS[[Y[ùÇ\õ⁄ôX›Œà\úò^O»Yà›ö[ôŒ»ò[YNà›ö[ôŒ»€€ùZ[ô\ïYŒà›ö[ô»OãäH¬ÇX€€ú›Ÿ[X›H[Ÿ[ú]Y\ûTŸ[X›‹äà‹õ⁄ôX›\Ÿ[X›äH\»SŸ[X›[[Y[ùÇZYà
-\Ÿ[X›
-Hô]\õÇÇÇ]⁄[H
-Ÿ[X›ò⁄[ô[ãõ[ô›àJH¬ÇB\Ÿ[X›úô[[›ôP⁄[
-Ÿ[X›ò⁄[ô[ñÃWJBÇ_BÇÇZYà
-õ⁄ôX›Àõ[ô›OOH
-H¬ÇBX€€ú›õ‘õ⁄ôX›”‹[€àHÿ›[Y[ùò‹ôX]Q[[Y[ù
-õ‹[€àäBÇB[õ‘õ⁄ôX›”‹[€ãùò[YHHàÇÇB[õ‘õ⁄ôX›”‹[€ãù^€€ù[ùHìõ»õ⁄ôX›»]òZ[XõHÇÇB[õ‘õ⁄ôX›”‹[€ãô\ÿXõYHùYBÇB\Ÿ[X›ò\[ô⁄[
-õ‘õ⁄ôX›”‹[€äBÇÇBX€€ú›[\‹ùù]€àH[Ÿ[ú]Y\ûTŸ[X›‹äÇBBHòù]€éõ\›X⁄[ãÇBJH\»Sù]€ë[[Y[ùÇBZYà
-[\‹ùù]€äH¬ÇBBZ[\‹ùù]€ãô\ÿXõYHùYBÇBBZ[\‹ùù]€ãú›[Kò‹‹’^HÇBBB\Y[ôŒàLMú¬ÇBBBXõ‹ô\éà\€€YôÿòJçMKçMKçMKåJN¬ÇBBBXõ‹ô\ã\òY]\ŒàLú¬ÇBBBXòX⁄Ÿ‹õ›[ôàôÿòJçMKçMKçMKåJN¬ÇBBBX€€‹éàôÿòJçMKçMKçMKå N¬ÇBBBYõ€ù\⁄^ôNàM¬ÇBBBYõ€ù]ŸZY⁄àL¬ÇBBBX›\ú€‹éàõ›X[›ŸY¬ÇBBB]ò[ú⁄][€éà[åú»X\ŸN¬ÇBBXÇB_BÇ_H[ŸH¬ÇB\õ⁄ôX›Àôõ‹ëXX⁄
+	const modal = createProjectSelectionModal(
+		projects,
+		async (selectedProject) => {
+			modal.remove()
 
-õ⁄ôX›
-HOà¬ÇBBX€€ú›‹[€àHÿ›[Y[ùò‹ôX]Q[[Y[ù
-õ‹[€àäBÇBB[‹[€ãùò[YHHõ⁄ôX›öYÇBB[‹[€ãù^€€ù[ùHõ⁄ôX›õò[YBÇBB[‹[€ãô]\Ÿ]ò€€ùZ[ô\ïY»Hõ⁄ôX›ò€€ùZ[ô\ïY¬ÇBB\Ÿ[X›ò\[ô⁄[
-‹[€äBÇB_JBÇ_BüB
+			try {
+				const importResponse = await browser.runtime.sendMessage({
+					type: MESSAGE_TYPES.BATCH_IMPORT_ALL,
+					selectedProject: selectedProject,
+				})
+				if (importResponse?.success) {
+					await trackEvent(POSTHOG_EVENT_KEY.TWITTER_IMPORT_STARTED, {
+						source: `${POSTHOG_EVENT_KEY.SOURCE}_content_script`,
+						project_selected: true,
+					})
+				}
+			} catch (error) {
+				console.error("Error importing all bookmarks:", error)
+			}
+		},
+		() => {
+			modal.remove()
+		},
+	)
+
+	document.body.appendChild(modal)
+}
+
+/**
+ * Shows the one-time onboarding toast with progress bar
+ */
+async function showOnboardingToast() {
+	await loadSpaceGroteskFonts()
+
+	// Remove any existing toast
+	const existingToast = document.getElementById(
+		ELEMENT_IDS.TWITTER_ONBOARDING_TOAST,
+	)
+	if (existingToast) {
+		existingToast.remove()
+	}
+
+	const duration = UI_CONFIG.ONBOARDING_TOAST_DURATION
+
+	// Create toast container
+	const toast = document.createElement("div")
+	toast.id = ELEMENT_IDS.TWITTER_ONBOARDING_TOAST
+	toast.style.cssText = `
+		position: fixed;
+		bottom: 20px;
+		right: 20px;
+		z-index: 2147483647;
+		background: #ffffff;
+		border-radius: 12px;
+		padding: 16px;
+		display: flex;
+		flex-direction: column;
+		gap: 12px;
+		font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+		font-size: 14px;
+		color: #374151;
+		min-width: 320px;
+		max-width: 380px;
+		box-shadow: 0 4px 24px 0 rgba(0,0,0,0.18), 0 1.5px 6px 0 rgba(0,0,0,0.12);
+		animation: smSlideInUp 0.3s ease-out;
+		overflow: hidden;
+	`
+
+	// Add keyframe animations if not already present
+	if (!document.getElementById("supermemory-onboarding-toast-styles")) {
+		const style = document.createElement("style")
+		style.id = "supermemory-onboarding-toast-styles"
+		style.textContent = `
+			@keyframes smSlideInUp {
+				from { transform: translateY(100%); opacity: 0; }
+				to { transform: translateY(0); opacity: 1; }
+			}
+			@keyframes smFadeOut {
+				from { transform: translateY(0); opacity: 1; }
+				to { transform: translateY(100%); opacity: 0; }
+			}
+			@keyframes smProgressGrow {
+				from { transform: scaleX(0); }
+				to { transform: scaleX(1); }
+			}
+			@keyframes smPulse {
+				0%, 100% { opacity: 1; }
+				50% { opacity: 0.4; }
+			}
+		`
+		document.head.appendChild(style)
+	}
+
+	// Header with icon, text and close button
+	const header = document.createElement("div")
+	header.style.cssText =
+		"display: flex; align-items: flex-start; gap: 12px; position: relative;"
+
+	const iconUrl = browser.runtime.getURL("/new_logo.png")
+	const icon = document.createElement("img")
+	icon.src = iconUrl
+	icon.alt = "Supermemory"
+	icon.style.cssText =
+		"width: 24px; height: 24px; border-radius: 4px; flex-shrink: 0; margin-top: 2px;"
+
+	const textContainer = document.createElement("div")
+	textContainer.style.cssText =
+		"display: flex; flex-direction: column; gap: 4px; flex: 1;"
+
+	const title = document.createElement("span")
+	title.style.cssText = "font-weight: 600; font-size: 14px; color: #111827;"
+	title.textContent = "Import X/Twitter Bookmarks"
+
+	const description = document.createElement("span")
+	description.style.cssText =
+		"font-size: 13px; color: #6b7280; line-height: 1.4;"
+	description.textContent =
+		"You can import all your Twitter bookmarks to Supermemory with one click."
+
+	textContainer.appendChild(title)
+	textContainer.appendChild(description)
+
+	// Close button
+	const closeButton = document.createElement("button")
+	closeButton.setAttribute("aria-label", "Close onboarding toast")
+	closeButton.style.cssText = `
+		position: absolute;
+		top: 0;
+		right: 0;
+		background: transparent;
+		border: none;
+		cursor: pointer;
+		padding: 4px;
+		color: #9ca3af;
+		display: flex;
+		align-items: center;
+		justify-content: center;
+		border-radius: 4px;
+		transition: background-color 0.2s;
+	`
+	closeButton.innerHTML = `
+		<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+			<line x1="18" y1="6" x2="6" y2="18"></line>
+			<line x1="6" y1="6" x2="18" y2="18"></line>
+		</svg>
+	`
+	closeButton.addEventListener("mouseenter", () => {
+		closeButton.style.backgroundColor = "#f3f4f6"
+	})
+	closeButton.addEventListener("mouseleave", () => {
+		closeButton.style.backgroundColor = "transparent"
+	})
+	closeButton.addEventListener("click", () => {
+		dismissToast(toast)
+	})
+
+	header.appendChild(icon)
+	header.appendChild(textContainer)
+	header.appendChild(closeButton)
+
+	// Action buttons
+	const buttonsContainer = document.createElement("div")
+	buttonsContainer.style.cssText = "display: flex; gap: 8px; margin-top: 4px;"
+
+	const importButton = document.createElement("button")
+	importButton.style.cssText = `
+		padding: 8px 16px;
+		border: none;
+		border-radius: 8px;
+		background: linear-gradient(182.37deg, #0ff0d2 -91.53%, #5bd3fb -67.8%, #1e0ff0 95.17%);
+		color: white;
+		font-size: 13px;
+		font-weight: 500;
+		cursor: pointer;
+		transition: opacity 0.2s;
+		font-family: inherit;
+	`
+	importButton.textContent = "Import now"
+	importButton.addEventListener("mouseenter", () => {
+		importButton.style.opacity = "0.9"
+	})
+	importButton.addEventListener("mouseleave", () => {
+		importButton.style.opacity = "1"
+	})
+	importButton.addEventListener("click", async () => {
+		dismissToast(toast)
+		await openImportModal()
+	})
+
+	const learnMoreButton = document.createElement("button")
+	learnMoreButton.style.cssText = `
+		padding: 8px 16px;
+		border: 1px solid #e5e7eb;
+		border-radius: 8px;
+		background: transparent;
+		color: #374151;
+		font-size: 13px;
+		font-weight: 500;
+		cursor: pointer;
+		transition: background-color 0.2s;
+		font-family: inherit;
+	`
+	learnMoreButton.textContent = "Learn more"
+	learnMoreButton.addEventListener("mouseenter", () => {
+		learnMoreButton.style.backgroundColor = "#f9fafb"
+	})
+	learnMoreButton.addEventListener("mouseleave", () => {
+		learnMoreButton.style.backgroundColor = "transparent"
+	})
+	learnMoreButton.addEventListener("click", () => {
+		window.open("https://docs.supermemory.ai/connectors/twitter", "_blank")
+	})
+
+	buttonsContainer.appendChild(importButton)
+	buttonsContainer.appendChild(learnMoreButton)
+
+	// Progress bar container
+	const progressBarContainer = document.createElement("div")
+	progressBarContainer.setAttribute("role", "progressbar")
+	progressBarContainer.setAttribute("aria-valuemin", "0")
+	progressBarContainer.setAttribute("aria-valuemax", "100")
+	progressBarContainer.setAttribute("aria-valuenow", "0")
+	progressBarContainer.setAttribute(
+		"aria-label",
+		"Onboarding toast auto-dismiss progress",
+	)
+	progressBarContainer.style.cssText = `
+		position: absolute;
+		bottom: 0;
+		left: 0;
+		right: 0;
+		height: 3px;
+		background: #e5e7eb;
+	`
+
+	const progressBar = document.createElement("div")
+	progressBar.style.cssText = `
+		height: 100%;
+		background: linear-gradient(90deg, #0ff0d2, #5bd3fb, #1e0ff0);
+		transform-origin: left;
+		animation: smProgressGrow ${duration}ms linear forwards;
+	`
+
+	// Update progress bar ARIA value as animation progresses
+	const startTime = Date.now()
+	const updateProgress = () => {
+		const elapsed = Date.now() - startTime
+		const progress = Math.min(100, Math.round((elapsed / duration) * 100))
+		progressBarContainer.setAttribute("aria-valuenow", String(progress))
+		if (progress < 100) {
+			requestAnimationFrame(updateProgress)
+		}
+	}
+	requestAnimationFrame(updateProgress)
+
+	progressBarContainer.appendChild(progressBar)
+
+	// Assemble toast
+	toast.appendChild(header)
+	toast.appendChild(buttonsContainer)
+	toast.appendChild(progressBarContainer)
+
+	document.body.appendChild(toast)
+
+	// Auto-dismiss after duration
+	setTimeout(() => {
+		if (document.body.contains(toast)) {
+			dismissToast(toast)
+		}
+	}, duration)
+}
+
+/**
+ * Dismiss the toast with animation
+ */
+function dismissToast(toast: HTMLElement) {
+	toast.style.animation = "smFadeOut 0.3s ease-out forwards"
+	setTimeout(() => {
+		if (document.body.contains(toast)) {
+			toast.remove()
+		}
+	}, 300)
+}
+
+/**
+ * Remove all Twitter-specific injected UI
+ */
+function removeAllTwitterUI() {
+	// Remove import button (legacy)
+	if (DOMUtils.elementExists(ELEMENT_IDS.TWITTER_IMPORT_BUTTON)) {
+		DOMUtils.removeElement(ELEMENT_IDS.TWITTER_IMPORT_BUTTON)
+	}
+	// Remove onboarding toast
+	if (DOMUtils.elementExists(ELEMENT_IDS.TWITTER_ONBOARDING_TOAST)) {
+		DOMUtils.removeElement(ELEMENT_IDS.TWITTER_ONBOARDING_TOAST)
+	}
+	// Remove import progress toast
+	if (DOMUtils.elementExists(ELEMENT_IDS.TWITTER_IMPORT_PROGRESS_TOAST)) {
+		DOMUtils.removeElement(ELEMENT_IDS.TWITTER_IMPORT_PROGRESS_TOAST)
+	}
+	// Remove any folder buttons
+	document.querySelectorAll("[data-supermemory-button]").forEach((button) => {
+		button.remove()
+	})
+}
+
+/**
+ * Shows or updates the import progress toast in the bottom-right
+ */
+let importToastDismissTimer: ReturnType<typeof setTimeout> | null = null
+
+function showOrUpdateImportProgressToast(
+	message: string,
+	status: "progress" | "success" | "error" = "progress",
+) {
+	if (importToastDismissTimer) {
+		clearTimeout(importToastDismissTimer)
+		importToastDismissTimer = null
+	}
+
+	let toast = document.getElementById(ELEMENT_IDS.TWITTER_IMPORT_PROGRESS_TOAST)
+
+	if (!toast) {
+		// Ensure animation styles are available
+		if (!document.getElementById("supermemory-onboarding-toast-styles")) {
+			const style = document.createElement("style")
+			style.id = "supermemory-onboarding-toast-styles"
+			style.textContent = `
+				@keyframes smSlideInUp {
+					from { transform: translateY(100%); opacity: 0; }
+					to { transform: translateY(0); opacity: 1; }
+				}
+				@keyframes smFadeOut {
+					from { transform: translateY(0); opacity: 1; }
+					to { transform: translateY(100%); opacity: 0; }
+				}
+				@keyframes smPulse {
+					0%, 100% { opacity: 1; }
+					50% { opacity: 0.4; }
+				}
+			`
+			document.head.appendChild(style)
+		}
+
+		// Create new toast
+		toast = document.createElement("div")
+		toast.id = ELEMENT_IDS.TWITTER_IMPORT_PROGRESS_TOAST
+		toast.style.cssText = `
+			position: fixed;
+			bottom: 20px;
+			right: 20px;
+			z-index: 2147483647;
+			background: #ffffff;
+			border-radius: 12px;
+			padding: 14px 16px;
+			display: flex;
+			align-items: center;
+			gap: 12px;
+			font-family: 'Space Grotesk', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+			font-size: 14px;
+			color: #374151;
+			min-width: 280px;
+			max-width: 360px;
+			box-shadow: 0 4px 24px 0 rgba(0,0,0,0.18), 0 1.5px 6px 0 rgba(0,0,0,0.12);
+			animation: smSlideInUp 0.3s ease-out;
+		`
+
+		const iconUrl = browser.runtime.getURL("/new_logo.png")
+		const icon = document.createElement("img")
+		icon.src = iconUrl
+		icon.alt = "Supermemory"
+		icon.id = "sm-import-progress-icon"
+		icon.style.cssText =
+			"width: 20px; height: 20px; border-radius: 4px; flex-shrink: 0; animation: smPulse 1.5s ease-in-out infinite;"
+
+		const textSpan = document.createElement("span")
+		textSpan.id = "sm-import-progress-text"
+		textSpan.style.cssText = "font-weight: 500; flex: 1;"
+		textSpan.textContent = message
+
+		toast.appendChild(icon)
+		toast.appendChild(textSpan)
+		document.body.appendChild(toast)
+	} else {
+		// Update existing toast
+		const textSpan = toast.querySelector(
+			"#sm-import-progress-text",
+		) as HTMLSpanElement
+		if (textSpan) {
+			textSpan.textContent = message
+		}
+	}
+
+	const icon = toast.querySelector(
+		"#sm-import-progress-icon",
+	) as HTMLImageElement
+	const textSpan = toast.querySelector(
+		"#sm-import-progress-text",
+	) as HTMLSpanElement
+
+	if (status === "progress") {
+		if (icon) {
+			icon.style.animation = "smPulse 1.5s ease-in-out infinite"
+			icon.style.opacity = "1"
+		}
+		if (textSpan) textSpan.style.color = "#374151"
+	} else {
+		if (icon) {
+			icon.style.animation = "none"
+			icon.style.opacity = "1"
+		}
+		if (textSpan) {
+			textSpan.style.color = status === "success" ? "#059669" : "#dc2626"
+		}
+
+		importToastDismissTimer = setTimeout(() => {
+			const existingToast = document.getElementById(
+				ELEMENT_IDS.TWITTER_IMPORT_PROGRESS_TOAST,
+			)
+			if (existingToast) {
+				dismissToast(existingToast)
+			}
+			importToastDismissTimer = null
+		}, 4000)
+	}
+}
+
+export function updateTwitterImportUI(message: {
+	type: string
+	importedMessage?: string
+	totalImported?: number
+}) {
+	if (message.type === MESSAGE_TYPES.IMPORT_UPDATE && message.importedMessage) {
+		showOrUpdateImportProgressToast(message.importedMessage)
+	}
+
+	if (message.type === MESSAGE_TYPES.IMPORT_DONE) {
+		showOrUpdateImportProgressToast(
+			`‚úì Imported ${message.totalImported} tweets!`,
+			"success",
+		)
+	}
+
+	if (message.type === MESSAGE_TYPES.IMPORT_ERROR && message.importedMessage) {
+		showOrUpdateImportProgressToast(message.importedMessage, "error")
+	}
+}
+
+export async function handleTwitterNavigation() {
+	if (!DOMUtils.isOnDomain(DOMAINS.TWITTER)) {
+		return
+	}
+
+	if (window.location.pathname === "/i/bookmarks") {
+		addTwitterImportButtonForFolders()
+		await handleBookmarksPageLoad()
+	} else {
+		removeAllTwitterUI()
+	}
+}
+
+/**
+ * Adds import buttons to bookmark folders
+ */
+function addTwitterImportButtonForFolders() {
+	if (window.location.pathname !== "/i/bookmarks") {
+		return
+	}
+
+	const targetElements = document.querySelectorAll(
+		".css-175oi2r.r-1wtj0ep.r-16x9es5.r-1mmae3n.r-o7ynqc.r-6416eg.r-1ny4l3l.r-1loqt21",
+	)
+
+	targetElements.forEach((element) => {
+		addButtonToElement(element as HTMLElement)
+	})
+}
+
+/**
+ * Adds an import button to a bookmark folder element
+ */
+function addButtonToElement(element: HTMLElement) {
+	if (element.querySelector("[data-supermemory-button]")) {
+		return
+	}
+
+	loadSpaceGroteskFonts()
+
+	const button = createSaveTweetElement(async () => {
+		const url = element.getAttribute("href")
+		const bookmarkCollectionId = url?.split("/").pop()
+		if (bookmarkCollectionId) {
+			await showFolderProjectSelectionModal(bookmarkCollectionId)
+		}
+	})
+
+	button.setAttribute("data-supermemory-button", "true")
+
+	element.appendChild(button)
+	element.style.flexDirection = "row"
+	element.style.alignItems = "center"
+	element.style.justifyContent = "center"
+	element.style.gap = "10px"
+	element.style.padding = "10px"
+}
+
+/**
+ * Shows the project selection modal for folder imports
+ */
+async function showFolderProjectSelectionModal(bookmarkCollectionId: string) {
+	await loadSpaceGroteskFonts()
+
+	const modal = createProjectSelectionModal(
+		[],
+		async (selectedProject) => {
+			modal.remove()
+
+			try {
+				await browser.runtime.sendMessage({
+					type: MESSAGE_TYPES.BATCH_IMPORT_ALL,
+					isFolderImport: true,
+					bookmarkCollectionId: bookmarkCollectionId,
+					selectedProject: selectedProject,
+				})
+			} catch (error) {
+				console.error("Error importing bookmarks:", error)
+			}
+		},
+		() => {
+			modal.remove()
+		},
+	)
+
+	document.body.appendChild(modal)
+
+	try {
+		const response = await browser.runtime.sendMessage({
+			action: MESSAGE_TYPES.FETCH_PROJECTS,
+		})
+
+		if (response.success && response.data) {
+			const projects = response.data
+			updateModalWithProjects(modal, projects)
+		} else {
+			console.error("Failed to fetch projects:", response.error)
+			updateModalWithProjects(modal, [])
+		}
+	} catch (error) {
+		console.error("Error fetching projects:", error)
+		updateModalWithProjects(modal, [])
+	}
+}
+
+/**
+ * Updates the modal with fetched projects
+ */
+function updateModalWithProjects(
+	modal: HTMLElement,
+	projects: Array<{ id: string; name: string; containerTag: string }>,
+) {
+	const select = modal.querySelector("#project-select") as HTMLSelectElement
+	if (!select) return
+
+	while (select.children.length > 1) {
+		select.removeChild(select.children[1])
+	}
+
+	if (projects.length === 0) {
+		const noProjectsOption = document.createElement("option")
+		noProjectsOption.value = ""
+		noProjectsOption.textContent = "No projects available"
+		noProjectsOption.disabled = true
+		select.appendChild(noProjectsOption)
+
+		const importButton = modal.querySelector(
+			"button:last-child",
+		) as HTMLButtonElement
+		if (importButton) {
+			importButton.disabled = true
+			importButton.style.cssText = `
+				padding: 10px 16px;
+				border: 1px solid rgba(255, 255, 255, 0.1);
+				border-radius: 12px;
+				background: rgba(255, 255, 255, 0.05);
+				color: rgba(255, 255, 255, 0.3);
+				font-size: 14px;
+				font-weight: 500;
+				cursor: not-allowed;
+				transition: all 0.2s ease;
+			`
+		}
+	} else {
+		projects.forEach((project) => {
+			const option = document.createElement("option")
+			option.value = project.id
+			option.textContent = project.name
+			option.dataset.containerTag = project.containerTag
+			select.appendChild(option)
+		})
+	}
+}

--- a/apps/browser-extension/utils/constants.ts
+++ b/apps/browser-extension/utils/constants.ts
@@ -93,6 +93,7 @@ export const MESSAGE_TYPES = {
 	BATCH_IMPORT_ALL: "sm-batch-import-all",
 	IMPORT_UPDATE: "sm-import-update",
 	IMPORT_DONE: "sm-import-done",
+	IMPORT_ERROR: "sm-import-error",
 	GET_RELATED_MEMORIES: "sm-get-related-memories",
 	CAPTURE_PROMPT: "sm-capture-prompt",
 	FETCH_PROJECTS: "sm-fetch-projects",

--- a/apps/browser-extension/utils/twitter-import-controller.test.ts
+++ b/apps/browser-extension/utils/twitter-import-controller.test.ts
@@ -2,13 +2,7 @@ import { describe, expect, mock, test } from "bun:test"
 import { createTwitterImportController } from "./twitter-import-controller"
 
 function deferred() {
-	let resolve!: () => void
-	let reject!: (error: Error) => void
-	const promise = new Promise<void>((onResolve, onReject) => {
-		resolve = onResolve
-		reject = onReject
-	})
-	return { promise, reject, resolve }
+	return Promise.withResolvers<void>()
 }
 
 describe("Twitter import controller", () => {

--- a/apps/browser-extension/utils/twitter-import-controller.test.ts
+++ b/apps/browser-extension/utils/twitter-import-controller.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, mock, test } from "bun:test"
+import { createTwitterImportController } from "./twitter-import-controller"
+
+function deferred() {
+	let resolve!: () => void
+	let reject!: (error: Error) => void
+	const promise = new Promise<void>((onResolve, onReject) => {
+		resolve = onResolve
+		reject = onReject
+	})
+	return { promise, reject, resolve }
+}
+
+describe("Twitter import controller", () => {
+	test("allows only one import until the active run completes", async () => {
+		const firstRun = deferred()
+		const secondRun = deferred()
+		const startImport = mock()
+			.mockImplementationOnce(() => firstRun.promise)
+			.mockImplementationOnce(() => secondRun.promise)
+		const createImporter = mock(() => ({ startImport }))
+		const controller = createTwitterImportController(createImporter)
+
+		const first = controller.start({ source: "first" })
+		const duplicate = controller.start({ source: "duplicate" })
+
+		expect(first).toBe(firstRun.promise)
+		expect(duplicate).toBeNull()
+		expect(createImporter).toHaveBeenCalledTimes(1)
+		expect(startImport).toHaveBeenCalledTimes(1)
+
+		firstRun.resolve()
+		await first
+
+		const second = controller.start({ source: "second" })
+		expect(second).toBe(secondRun.promise)
+		expect(createImporter).toHaveBeenCalledTimes(2)
+	})
+
+	test("releases the lock when an import rejects", async () => {
+		const failedRun = deferred()
+		const recoveredRun = deferred()
+		const startImport = mock()
+			.mockImplementationOnce(() => failedRun.promise)
+			.mockImplementationOnce(() => recoveredRun.promise)
+		const controller = createTwitterImportController(() => ({ startImport }))
+
+		const failed = controller.start("failed")
+		failedRun.reject(new Error("network failed"))
+		await expect(failed).rejects.toThrow("network failed")
+
+		expect(controller.start("recovered")).toBe(recoveredRun.promise)
+		expect(startImport).toHaveBeenCalledTimes(2)
+	})
+
+	test("releases the lock when importer startup throws", async () => {
+		const recoveredRun = deferred()
+		const createImporter = mock()
+			.mockImplementationOnce(() => {
+				throw new Error("startup failed")
+			})
+			.mockImplementationOnce(() => ({
+				startImport: () => recoveredRun.promise,
+			}))
+		const controller = createTwitterImportController(createImporter)
+
+		await expect(controller.start("failed")).rejects.toThrow("startup failed")
+
+		expect(controller.start("recovered")).toBe(recoveredRun.promise)
+		expect(createImporter).toHaveBeenCalledTimes(2)
+	})
+})

--- a/apps/browser-extension/utils/twitter-import-controller.ts
+++ b/apps/browser-extension/utils/twitter-import-controller.ts
@@ -11,12 +11,13 @@ export function createTwitterImportController<Config>(
 		start(config: Config): Promise<void> | null {
 			if (running) return null
 
-			let task: Promise<void>
-			try {
-				task = Promise.resolve(createImporter(config).startImport())
-			} catch (error) {
-				task = Promise.reject(error)
-			}
+			const task = (() => {
+				try {
+					return Promise.resolve(createImporter(config).startImport())
+				} catch (error) {
+					return Promise.reject(error)
+				}
+			})()
 
 			running = task
 			void task

--- a/apps/browser-extension/utils/twitter-import-controller.ts
+++ b/apps/browser-extension/utils/twitter-import-controller.ts
@@ -1,0 +1,31 @@
+type TwitterImportRunner = {
+	startImport: () => Promise<void>
+}
+
+export function createTwitterImportController<Config>(
+	createImporter: (config: Config) => TwitterImportRunner,
+) {
+	let running: Promise<void> | null = null
+
+	return {
+		start(config: Config): Promise<void> | null {
+			if (running) return null
+
+			let task: Promise<void>
+			try {
+				task = Promise.resolve(createImporter(config).startImport())
+			} catch (error) {
+				task = Promise.reject(error)
+			}
+
+			running = task
+			void task
+				.finally(() => {
+					if (running === task) running = null
+				})
+				.catch(() => {})
+
+			return task
+		},
+	}
+}

--- a/apps/browser-extension/utils/twitter-import-notifications.test.ts
+++ b/apps/browser-extension/utils/twitter-import-notifications.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, mock, test } from "bun:test"
+import { MESSAGE_TYPES } from "./constants"
+import { createTwitterImportNotifications } from "./twitter-import-notifications"
+
+describe("Twitter import notifications", () => {
+	test("keeps progress, errors, and completion on the initiating tab", async () => {
+		let activeTabId = 7
+		const sendMessage = mock(async () => {})
+		const notifications = createTwitterImportNotifications(
+			activeTabId,
+			sendMessage,
+		)
+
+		activeTabId = 42
+		await notifications.onProgress("Imported 10 bookmarks")
+		await notifications.onError(new Error("rate limited"))
+		await notifications.onComplete(10)
+
+		expect(activeTabId).toBe(42)
+		expect(sendMessage.mock.calls).toEqual([
+			[
+				7,
+				{
+					type: MESSAGE_TYPES.IMPORT_UPDATE,
+					importedMessage: "Imported 10 bookmarks",
+				},
+			],
+			[
+				7,
+				{
+					type: MESSAGE_TYPES.IMPORT_UPDATE,
+					importedMessage: "Error: rate limited",
+				},
+			],
+			[7, { type: MESSAGE_TYPES.IMPORT_DONE, totalImported: 10 }],
+		])
+	})
+
+	test("does not let tab closure interrupt import callbacks", async () => {
+		const sendMessage = mock(async () => {
+			throw new Error("Receiving end does not exist")
+		})
+		const notifications = createTwitterImportNotifications(7, sendMessage)
+
+		await notifications.onProgress("Retrying")
+		await notifications.onError(new Error("failed"))
+		await notifications.onComplete(0)
+
+		expect(sendMessage).toHaveBeenCalledTimes(3)
+	})
+
+	test("accepts tab id zero", async () => {
+		const sendMessage = mock(async () => {})
+		const notifications = createTwitterImportNotifications(0, sendMessage)
+
+		await notifications.onProgress("Starting")
+
+		expect(sendMessage).toHaveBeenCalledWith(0, {
+			type: MESSAGE_TYPES.IMPORT_UPDATE,
+			importedMessage: "Starting",
+		})
+	})
+
+	test("skips notifications when the request has no sender tab", async () => {
+		const sendMessage = mock(async () => {})
+		const notifications = createTwitterImportNotifications(
+			undefined,
+			sendMessage,
+		)
+
+		await notifications.onProgress("Starting")
+		await notifications.onComplete(0)
+
+		expect(sendMessage).not.toHaveBeenCalled()
+	})
+})
+

--- a/apps/browser-extension/utils/twitter-import-notifications.test.ts
+++ b/apps/browser-extension/utils/twitter-import-notifications.test.ts
@@ -74,4 +74,3 @@ describe("Twitter import notifications", () => {
 		expect(sendMessage).not.toHaveBeenCalled()
 	})
 })
-

--- a/apps/browser-extension/utils/twitter-import-notifications.test.ts
+++ b/apps/browser-extension/utils/twitter-import-notifications.test.ts
@@ -1,8 +1,24 @@
 import { describe, expect, mock, test } from "bun:test"
 import { MESSAGE_TYPES } from "./constants"
-import { createTwitterImportNotifications } from "./twitter-import-notifications"
+import {
+	createTwitterImportNotifications,
+	isTwitterImportNotification,
+} from "./twitter-import-notifications"
 
 describe("Twitter import notifications", () => {
+	test("recognizes every notification routed to the content script", () => {
+		for (const type of [
+			MESSAGE_TYPES.IMPORT_UPDATE,
+			MESSAGE_TYPES.IMPORT_DONE,
+			MESSAGE_TYPES.IMPORT_ERROR,
+		]) {
+			expect(isTwitterImportNotification({ type })).toBe(true)
+		}
+		expect(
+			isTwitterImportNotification({ type: MESSAGE_TYPES.BATCH_IMPORT_ALL }),
+		).toBe(false)
+	})
+
 	test("keeps progress, errors, and completion on the initiating tab", async () => {
 		let activeTabId = 7
 		const sendMessage = mock(async () => {})
@@ -28,7 +44,7 @@ describe("Twitter import notifications", () => {
 			[
 				7,
 				{
-					type: MESSAGE_TYPES.IMPORT_UPDATE,
+					type: MESSAGE_TYPES.IMPORT_ERROR,
 					importedMessage: "Error: rate limited",
 				},
 			],

--- a/apps/browser-extension/utils/twitter-import-notifications.ts
+++ b/apps/browser-extension/utils/twitter-import-notifications.ts
@@ -47,4 +47,3 @@ export function createTwitterImportNotifications(
 			}),
 	}
 }
-

--- a/apps/browser-extension/utils/twitter-import-notifications.ts
+++ b/apps/browser-extension/utils/twitter-import-notifications.ts
@@ -1,0 +1,50 @@
+import { MESSAGE_TYPES } from "./constants"
+
+type TwitterImportNotification =
+	| {
+			type: typeof MESSAGE_TYPES.IMPORT_UPDATE
+			importedMessage: string
+	  }
+	| {
+			type: typeof MESSAGE_TYPES.IMPORT_DONE
+			totalImported: number
+	  }
+
+type SendTabMessage = (
+	tabId: number,
+	message: TwitterImportNotification,
+) => Promise<unknown>
+
+export function createTwitterImportNotifications(
+	tabId: number | undefined,
+	sendMessage: SendTabMessage,
+) {
+	const deliver = async (message: TwitterImportNotification): Promise<void> => {
+		if (tabId === undefined) return
+		try {
+			await sendMessage(tabId, message)
+		} catch {
+			// The initiating tab can be closed or navigated while the import keeps
+			// running. Notification delivery must not cancel the import itself.
+		}
+	}
+
+	return {
+		onProgress: (message: string) =>
+			deliver({
+				type: MESSAGE_TYPES.IMPORT_UPDATE,
+				importedMessage: message,
+			}),
+		onComplete: (totalImported: number) =>
+			deliver({
+				type: MESSAGE_TYPES.IMPORT_DONE,
+				totalImported,
+			}),
+		onError: (error: Error) =>
+			deliver({
+				type: MESSAGE_TYPES.IMPORT_UPDATE,
+				importedMessage: `Error: ${error.message}`,
+			}),
+	}
+}
+

--- a/apps/browser-extension/utils/twitter-import-notifications.ts
+++ b/apps/browser-extension/utils/twitter-import-notifications.ts
@@ -9,11 +9,25 @@ type TwitterImportNotification =
 			type: typeof MESSAGE_TYPES.IMPORT_DONE
 			totalImported: number
 	  }
+	| {
+			type: typeof MESSAGE_TYPES.IMPORT_ERROR
+			importedMessage: string
+	  }
 
 type SendTabMessage = (
 	tabId: number,
 	message: TwitterImportNotification,
 ) => Promise<unknown>
+
+const TWITTER_IMPORT_NOTIFICATION_TYPES = new Set<string>([
+	MESSAGE_TYPES.IMPORT_UPDATE,
+	MESSAGE_TYPES.IMPORT_DONE,
+	MESSAGE_TYPES.IMPORT_ERROR,
+])
+
+export function isTwitterImportNotification(message: { type?: string }) {
+	return !!message.type && TWITTER_IMPORT_NOTIFICATION_TYPES.has(message.type)
+}
 
 export function createTwitterImportNotifications(
 	tabId: number | undefined,
@@ -42,7 +56,7 @@ export function createTwitterImportNotifications(
 			}),
 		onError: (error: Error) =>
 			deliver({
-				type: MESSAGE_TYPES.IMPORT_UPDATE,
+				type: MESSAGE_TYPES.IMPORT_ERROR,
 				importedMessage: `Error: ${error.message}`,
 			}),
 	}


### PR DESCRIPTION
## Summary

- keep X bookmark import progress, completion, and errors pinned to the tab that started the import
- enforce one background import at a time so rapid duplicate requests cannot start parallel full imports
- surface duplicate/import failures in a terminal error toast, while keeping tab delivery best-effort so a closed tab cannot interrupt the job
- record the import-started analytics event only when the background worker actually accepts the request

The background worker previously looked up the currently active tab for every callback and created a new `TwitterImporter` for every message. Switching tabs could route status to an unrelated page, while rapid requests bypassed the importer's instance-local guard and started overlapping imports.

## Validation

- `bun test utils` in `apps/browser-extension` — 20 passed
- Chrome MV3 production build — passed
- Firefox MV2 production build — passed
- Biome and `git diff --check` — passed
- extension typecheck reaches one pre-existing nullability error in unchanged `utils/ui-components.ts:611`; changed files have zero diagnostics
- independent final review — no blocking findings

Duplicate audit covered all 99 open PRs and 38 open issues. #1490 and #1491 are adjacent X-import work, and #1422 touches an unrelated background path; none solve or overlap this lifecycle behavior.