### PR TITLE
fix(web): stop re-serializing the graph canvas on every share-modal render

### DIFF
--- a/apps/web/components/share-modal.tsx
+++ b/apps/web/components/share-modal.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useState, useRef, useCallback } from "react"
+import { useState, useRef, useEffect, useCallback } from "react"
 import { dmSansClassName, dmSans125ClassName } from "@/lib/fonts"
 import {
 	Dialog,
@@ -285,6 +285,22 @@ export function ShareModal({
 	const [copied, setCopied] = useState(false)
 	const previewRef = useRef<HTMLDivElement>(null)
 
+	// Snapshot the live graph canvas once when the modal opens. Reading
+	// `canvas.toDataURL()` inline in render re-serialized the whole (animated)
+	// canvas to a PNG on every re-render — including on each theme-button click.
+	const [graphImage, setGraphImage] = useState<string | null>(null)
+	useEffect(() => {
+		if (!isOpen) {
+			setGraphImage(null)
+			return
+		}
+		const id = requestAnimationFrame(() => {
+			const canvas = graphCanvasRef?.current
+			if (canvas) setGraphImage(canvas.toDataURL("image/png"))
+		})
+		return () => cancelAnimationFrame(id)
+	}, [isOpen, graphCanvasRef])
+
 	const localStorageUsername = useLocalStorageUsername()
 	const displayName =
 		user?.displayUsername ||
@@ -460,9 +476,9 @@ export function ShareModal({
 
 						{/* Graph canvas placeholder - will show the actual graph */}
 						<div className="absolute inset-0 flex items-center justify-center">
-							{graphCanvasRef?.current ? (
+							{graphImage ? (
 								<img
-									src={graphCanvasRef.current.toDataURL("image/png")}
+									src={graphImage}
 									alt="Memory graph"
 									className="max-w-full max-h-full object-contain"
 								/>


### PR DESCRIPTION
### Bug

The share preview rendered the graph image like this:

```tsx
{graphCanvasRef?.current ? (
  <img src={graphCanvasRef.current.toDataURL("image/png")} ... />
) : ( ... )}
```

`canvas.toDataURL()` runs **inline in JSX**, so the entire graph canvas is re-encoded to a base64 PNG on **every render** of the modal — every theme-button click, every `isCopying` / `copied` state change. Each render also hands the `<img>` a brand-new `src` string, forcing it to decode/reload. On a large, high-DPR graph canvas that's a heavy synchronous main-thread operation, so interacting with the modal (e.g. switching background themes) janks.

### Fix

Capture the snapshot **once** when the modal opens, store it in state, and clear it on close (a `requestAnimationFrame` guard makes sure we read a painted frame):

```ts
const [graphImage, setGraphImage] = useState<string | null>(null)
useEffect(() => {
  if (!isOpen) { setGraphImage(null); return }
  const id = requestAnimationFrame(() => {
    const canvas = graphCanvasRef?.current
    if (canvas) setGraphImage(canvas.toDataURL("image/png"))
  })
  return () => cancelAnimationFrame(id)
}, [isOpen, graphCanvasRef])
```

The `<img>` now renders from `graphImage`, so theme switches and copy/download no longer re-encode the canvas. Type-check and Biome clean.