### PR TITLE
fix(web): scope the guest ?view= bypass to the root route

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -4,6 +4,10 @@ import { getPublicRequestUrl } from "@/lib/url-helpers"
 
 const LOCAL_DEV_HOSTS = new Set(["localhost", "127.0.0.1", "::1"])
 
+// Views that are public in guest mode. These are page views on the root route,
+// selected by ?view= — see isPublicAppPage in components/ensure-workspace.tsx.
+const PUBLIC_ROOT_VIEWS = new Set(["integrations", "mcp"])
+
 function getAuthSessionCookie(request: Request): string | null {
 	return (
 		getSessionCookie(request) ??
@@ -41,13 +45,15 @@ export default async function proxy(request: Request) {
 		return NextResponse.next()
 	}
 
-	// MCP setup page is public — no auth required
-	if (url.searchParams.get("view") === "mcp") {
-		return NextResponse.next()
-	}
-
-	// Integrations index is public in guest mode; actions still require login.
-	if (url.pathname === "/" && url.searchParams.get("view") === "integrations") {
+	// MCP setup and the integrations index are public in guest mode; actions
+	// still require login. The pathname check is load-bearing: this runs before
+	// the /api/ gate below, so matching ?view= on any path would also let
+	// "/api/<anything>?view=mcp" skip the 401 and reach the web app's own API
+	// handlers unauthenticated.
+	if (
+		url.pathname === "/" &&
+		PUBLIC_ROOT_VIEWS.has(url.searchParams.get("view") ?? "")
+	) {
 		return NextResponse.next()
 	}
 


### PR DESCRIPTION
## Summary

The `?view=mcp` guest-mode escape hatch in `apps/web/middleware.ts` is not scoped to a
path, and it is evaluated **before** the `/api/*` authentication gate. Adding
`?view=mcp` to any request therefore returns `NextResponse.next()` and skips the 401,
reaching the web app's own API route handlers unauthenticated.

```ts
// MCP setup page is public — no auth required
if (url.searchParams.get("view") === "mcp") {
    return NextResponse.next()          // no pathname check
}
...
if (url.pathname.startsWith("/api/")) {
    if (!sessionCookie) return 401       // never reached
}
```

Every neighbouring public-route check is path-scoped — `publicPaths.includes(url.pathname)`,
`url.pathname === "/" && view=integrations`, `/integrations`, `/integrations/mcp`. This
one is the outlier.

The middleware `matcher` only excludes `api/emails`, so the remaining API routes are all
affected:

| Request | Effect without a session |
| --- | --- |
| `POST /api/onboarding/research?view=mcp` | Grok-4 call with `web_search` + `x_search` tools, billed per request |
| `POST /api/onboarding/extract-content?view=mcp` | Exa live-crawl, billed per URL, and the `urls` array is currently unbounded |
| `GET /api/og?view=mcp` | Outbound fetch proxy |
| `GET /api/onboarding/account-status?view=mcp` | Outbound fetch |

## Fix

Scope the `view` check to the root route, matching the client-side gate that already
defines this policy in `components/ensure-workspace.tsx`:

```ts
const isPublicAppPage =
    pathname === "/integrations" ||
    pathname === "/integrations/mcp" ||
    (pathname === "/" && ["integrations", "mcp"].includes(searchParams.get("view") ?? ""))
```

Since `view=integrations` was already scoped to `/`, the two adjacent checks collapse
into one against a `PUBLIC_ROOT_VIEWS` set, and a comment records why the pathname
check is load-bearing.

## Why this is behaviour-preserving for legitimate traffic

`?view=` is a root-route concept everywhere in the app:

- `lib/view-mode-context.tsx` only ever pushes `/?view=${mode}` (line 57).
- `useLegacyViewRedirect` returns early unless `pathname === "/"` (line 76).
- No call site anywhere in the repo constructs a `view=mcp` link on a non-root path.
- `/integrations` and `/integrations/mcp` are real routes, allowed by the next check.

## Notes

- Distinct from #1272, which validates session cookies but leaves this ordering intact
  (`if (url.pathname.startsWith("/api/"))` is an unchanged context line in its diff).
- `apps/web` has no test runner configured (no `vitest` dependency, no `test` script),
  so this change adds no test infrastructure. Happy to add coverage if a runner lands.
- `biome check` passes on the changed file.
