### PR TITLE
refactor(brain): one isCompanyBrainOrg helper in the web app

### DIFF
--- a/apps/web/hooks/use-company-brain.ts
+++ b/apps/web/hooks/use-company-brain.ts
@@ -1,16 +1,8 @@
 import { useAuth } from "@lib/auth-context"
-import {
-	getBrainMode,
-	getCompanyBrainOverride,
-	hasCompanyBrain,
-} from "@/lib/billing-utils"
+import { isCompanyBrainOrg } from "@/lib/billing-utils"
 
 export function useHasCompanyBrain(): boolean {
 	const { org } = useAuth()
 	const metadata = org?.metadata as Record<string, unknown> | string | undefined
-	// An explicit concierge override wins over the team-onboarding fallback.
-	const override = getCompanyBrainOverride(metadata)
-	if (override !== undefined) return override
-	// Team-brain orgs use brain spaces even before the add-on webhook lands.
-	return hasCompanyBrain(metadata) || getBrainMode(metadata) === "team"
+	return isCompanyBrainOrg(metadata)
 }

--- a/apps/web/lib/billing-utils.ts
+++ b/apps/web/lib/billing-utils.ts
@@ -112,6 +112,15 @@ export function getBrainMode(
 		: null
 }
 
+export function isCompanyBrainOrg(
+	metadataRaw: Record<string, unknown> | string | null | undefined,
+): boolean {
+	const override = getCompanyBrainOverride(metadataRaw)
+	if (override !== undefined) return override
+	if (hasCompanyBrain(metadataRaw)) return true
+	return getBrainMode(metadataRaw) === "team"
+}
+
 export type BrainTrialStatus =
 	| "active"
 	| "exhausted"

--- a/apps/web/lib/company-brain-entry.ts
+++ b/apps/web/lib/company-brain-entry.ts
@@ -1,9 +1,4 @@
-import {
-	getBrainMode,
-	getBrainWorkspaceDomain,
-	getCompanyBrainOverride,
-	hasCompanyBrain,
-} from "./billing-utils"
+import { getBrainWorkspaceDomain, isCompanyBrainOrg } from "./billing-utils"
 
 export type BrainEntryOrganization = {
 	id: string
@@ -18,21 +13,12 @@ export type CompanyBrainEntryDecision =
 	| { action: "choose"; organizations: BrainEntryOrganization[] }
 	| { action: "create" }
 
-export function isCompanyBrainOrganization(
-	organization: BrainEntryOrganization,
-): boolean {
-	const override = getCompanyBrainOverride(organization.metadata)
-	if (override !== undefined) return override
-	return (
-		hasCompanyBrain(organization.metadata) ||
-		getBrainMode(organization.metadata) === "team"
-	)
-}
-
 export function getCompanyBrainOrganizations(
 	organizations: BrainEntryOrganization[],
 ): BrainEntryOrganization[] {
-	return organizations.filter(isCompanyBrainOrganization)
+	return organizations.filter((organization) =>
+		isCompanyBrainOrg(organization.metadata),
+	)
 }
 
 function normalizeDomain(domain: string): string {


### PR DESCRIPTION
Two hand-rolled copies of the add-on/brainMode rule replaced by a single shared helper, and the one-line isCompanyBrainOrganization wrapper dropped. No behaviour change.