### PR TITLE
feat(web): support discount code checkout

### DIFF
--- a/apps/web/app/(app)/layout.tsx
+++ b/apps/web/app/(app)/layout.tsx
@@ -3,10 +3,12 @@
 import { EnsureWorkspace } from "@/components/ensure-workspace"
 import { PWAInstallPrompt } from "@/components/pwa-install-prompt"
 import { SettingsModalProvider } from "@/components/settings/settings-modal"
+import { PromoCodeHost } from "@/hooks/use-promo-code"
 
 export default function AppLayout({ children }: { children: React.ReactNode }) {
 	return (
 		<SettingsModalProvider>
+			<PromoCodeHost />
 			<EnsureWorkspace>{children}</EnsureWorkspace>
 			<PWAInstallPrompt />
 		</SettingsModalProvider>

--- a/apps/web/app/layout.tsx
+++ b/apps/web/app/layout.tsx
@@ -11,6 +11,7 @@ import { Suspense } from "react"
 import { Toaster } from "@ui/components/sonner"
 import { NuqsAdapter } from "nuqs/adapters/next/app"
 import { ThemeProvider } from "@/lib/theme-provider"
+import { PromoCodeCapture } from "@/hooks/use-promo-code"
 
 const font = Space_Grotesk({
 	subsets: ["latin"],
@@ -95,6 +96,7 @@ export default function RootLayout({
 						includeCredentials={true}
 						headers={{ "X-App-Source": "nova" }}
 					>
+						<PromoCodeCapture />
 						<QueryProvider>
 							<AuthProvider>
 								<PostHogProvider>

--- a/apps/web/components/add-document/connections.tsx
+++ b/apps/web/components/add-document/connections.tsx
@@ -42,6 +42,7 @@ import {
 	getConnectionSubtitle,
 } from "@/components/settings/sync-utils"
 import type { ImportProvider } from "@/components/settings/sync-utils"
+import { usePromoCode } from "@/hooks/use-promo-code"
 
 type GDriveSyncScope = "scoped" | "full"
 
@@ -309,6 +310,7 @@ interface ConnectContentProps {
 export function ConnectContent({ selectedProject }: ConnectContentProps) {
 	const queryClient = useQueryClient()
 	const autumn = useCustomer()
+	const promoCode = usePromoCode()
 	const { connectorAccess } = useConnectorAccess()
 	const [connectingProvider, setConnectingProvider] =
 		useState<ConnectorProvider | null>(null)
@@ -330,8 +332,10 @@ export function ConnectContent({ selectedProject }: ConnectContentProps) {
 		try {
 			const result = await autumn.attach({
 				planId,
+				discounts: promoCode.getDiscounts(),
 				successUrl: window.location.href,
 			})
+			promoCode.clear()
 			if (result?.paymentUrl) {
 				window.open(result.paymentUrl, "_self")
 				return

--- a/apps/web/components/add-document/index.tsx
+++ b/apps/web/components/add-document/index.tsx
@@ -21,6 +21,7 @@ import { formatUsageNumber } from "@/lib/billing-utils"
 import { SpaceSelector } from "../space-selector"
 import { useIsMobile } from "@hooks/use-mobile"
 import { addDocumentParam } from "@/lib/search-params"
+import { usePromoCode } from "@/hooks/use-promo-code"
 
 type TabType = "note" | "link" | "file" | "connect"
 
@@ -153,6 +154,7 @@ export function AddDocument({
 		})
 
 	const autumn = useCustomer()
+	const promoCode = usePromoCode()
 	const {
 		tokensUsed,
 		searchesUsed,
@@ -342,8 +344,10 @@ export function AddDocument({
 							try {
 								const result = await autumn.attach({
 									planId: "api_pro",
+									discounts: promoCode.getDiscounts(),
 									successUrl: `${window.location.origin}/settings#account`,
 								})
+								promoCode.clear()
 								if (result?.paymentUrl) {
 									window.open(result.paymentUrl, "_self")
 									return
@@ -442,8 +446,10 @@ export function AddDocument({
 									try {
 										const result = await autumn.attach({
 											planId: "api_pro",
+											discounts: promoCode.getDiscounts(),
 											successUrl: `${window.location.origin}/settings#account`,
 										})
+										promoCode.clear()
 										if (result?.paymentUrl) {
 											window.open(result.paymentUrl, "_self")
 											return

--- a/apps/web/components/integrations-view.tsx
+++ b/apps/web/components/integrations-view.tsx
@@ -80,6 +80,7 @@ import {
 import { MCPSteps } from "./mcp-modal/mcp-detail-view"
 import { GranolaConnectModal } from "./granola-connect-modal"
 import { detectPluginSpace, detectPluginSource } from "@/lib/plugin-space"
+import { usePromoCode } from "@/hooks/use-promo-code"
 
 type Connection = z.infer<typeof ConnectionResponseSchema>
 
@@ -2555,6 +2556,7 @@ export function IntegrationsView({
 	const { allProjects } = useContainerTags()
 	const shortcutsConnect = useShortcutsConnect()
 	const autumn = useCustomer({ queryOptions: { enabled: !publicMode } })
+	const promoCode = usePromoCode()
 	// connectorAccess covers pro-tier connectors (incl. company_brain orgs); plugins
 	// stay on hasProProduct. See useConnectorAccess.
 	const { hasPro: hasProProduct, connectorAccess } = useConnectorAccess({
@@ -2825,8 +2827,10 @@ export function IntegrationsView({
 			try {
 				const result = await autumn.attach({
 					planId: checkoutPlanId,
+					discounts: promoCode.getDiscounts(),
 					successUrl: `${window.location.origin}/integrations`,
 				})
+				promoCode.clear()
 				if (result?.paymentUrl) {
 					window.open(result.paymentUrl, "_self")
 					return
@@ -2837,7 +2841,7 @@ export function IntegrationsView({
 				toast.error("Failed to start checkout. Please try again.")
 			}
 		},
-		[autumn],
+		[autumn, promoCode],
 	)
 
 	const redirectToLogin = useCallback(() => {

--- a/apps/web/components/integrations/plugins-detail.tsx
+++ b/apps/web/components/integrations/plugins-detail.tsx
@@ -30,6 +30,7 @@ import {
 	type PluginInfo,
 } from "@/lib/plugin-catalog"
 import { INSET, InstallSteps, PillButton } from "./install-steps"
+import { usePromoCode } from "@/hooks/use-promo-code"
 
 interface ConnectedPlugin {
 	id: string
@@ -418,6 +419,7 @@ function PluginRow({
 export function PluginsDetail() {
 	const { org } = useAuth()
 	const autumn = useCustomer()
+	const promoCode = usePromoCode()
 	const queryClient = useQueryClient()
 	const [connectingPlugin, setConnectingPlugin] = useState<string | null>(null)
 	const [finishSetupPluginId, setFinishSetupPluginId] = useState<string | null>(
@@ -570,8 +572,10 @@ export function PluginsDetail() {
 		try {
 			const result = await autumn.attach({
 				planId: "api_pro",
+				discounts: promoCode.getDiscounts(),
 				successUrl: `${window.location.origin}/integrations`,
 			})
+			promoCode.clear()
 			if (result?.paymentUrl) {
 				window.open(result.paymentUrl, "_self")
 				return

--- a/apps/web/components/onboarding-brain/step-sources.tsx
+++ b/apps/web/components/onboarding-brain/step-sources.tsx
@@ -82,6 +82,7 @@ import { useCustomer } from "autumn-js/react"
 import { toast } from "sonner"
 import { analytics } from "@/lib/analytics"
 import type { BrainMode } from "./types"
+import { usePromoCode } from "@/hooks/use-promo-code"
 
 type SourceId =
 	| "drive"
@@ -614,6 +615,7 @@ function OnboardingPlansModal({
 	requestedPlan: RequiredPlan
 }) {
 	const autumn = useCustomer()
+	const promoCode = usePromoCode()
 	const { currentPlan, isLoading } = useTokenUsage(autumn)
 	const [upgradingPlan, setUpgradingPlan] = useState<CheckoutPlanId | null>(
 		null,
@@ -632,8 +634,10 @@ function OnboardingPlansModal({
 		try {
 			const result = await autumn.attach({
 				planId,
+				discounts: promoCode.getDiscounts(),
 				successUrl: window.location.href,
 			})
+			promoCode.clear()
 			if ((result as { paymentUrl?: string })?.paymentUrl) {
 				window.location.href = (result as { paymentUrl: string }).paymentUrl
 				return

--- a/apps/web/components/settings/billing.tsx
+++ b/apps/web/components/settings/billing.tsx
@@ -36,6 +36,7 @@ import {
 } from "lucide-react"
 import { useEffect, useMemo, useRef, useState } from "react"
 import { toast } from "sonner"
+import { usePromoCode } from "@/hooks/use-promo-code"
 
 const API_BASE =
 	process.env.NEXT_PUBLIC_BACKEND_URL ?? "https://api.supermemory.ai"
@@ -531,6 +532,7 @@ export default function Billing() {
 	const queryClient = useQueryClient()
 	const { user, org } = useAuth()
 	const autumn = useCustomer()
+	const promoCode = usePromoCode()
 	const posthog = usePostHog()
 	const isCompanyBrain = useHasCompanyBrain()
 	const brainTrial = useMemo(
@@ -698,8 +700,10 @@ export default function Billing() {
 		try {
 			const result = await autumn.attach({
 				planId,
+				discounts: promoCode.getDiscounts(),
 				successUrl: `${window.location.origin}/settings#billing`,
 			})
+			promoCode.clear()
 			if ((result as { paymentUrl?: string })?.paymentUrl) {
 				window.location.href = (result as { paymentUrl: string }).paymentUrl
 				return

--- a/apps/web/components/settings/connections-mcp.tsx
+++ b/apps/web/components/settings/connections-mcp.tsx
@@ -38,6 +38,7 @@ import {
 	getConnectionSubtitle,
 } from "@/components/settings/sync-utils"
 import type { ImportProvider } from "@/components/settings/sync-utils"
+import { usePromoCode } from "@/hooks/use-promo-code"
 
 type Connection = z.infer<typeof ConnectionResponseSchema>
 
@@ -420,6 +421,7 @@ function FeatureItem({ text }: { text: string }) {
 export default function ConnectionsMCP() {
 	const queryClient = useQueryClient()
 	const autumn = useCustomer()
+	const promoCode = usePromoCode()
 	const [addDoc, setAddDoc] = useQueryState("add", addDocumentParam)
 	const router = useRouter()
 	const [removeDialog, setRemoveDialog] = useState<{
@@ -552,8 +554,10 @@ export default function ConnectionsMCP() {
 		try {
 			const result = await autumn.attach({
 				planId: "api_pro",
+				discounts: promoCode.getDiscounts(),
 				successUrl: `${window.location.origin}/settings#connections`,
 			})
+			promoCode.clear()
 			if (result?.paymentUrl) {
 				window.open(result.paymentUrl, "_self")
 				return

--- a/apps/web/hooks/use-promo-code.ts
+++ b/apps/web/hooks/use-promo-code.ts
@@ -1,0 +1,82 @@
+"use client"
+
+import { useAuth } from "@lib/auth-context"
+import { useRouter } from "next/navigation"
+import { useCallback, useEffect, useMemo } from "react"
+import { toast } from "sonner"
+
+const PENDING_PROMO_CODE_KEY = "sm.promoCode.pending"
+const PROMO_TOAST_ID = "promo-code"
+
+function promoCodeKey(orgId: string): string {
+	return `sm.promoCode.org_${orgId}`
+}
+
+function readOrgPromoCode(orgId?: string): string | null {
+	if (!orgId || typeof window === "undefined") return null
+	return window.localStorage.getItem(promoCodeKey(orgId))
+}
+
+export function usePromoCode() {
+	const { org } = useAuth()
+	const orgId = org?.id
+
+	const getDiscounts = useCallback(() => {
+		const promotionCode = readOrgPromoCode(orgId)
+		return promotionCode ? [{ promotionCode }] : undefined
+	}, [orgId])
+
+	const clear = useCallback(() => {
+		if (!orgId) return
+		window.localStorage.removeItem(promoCodeKey(orgId))
+		toast.dismiss(PROMO_TOAST_ID)
+	}, [orgId])
+
+	return useMemo(() => ({ getDiscounts, clear }), [getDiscounts, clear])
+}
+
+export function PromoCodeCapture() {
+	useEffect(() => {
+		const url = new URL(window.location.href)
+		const code = url.searchParams.get("discountCode")
+		if (!code) return
+
+		window.localStorage.setItem(PENDING_PROMO_CODE_KEY, code)
+		url.searchParams.delete("discountCode")
+		window.history.replaceState({}, "", url.toString())
+	}, [])
+
+	return null
+}
+
+export function PromoCodeHost() {
+	const { org } = useAuth()
+	const router = useRouter()
+
+	useEffect(() => {
+		if (!org?.id) return
+
+		const pending = window.localStorage.getItem(PENDING_PROMO_CODE_KEY)
+		if (pending) {
+			window.localStorage.setItem(promoCodeKey(org.id), pending)
+			window.localStorage.removeItem(PENDING_PROMO_CODE_KEY)
+		}
+
+		const code = readOrgPromoCode(org.id)
+		if (!code) {
+			toast.dismiss(PROMO_TOAST_ID)
+			return
+		}
+		toast.success("Discount code active", {
+			id: PROMO_TOAST_ID,
+			description: `Code ${code} will apply at checkout.`,
+			duration: Number.POSITIVE_INFINITY,
+			action: {
+				label: "Upgrade",
+				onClick: () => router.push("/settings#billing"),
+			},
+		})
+	}, [org?.id, router])
+
+	return null
+}


### PR DESCRIPTION
<!-- VORFLUX_AGENT_PR_BODY_BEGIN -->
Mirrors the console discount-code flow in the consumer app so promotional links survive authentication and apply to paid plan checkout for the active organization.

## Changes

- Capture `?discountCode=` globally, remove it from the URL, and bind it to the active organization after authentication.
- Show a persistent “Discount code active” toast with a direct upgrade action, including correct behavior across reloads and organization switches.
- Apply the stored promotion code to every paid-plan Autumn checkout and clear it after checkout initiation.
- Keep credit top-ups and the separate Company Brain trial-start endpoint excluded from promotion codes.

## Out-of-Scope Feedback

- Missing automated regression coverage for promo capture, organization binding, and checkout payloads — Ignored (tests were not requested; runtime and static verification were performed).

## Testing

- **Passed:** `x biome check apps/web/hooks/use-promo-code.ts apps/web/app/layout.tsx 'apps/web/app/(app)/layout.tsx' apps/web/components/settings/billing.tsx apps/web/components/integrations-view.tsx apps/web/components/integrations/plugins-detail.tsx apps/web/components/settings/connections-mcp.tsx apps/web/components/onboarding-brain/step-sources.tsx apps/web/components/add-document/index.tsx apps/web/components/add-document/connections.tsx`
- **Passed:** `git diff --check`
- **Passed:** Public guest runtime verified `?discountCode=QA_DISCOUNT_2026` is removed from the URL and preserved in local storage; the integrations UI returned HTTP 200.
- **Passed:** Static audit confirmed all paid-plan `autumn.attach` calls use `discounts: [{ promotionCode }]`; credit top-up and `/brain/trial/start` remain excluded.
- **Partial:** `run --filter @repo/web check-types` remains non-actionable because of broad pre-existing repository dependency/API type errors. No discount-specific type error remained after installing declared dependencies.
- **Blocked:** Active-organization binding, authenticated toast persistence, live checkout payload, and post-attach clearing could not be exercised because no disposable authenticated browser session was available.

---
**Attached Images and Videos**

![discount-code-query-removal.png](https://api.us1.vorflux.com/assets/artifacts/c3VwZXJtZW1vcnk6Zjo4MDM4.akcwk1gek0WQfBqdS6jk-aFpMQLNIml1mGDoJE1pBnI.png)

🎥 [View recording: discount-code-query-removal.webm](https://api.us1.vorflux.com/assets/artifacts/c3VwZXJtZW1vcnk6Zjo4MDM5.6Kc2blxfc7gCeCn7XM2GFsYAidrb_KS83RL4C3c7-v0.mp4)

![discount-code-capture.png](https://api.us1.vorflux.com/assets/artifacts/c3VwZXJtZW1vcnk6Zjo4MDQw.F7p_rVypkkhF6KhBttJmgDvtUG9o8Faxv2k1Ky4fI0w.png)

🎥 [View recording: discount-code-capture.webm](https://api.us1.vorflux.com/assets/artifacts/c3VwZXJtZW1vcnk6Zjo4MDQx.PG5fGJvAjeJ1nZx6A2dpwVKFseueY6C8eLoLg38X3EQ.mp4)
<!-- VORFLUX_AGENT_PR_BODY_END -->

---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/d2671f2e-03ca-4c25-a7ea-8dd99c64e170)
- Requested by: Dhravya Shah (dhravya@supermemory.com)
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches billing checkout across many UI surfaces; incorrect discount binding or clearing could affect revenue, but changes are localized to localStorage and attach payloads without altering auth or payment APIs directly.
> 
> **Overview**
> Adds **promotional discount codes** to the consumer web app so `?discountCode=` links survive login and apply at paid-plan checkout for the active organization.
> 
> A new **`use-promo-code`** hook captures the query param globally (strips it from the URL), stores a pending code in `localStorage`, then **`PromoCodeHost`** binds it to the current org after auth. Users see a persistent **“Discount code active”** toast with an upgrade shortcut to billing.
> 
> Every paid-plan **`autumn.attach`** path now passes **`discounts: promoCode.getDiscounts()`** and **`promoCode.clear()`** after checkout starts (billing, integrations, add-document, onboarding upgrade modals, connections). Credit top-ups and non-attach flows are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b468de2d15652f7bb9ea15d1e50eefda3a6332b5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->