### PR TITLE
fix(web): bound and validate the onboarding extract-content batch

### DIFF
--- a/apps/web/app/api/onboarding/extract-content/route.ts
+++ b/apps/web/app/api/onboarding/extract-content/route.ts
@@ -16,6 +16,10 @@ if (!exaApiKey) {
 	)
 }
 
+// Each URL becomes a (potentially billed live-crawled) Exa request, so cap the
+// batch size to bound cost/abuse from a single call.
+const MAX_URLS = 20
+
 export async function POST(request: Request) {
 	try {
 		if (!exaApiKey) {
@@ -34,11 +38,44 @@ export async function POST(request: Request) {
 			)
 		}
 
-		if (!urls.every((url) => typeof url === "string" && url.trim())) {
+		if (urls.length > MAX_URLS) {
 			return Response.json(
-				{ error: "Invalid input: all urls must be non-empty strings" },
+				{ error: `Invalid input: at most ${MAX_URLS} urls are allowed` },
 				{ status: 400 },
 			)
+		}
+
+		// Validate, normalize, and de-duplicate before hitting the paid Exa API.
+		const normalizedUrls: string[] = []
+		const seen = new Set<string>()
+		for (const url of urls) {
+			if (typeof url !== "string" || !url.trim()) {
+				return Response.json(
+					{ error: "Invalid input: all urls must be non-empty strings" },
+					{ status: 400 },
+				)
+			}
+
+			let parsed: URL
+			try {
+				parsed = new URL(url.trim())
+			} catch {
+				return Response.json(
+					{ error: "Invalid input: all urls must be valid URLs" },
+					{ status: 400 },
+				)
+			}
+
+			if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+				return Response.json(
+					{ error: "Invalid input: urls must use http or https" },
+					{ status: 400 },
+				)
+			}
+
+			if (seen.has(parsed.href)) continue
+			seen.add(parsed.href)
+			normalizedUrls.push(parsed.href)
 		}
 
 		const response = await fetch("https://api.exa.ai/contents", {
@@ -48,7 +85,7 @@ export async function POST(request: Request) {
 				"Content-Type": "application/json",
 			},
 			body: JSON.stringify({
-				urls,
+				urls: normalizedUrls,
 				text: true,
 				livecrawl: "fallback",
 			}),


### PR DESCRIPTION
## Summary

`/api/onboarding/extract-content` forwards a caller-supplied `urls` array straight to
`https://api.exa.ai/contents` with `livecrawl: "fallback"`. The only validation today is
that every element is a non-empty string:

```ts
if (!urls.every((url) => typeof url === "string" && url.trim())) { ... }

body: JSON.stringify({ urls, text: true, livecrawl: "fallback" })
```

The array is unbounded, entries are never parsed or de-duplicated, and the scheme is
never checked. Each entry is a potentially live-crawled — and billed — Exa request, so a
single call carrying thousands of URLs (or the same URL thousands of times) turns into a
proportionally large invoice.

## Changes

- Cap the batch at `MAX_URLS = 20` and reject larger payloads with `400`.
- Parse each entry with `new URL()` and reject malformed values with `400`, instead of
  passing junk through to a paid API.
- Require `http:` or `https:`, so schemes like `file:` / `data:` never reach Exa.
- De-duplicate on the normalized `href`, so a repeated URL is billed once.

Behaviour for well-formed input is unchanged, apart from the URLs being sent in
normalized form.

## Note for reviewers: this route appears to be unused

While checking the call site to pick a safe `MAX_URLS`, I could not find any caller for
this route in the monorepo. The only `/api/*` route the web client fetches is `/api/og`
(`apps/web/components/memories-grid.tsx:157`).

The same appears to hold for its two siblings, `/api/onboarding/research` and
`/api/onboarding/account-status`. All three were added in #672 (Jan 2026), and the
onboarding flow has since been rebuilt more than once — #904 (`remove unused old
onboarding flow`), #1067, #1178 — which looks like it dropped the callers and left the
routes in place.

I have only grepped this repository, so I cannot rule out a caller outside the monorepo,
which is why this PR hardens rather than removes. If these routes are in fact dead,
deleting all three would be the better fix — it removes a network-reachable surface that
spends money against Exa and xAI — and I am happy to open that PR instead.

## Testing

`biome check` passes on the changed file. `apps/web` has no test runner configured (no
`vitest` dependency, no `test` script), so no tests were added.
