### PR TITLE
fix(tools): await VoltAgent conversation persistence

### DIFF
--- a/packages/tools/src/voltagent/hooks.test.ts
+++ b/packages/tools/src/voltagent/hooks.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
+import { createSupermemoryHooks } from "./hooks"
+import type { HookEndArgs } from "./types"
+
+const TEST_ARGS: HookEndArgs = {
+	agent: { name: "test-agent" },
+	context: {
+		input: {
+			messages: [{ role: "user", content: "Remember this" }],
+		},
+	},
+	output: "I will remember that.",
+}
+
+const createDeferredFetch = () => {
+	let resolveFetch: ((response: Response) => void) | undefined
+	const fetchPromise = new Promise<Response>((resolve) => {
+		resolveFetch = resolve
+	})
+	const fetchMock = vi.fn(() => fetchPromise)
+
+	return {
+		fetchMock,
+		resolve: (response: Response) => resolveFetch?.(response),
+	}
+}
+
+describe("VoltAgent onEnd", () => {
+	let originalFetch: typeof globalThis.fetch
+
+	beforeEach(() => {
+		originalFetch = globalThis.fetch
+	})
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch
+		vi.restoreAllMocks()
+	})
+
+	it("waits for conversation persistence to finish", async () => {
+		const deferredFetch = createDeferredFetch()
+		globalThis.fetch = deferredFetch.fetchMock as unknown as typeof fetch
+		const hooks = createSupermemoryHooks("test-user", {
+			apiKey: "test-api-key",
+			baseUrl: "https://example.test",
+			customId: "test-conversation",
+		})
+		let settled = false
+
+		const onEndPromise = Promise.resolve(hooks.onEnd?.(TEST_ARGS)).finally(
+			() => {
+				settled = true
+			},
+		)
+
+		expect(deferredFetch.fetchMock).toHaveBeenCalledOnce()
+		await Promise.resolve()
+		expect(settled).toBe(false)
+
+		deferredFetch.resolve(
+			new Response(
+				JSON.stringify({
+					id: "memory-1",
+					conversationId: "test-conversation",
+					status: "queued",
+				}),
+				{ status: 200 },
+			),
+		)
+		await onEndPromise
+
+		expect(settled).toBe(true)
+	})
+
+	it("waits for a failed save, logs it, and resolves without throwing", async () => {
+		const deferredFetch = createDeferredFetch()
+		globalThis.fetch = deferredFetch.fetchMock as unknown as typeof fetch
+		vi.spyOn(console, "log").mockImplementation(() => {})
+		const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {})
+		const hooks = createSupermemoryHooks("test-user", {
+			apiKey: "test-api-key",
+			baseUrl: "https://example.test",
+			customId: "test-conversation",
+			verbose: true,
+		})
+		let settled = false
+
+		const onEndPromise = Promise.resolve(hooks.onEnd?.(TEST_ARGS)).finally(
+			() => {
+				settled = true
+			},
+		)
+
+		expect(deferredFetch.fetchMock).toHaveBeenCalledOnce()
+		await Promise.resolve()
+		expect(settled).toBe(false)
+
+		deferredFetch.resolve(
+			new Response("Server error", {
+				status: 500,
+				statusText: "Internal Server Error",
+			}),
+		)
+		await expect(onEndPromise).resolves.toBeUndefined()
+
+		expect(errorSpy).toHaveBeenCalledWith(
+			"[supermemory] Error saving conversation",
+			expect.stringContaining(
+				"Failed to add conversation: 500 Internal Server Error. Server error",
+			),
+		)
+	})
+})

--- a/packages/tools/src/voltagent/hooks.ts
+++ b/packages/tools/src/voltagent/hooks.ts
@@ -129,11 +129,7 @@ export function createSupermemoryHooks(
 					return
 				}
 
-				saveConversation(messages, ctx).catch((error) => {
-					ctx.logger.error("Background conversation save failed", {
-						error: error instanceof Error ? error.message : "Unknown error",
-					})
-				})
+				await saveConversation(messages, ctx)
 			} catch (error) {
 				ctx.logger.error("Error in onEnd", {
 					error: error instanceof Error ? error.message : "Unknown error",

--- a/packages/tools/src/voltagent/middleware.ts
+++ b/packages/tools/src/voltagent/middleware.ts
@@ -448,7 +448,7 @@ const convertToConversationMessages = (
 }
 
 /**
- * Saves conversation to Supermemory (fire-and-forget).
+ * Saves conversation to Supermemory.
  */
 export const saveConversation = async (
 	messages: VoltAgentMessage[],


### PR DESCRIPTION
## Summary

- await VoltAgent conversation persistence before the `onEnd` lifecycle hook resolves
- preserve fail-open behavior because save failures are still caught and logged
- add deferred-fetch regressions for delayed success and delayed HTTP failure

## Why

The hook previously detached `saveConversation()`. In serverless or short-lived runtimes, the request could terminate after `onEnd` resolved but before `/v4/conversations` completed, silently dropping conversation memory.

## Validation

- `bunx vitest run src/voltagent/hooks.test.ts` (2/2)
- runnable tools suite: 92 passed, 30 skipped
- package build
- changed-file TypeScript check
- Biome and `git diff --check`

The two full-suite load failures are unchanged from main (missing `SUPERMEMORY_API_KEY` and the existing `./claude-memory` import).