### PR TITLE
fix(tools): enforce configured container scope

### DIFF
--- a/packages/tools/src/ai-sdk.ts
+++ b/packages/tools/src/ai-sdk.ts
@@ -6,6 +6,7 @@ import {
 	PARAMETER_DESCRIPTIONS,
 	TOOL_DESCRIPTIONS,
 	getContainerTags,
+	resolveConfiguredContainerTag,
 } from "./tools-shared"
 import { forgetMemoryRequest } from "./shared/forget-memory"
 import type { SupermemoryToolsConfig } from "./types"
@@ -141,7 +142,7 @@ export const getProfileTool = (
 		}),
 		execute: async ({ containerTag, query }) => {
 			try {
-				const tag = containerTag || containerTags[0]
+				const tag = resolveConfiguredContainerTag(containerTags, containerTag)
 
 				const response = await client.profile({
 					containerTag: tag,
@@ -196,7 +197,7 @@ export const documentListTool = (
 		}),
 		execute: async ({ containerTag, limit, page }) => {
 			try {
-				const tag = containerTag || containerTags[0]
+				const tag = resolveConfiguredContainerTag(containerTags, containerTag)
 
 				const response = await client.documents.list({
 					containerTags: [tag],
@@ -327,12 +328,12 @@ export const memoryForgetTool = (
 					}
 				}
 
-				const tag = containerTag || containerTags[0]
+				const tag = resolveConfiguredContainerTag(containerTags, containerTag)
 
 				await forgetMemoryRequest(
 					apiKey,
 					{
-						containerTag: tag as string,
+						containerTag: tag,
 						...(memoryId && { id: memoryId }),
 						...(memoryContent && { content: memoryContent }),
 						...(reason && { reason }),

--- a/packages/tools/src/openai/tools.ts
+++ b/packages/tools/src/openai/tools.ts
@@ -5,6 +5,7 @@ import {
 	PARAMETER_DESCRIPTIONS,
 	TOOL_DESCRIPTIONS,
 	getContainerTags,
+	resolveConfiguredContainerTag,
 } from "../tools-shared"
 import { forgetMemoryRequest } from "../shared/forget-memory"
 import type { SupermemoryToolsConfig } from "../types"
@@ -323,7 +324,7 @@ export function createGetProfileFunction(
 		query?: string
 	}): Promise<ProfileResult> {
 		try {
-			const tag = containerTag || containerTags[0]
+			const tag = resolveConfiguredContainerTag(containerTags, containerTag)
 
 			const response = await client.profile({
 				containerTag: tag,
@@ -363,7 +364,7 @@ export function createDocumentListFunction(
 		page?: number
 	}): Promise<DocumentListResult> {
 		try {
-			const tag = containerTag || containerTags[0]
+			const tag = resolveConfiguredContainerTag(containerTags, containerTag)
 
 			const response = await client.documents.list({
 				containerTags: [tag],
@@ -485,12 +486,12 @@ export function createMemoryForgetFunction(
 				}
 			}
 
-			const tag = containerTag || containerTags[0]
+			const tag = resolveConfiguredContainerTag(containerTags, containerTag)
 
 			await forgetMemoryRequest(
 				apiKey,
 				{
-					containerTag: tag as string,
+					containerTag: tag,
 					...(memoryId && { id: memoryId }),
 					...(memoryContent && { content: memoryContent }),
 					...(reason && { reason }),

--- a/packages/tools/src/tool-operations.test.ts
+++ b/packages/tools/src/tool-operations.test.ts
@@ -4,12 +4,14 @@ import { beforeEach, describe, expect, it, vi } from "vitest"
 // executions can be verified deterministically without network access.
 const documentsDelete = vi.fn()
 const documentsList = vi.fn()
+const profileRequest = vi.fn()
 const searchExecute = vi.fn()
 const clientAdd = vi.fn()
 
 vi.mock("supermemory", () => {
 	return {
 		default: class MockSupermemory {
+			profile = profileRequest
 			search = { execute: searchExecute }
 			add = clientAdd
 			documents = {
@@ -40,9 +42,104 @@ beforeEach(() => {
 		memories: [{ id: "doc_1", title: "Doc one" }],
 		pagination: { currentPage: 1, totalItems: 1, totalPages: 1 },
 	})
+	profileRequest.mockReset().mockResolvedValue({
+		profile: { static: [], dynamic: [] },
+		searchResults: { results: [] },
+	})
 	searchExecute.mockReset()
 	clientAdd.mockReset().mockResolvedValue({ id: "doc_new" })
 	vi.unstubAllGlobals()
+})
+
+describe("configured container scope", () => {
+	it("rejects out-of-scope tags across both tool surfaces before I/O", async () => {
+		const config = { containerTags: ["tenant-a"] }
+		const fetchMock = vi.fn()
+		vi.stubGlobal("fetch", fetchMock)
+
+		const results = (await Promise.all([
+			executeTool(aiSdk.getProfileTool(API_KEY, config), {
+				containerTag: "tenant-b",
+			}),
+			openAi.createGetProfileFunction(
+				API_KEY,
+				config,
+			)({
+				containerTag: "tenant-b",
+			}),
+			executeTool(aiSdk.documentListTool(API_KEY, config), {
+				containerTag: "tenant-b",
+			}),
+			openAi.createDocumentListFunction(
+				API_KEY,
+				config,
+			)({
+				containerTag: "tenant-b",
+			}),
+			executeTool(aiSdk.memoryForgetTool(API_KEY, config), {
+				containerTag: "tenant-b",
+				memoryId: "mem_1",
+			}),
+			openAi.createMemoryForgetFunction(
+				API_KEY,
+				config,
+			)({
+				containerTag: "tenant-b",
+				memoryId: "mem_1",
+			}),
+		])) as Array<{ success: boolean; error?: string }>
+
+		expect(results).toHaveLength(6)
+		for (const result of results) {
+			expect(result.success).toBe(false)
+			expect(result.error).toContain("outside the configured scope")
+		}
+		expect(profileRequest).not.toHaveBeenCalled()
+		expect(documentsList).not.toHaveBeenCalled()
+		expect(fetchMock).not.toHaveBeenCalled()
+	})
+
+	it("allows selecting another explicitly configured tag", async () => {
+		const getProfile = openAi.createGetProfileFunction(API_KEY, {
+			containerTags: ["tenant-a", "tenant-b"],
+		})
+
+		const result = await getProfile({ containerTag: "tenant-b" })
+
+		expect(result.success).toBe(true)
+		expect(profileRequest).toHaveBeenCalledWith({
+			containerTag: "tenant-b",
+		})
+	})
+
+	it("does not let model input override implicit or project scopes", async () => {
+		const implicitResult = await openAi.createDocumentListFunction(API_KEY)({
+			containerTag: "tenant-b",
+		})
+		const projectResult = (await executeTool(
+			aiSdk.getProfileTool(API_KEY, { projectId: "alpha" }),
+			{ containerTag: "tenant-b" },
+		)) as { success: boolean; error?: string }
+
+		expect(implicitResult.success).toBe(false)
+		expect(implicitResult.error).toContain("outside the configured scope")
+		expect(projectResult.success).toBe(false)
+		expect(projectResult.error).toContain("outside the configured scope")
+		expect(documentsList).not.toHaveBeenCalled()
+		expect(profileRequest).not.toHaveBeenCalled()
+	})
+
+	it("fails closed when the configured scope is empty", async () => {
+		const result = await openAi.createGetProfileFunction(API_KEY, {
+			containerTags: [],
+		})({})
+
+		expect(result.success).toBe(false)
+		expect(result.error).toContain(
+			"require at least one configured container tag",
+		)
+		expect(profileRequest).not.toHaveBeenCalled()
+	})
 })
 
 describe("documentDelete", () => {

--- a/packages/tools/src/tool-operations.test.ts
+++ b/packages/tools/src/tool-operations.test.ts
@@ -122,10 +122,10 @@ describe("configured container scope", () => {
 		const implicitResult = await openAi.createDocumentListFunction(API_KEY)({
 			containerTag: "tenant-b",
 		})
-		const projectResult = (await executeTool(
+		const projectResult = await executeTool(
 			aiSdk.getProfileTool(API_KEY, { projectId: "alpha" }),
 			{ containerTag: "tenant-b" },
-		)) as { success: boolean; error?: string }
+		)
 
 		expect(implicitResult.success).toBe(false)
 		expect(implicitResult.error).toContain("outside the configured scope")
@@ -151,9 +151,7 @@ describe("configured container scope", () => {
 describe("documentDelete", () => {
 	it("ai-sdk variant passes the document id string to the SDK", async () => {
 		const tool = aiSdk.documentDeleteTool(API_KEY)
-		const result = (await executeTool(tool, { documentId: "doc_123" })) as {
-			success: boolean
-		}
+		const result = await executeTool(tool, { documentId: "doc_123" })
 
 		expect(result.success).toBe(true)
 		expect(documentsDelete).toHaveBeenCalledWith("doc_123")
@@ -244,9 +242,9 @@ describe("memoryForget", () => {
 			containerTags: ["user_2"],
 		})
 
-		const result = (await executeTool(tool, {
+		const result = await executeTool(tool, {
 			memoryContent: "stale fact",
-		})) as { success: boolean }
+		})
 
 		expect(result.success).toBe(true)
 		const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]

--- a/packages/tools/src/tool-operations.test.ts
+++ b/packages/tools/src/tool-operations.test.ts
@@ -30,9 +30,15 @@ import * as openAi from "./openai/tools"
 
 const API_KEY = "sm_test_key"
 
-type ToolWithExecute = { execute: (args: Record<string, unknown>) => unknown }
+type ToolExecutionResult = { success: boolean; error?: string }
+type ToolWithExecute = {
+	execute: (args: Record<string, unknown>) => Promise<ToolExecutionResult>
+}
 
-function executeTool(tool: unknown, args: Record<string, unknown>) {
+function executeTool(
+	tool: unknown,
+	args: Record<string, unknown>,
+): Promise<ToolExecutionResult> {
 	return (tool as ToolWithExecute).execute(args)
 }
 
@@ -57,7 +63,7 @@ describe("configured container scope", () => {
 		const fetchMock = vi.fn()
 		vi.stubGlobal("fetch", fetchMock)
 
-		const results = (await Promise.all([
+		const results: ToolExecutionResult[] = await Promise.all([
 			executeTool(aiSdk.getProfileTool(API_KEY, config), {
 				containerTag: "tenant-b",
 			}),
@@ -87,7 +93,7 @@ describe("configured container scope", () => {
 				containerTag: "tenant-b",
 				memoryId: "mem_1",
 			}),
-		])) as Array<{ success: boolean; error?: string }>
+		])
 
 		expect(results).toHaveLength(6)
 		for (const result of results) {

--- a/packages/tools/src/tools-shared.test.ts
+++ b/packages/tools/src/tools-shared.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest"
-import { deduplicateMemoriesForMode, getContainerTags } from "./tools-shared"
+import {
+	deduplicateMemoriesForMode,
+	getContainerTags,
+	resolveConfiguredContainerTag,
+} from "./tools-shared"
 
 describe("getContainerTags", () => {
 	it("uses the default project when no config is provided", () => {
@@ -24,6 +28,32 @@ describe("getContainerTags", () => {
 				containerTags: ["tag-a"],
 			}),
 		).toThrow("either projectId or containerTags")
+	})
+})
+
+describe("resolveConfiguredContainerTag", () => {
+	it("defaults to the first configured tag", () => {
+		expect(resolveConfiguredContainerTag(["tenant-a", "tenant-b"])).toBe(
+			"tenant-a",
+		)
+	})
+
+	it("allows selection within a multi-tag scope", () => {
+		expect(
+			resolveConfiguredContainerTag(["tenant-a", "tenant-b"], "tenant-b"),
+		).toBe("tenant-b")
+	})
+
+	it("rejects tags outside the configured scope", () => {
+		expect(() =>
+			resolveConfiguredContainerTag(["tenant-a"], "tenant-b"),
+		).toThrow('Container tag "tenant-b" is outside the configured scope')
+	})
+
+	it("rejects an empty configured scope", () => {
+		expect(() => resolveConfiguredContainerTag([])).toThrow(
+			"require at least one configured container tag",
+		)
 	})
 })
 

--- a/packages/tools/src/tools-shared.ts
+++ b/packages/tools/src/tools-shared.ts
@@ -75,6 +75,34 @@ export function getContainerTags(config?: {
 }
 
 /**
+ * Resolves a model-supplied container tag without allowing it to escape the
+ * developer-configured scope.
+ */
+export function resolveConfiguredContainerTag(
+	configuredTags: readonly string[],
+	requestedTag?: string,
+): string {
+	const defaultTag = configuredTags[0]
+	if (defaultTag === undefined) {
+		throw new Error(
+			"Supermemory tools require at least one configured container tag.",
+		)
+	}
+
+	if (requestedTag === undefined) {
+		return defaultTag
+	}
+
+	if (!configuredTags.includes(requestedTag)) {
+		throw new Error(
+			`Container tag "${requestedTag}" is outside the configured scope.`,
+		)
+	}
+
+	return requestedTag
+}
+
+/**
  * Memory item interface representing a single memory with optional metadata
  */
 export interface MemoryItem {


### PR DESCRIPTION
## Summary

- treat configured `containerTags` and `projectId` as a strict allowlist for model-callable operations
- apply the same resolver to AI SDK and OpenAI profile, document-list, and memory-forget tools
- fail closed when the configured scope is empty or a requested tag is outside it
- add no-I/O regressions for all six affected operations

## Why

The affected tools used `containerTag || containerTags[0]`, so a model-supplied tag replaced the developer-configured tenant scope. With a broader API key, that allowed profile/document reads and soft deletion outside the configured container.

A requested tag is now accepted only when it is present in the configured set; omission still selects the first configured tag for compatibility.

## Validation

- focused tests: 30 passed
- full package suite: 98 passed, 30 skipped; the two suite-load failures are pre-existing (missing `SUPERMEMORY_API_KEY` and a broken relative test import)
- production package build passed
- Biome and `git diff --check` passed
- package typecheck remains baseline-red in existing SDK/dependency/example code, with no new helper/test diagnostic

## Coordination

Open PR #1453 adds four more model-callable operations using the old fallback expression. If it lands, those new sites should adopt `resolveConfiguredContainerTag` during rebase; this PR is complete against current `main`.