### PR TITLE
fix(web): keep timeline date labels fresh and stop regrouping every render

### DIFF
--- a/apps/web/components/timeline-view.tsx
+++ b/apps/web/components/timeline-view.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useEffect, useRef, useCallback } from "react"
+import { useState, useEffect, useMemo, useRef, useCallback } from "react"
 import { AnimatePresence, motion } from "motion/react"
 import type { DocumentsWithMemoriesResponseSchema } from "@repo/validation/api"
 import type { z } from "zod"
@@ -505,7 +505,21 @@ export function TimelineView({
 	selectedDocumentIds = new Set(),
 	onToggleSelection,
 }: TimelineViewProps) {
-	const [now] = useState(() => new Date())
+	// `now` drives the "Today"/"Yesterday"/weekday labels. Refresh it when the
+	// calendar day rolls over so a tab left open across midnight doesn't keep
+	// labelling yesterday's documents as "Today". Same-day ticks return the
+	// previous value, so React skips the re-render and the grouping below only
+	// recomputes on an actual day change.
+	const [now, setNow] = useState(() => new Date())
+	useEffect(() => {
+		const id = setInterval(() => {
+			setNow((prev) => {
+				const current = new Date()
+				return current.toDateString() === prev.toDateString() ? prev : current
+			})
+		}, 60_000)
+		return () => clearInterval(id)
+	}, [])
 	const [expandedGroups, setExpandedGroups] = useState<Set<string>>(new Set())
 	const sentinelRef = useRef<HTMLDivElement>(null)
 
@@ -532,7 +546,10 @@ export function TimelineView({
 		})
 	}, [])
 
-	const periodGroups = groupDocuments(documents, now)
+	const periodGroups = useMemo(
+		() => groupDocuments(documents, now),
+		[documents, now],
+	)
 	const handleTimelineCardSelection = useCallback(
 		(doc: DocumentWithMemories) => {
 			if (doc.id) onToggleSelection?.(doc.id)


### PR DESCRIPTION
Two issues in the timeline view:

**1. Stale relative-date headers.** `now` was captured once via `useState(() => new Date())`, so the "Today" / "Yesterday" / weekday headers never updated. Leave the tab open across midnight and yesterday's documents keep showing under **"Today"**. Fixed by refreshing `now` on a one-minute interval, swapping the value only when the calendar day actually changes:

```ts
setNow((prev) => {
  const current = new Date()
  return current.toDateString() === prev.toDateString() ? prev : current
})
```

Because same-day ticks return the previous reference, React bails on the re-render and the grouping below doesn't recompute.

**2. Re-grouping on every render.** `groupDocuments(documents, now)` sorts the entire list (up to 1000 docs) and reparses every `createdAt` into a `Date`, and it ran on **every** render — including during scroll and selection toggles. Wrapped it in `useMemo(..., [documents, now])` so it only recomputes when the data or the day changes.

Type-check and Biome clean (the pre-existing `className`/`style` type error at line 279 is unrelated and present on main).