### PR TITLE
fix(mcp): strip API extras from listMemories entries

### DIFF
--- a/apps/mcp/src/server/client/index.ts
+++ b/apps/mcp/src/server/client/index.ts
@@ -7,11 +7,14 @@ import { z } from "zod"
 import {
 	containerTagSchema,
 	documentsApiResponseSchema,
-	paginationSchema,
+	memoriesListSchema,
 	type ContainerTag,
 	type DocumentMemoryEntry,
 	type DocumentsApiResponse,
 	type DocumentWithMemories,
+	type MemoriesList,
+	type MemoryEntry,
+	type MemoryEntryHistory,
 } from "../../shared/types"
 
 const MAX_CHARS = 200000
@@ -34,44 +37,10 @@ export interface DocumentsListResponse {
 	pagination: SdkDocumentListResponse["pagination"]
 }
 
-// z.object strips API extras that the strict MCP output schema would reject.
-const memoryEntryHistorySchema = z.object({
-	id: z.string(),
-	memory: z.string(),
-	version: z.number(),
-	createdAt: z.string(),
-	updatedAt: z.string(),
-	parentMemoryId: z.string().nullish(),
-	rootMemoryId: z.string().nullish(),
-	isLatest: z.boolean().optional(),
-	isForgotten: z.boolean().optional(),
-})
-
-export type MemoryEntryHistory = z.infer<typeof memoryEntryHistorySchema>
-
-const memoryEntrySchema = z.object({
-	id: z.string(),
-	memory: z.string(),
-	version: z.number(),
-	isLatest: z.boolean(),
-	isForgotten: z.boolean(),
-	isStatic: z.boolean().optional(),
-	isInference: z.boolean().optional(),
-	createdAt: z.string(),
-	updatedAt: z.string(),
-	sourceCount: z.number().optional(),
-	documentIds: z.array(z.string()).optional(),
-	history: z.array(memoryEntryHistorySchema).optional(),
-})
-
-export type MemoryEntry = z.infer<typeof memoryEntrySchema>
-
-const memoryEntriesResponseSchema = z.object({
-	memoryEntries: z.array(memoryEntrySchema),
-	pagination: paginationSchema,
-})
-
-export type MemoryEntriesResponse = z.infer<typeof memoryEntriesResponseSchema>
+// Memory-entry shapes live in shared/types so the client parser and the
+// listMemories output schema share one definition and can't drift.
+export type { MemoryEntry, MemoryEntryHistory }
+export type MemoryEntriesResponse = MemoriesList
 
 export type Memory =
 	| {
@@ -453,7 +422,7 @@ export class SupermemoryClient {
 				})
 			}
 
-			return memoryEntriesResponseSchema.parse(await response.json())
+			return memoriesListSchema.parse(await response.json())
 		} catch (error) {
 			this.handleError(error)
 		}

--- a/apps/mcp/src/server/client/index.ts
+++ b/apps/mcp/src/server/client/index.ts
@@ -34,7 +34,8 @@ export interface DocumentsListResponse {
 	pagination: SdkDocumentListResponse["pagination"]
 }
 
-const memoryEntryHistorySchema = z.looseObject({
+// z.object strips API extras that the strict MCP output schema would reject.
+const memoryEntryHistorySchema = z.object({
 	id: z.string(),
 	memory: z.string(),
 	version: z.number(),
@@ -48,7 +49,7 @@ const memoryEntryHistorySchema = z.looseObject({
 
 export type MemoryEntryHistory = z.infer<typeof memoryEntryHistorySchema>
 
-const memoryEntrySchema = z.looseObject({
+const memoryEntrySchema = z.object({
 	id: z.string(),
 	memory: z.string(),
 	version: z.number(),

--- a/apps/mcp/src/server/tools/output-schemas.ts
+++ b/apps/mcp/src/server/tools/output-schemas.ts
@@ -1,6 +1,7 @@
 import { z } from "zod"
 import {
 	containerTagAccessSchema,
+	memoriesListSchema,
 	paginationSchema,
 	sessionScopeSchema,
 } from "../../shared/types"
@@ -42,33 +43,6 @@ const documentSummarySchema = z.object({
 	summary: z.string().nullable(),
 })
 
-const memoryHistorySchema = z.object({
-	id: z.string(),
-	memory: z.string(),
-	version: z.number(),
-	createdAt: z.string(),
-	updatedAt: z.string(),
-	parentMemoryId: z.string().nullish(),
-	rootMemoryId: z.string().nullish(),
-	isLatest: z.boolean().optional(),
-	isForgotten: z.boolean().optional(),
-})
-
-const memoryEntryOutputSchema = z.object({
-	id: z.string(),
-	memory: z.string(),
-	version: z.number(),
-	isLatest: z.boolean(),
-	isForgotten: z.boolean(),
-	isStatic: z.boolean().optional(),
-	isInference: z.boolean().optional(),
-	createdAt: z.string(),
-	updatedAt: z.string(),
-	sourceCount: z.number().optional(),
-	documentIds: z.array(z.string()).optional(),
-	history: z.array(memoryHistorySchema).optional(),
-})
-
 export const addMemoryOutputSchema = z.object({
 	action: z.enum(["save", "forget"]),
 	success: z.boolean(),
@@ -104,10 +78,9 @@ export const listDocumentsOutputSchema = z.object({
 
 export type ListDocumentsOutput = z.infer<typeof listDocumentsOutputSchema>
 
-export const listMemoriesOutputSchema = z.object({
-	memoryEntries: z.array(memoryEntryOutputSchema),
-	pagination: paginationSchema,
-})
+// Reuse the shared schema so the tool's output contract stays identical to what
+// the client parses — the two can't drift.
+export const listMemoriesOutputSchema = memoriesListSchema
 
 export type ListMemoriesOutput = z.infer<typeof listMemoriesOutputSchema>
 

--- a/apps/mcp/src/shared/types.ts
+++ b/apps/mcp/src/shared/types.ts
@@ -116,6 +116,49 @@ export const documentsApiResponseSchema = z.object({
 
 export type DocumentsApiResponse = z.infer<typeof documentsApiResponseSchema>
 
+// Extracted memory entries from /v4/memories/list. Single source of truth for
+// both the client parser and the listMemories tool output schema, so the two
+// can't drift (a mismatch previously produced Ajv "must NOT have additional
+// properties"). z.object strips unknown API fields on parse, keeping parsed data
+// matched to the strict MCP output contract while tolerating new API fields.
+export const memoryEntryHistorySchema = z.object({
+	id: z.string(),
+	memory: z.string(),
+	version: z.number(),
+	createdAt: z.string(),
+	updatedAt: z.string(),
+	parentMemoryId: z.string().nullish(),
+	rootMemoryId: z.string().nullish(),
+	isLatest: z.boolean().optional(),
+	isForgotten: z.boolean().optional(),
+})
+
+export type MemoryEntryHistory = z.infer<typeof memoryEntryHistorySchema>
+
+export const memoryEntrySchema = z.object({
+	id: z.string(),
+	memory: z.string(),
+	version: z.number(),
+	isLatest: z.boolean(),
+	isForgotten: z.boolean(),
+	isStatic: z.boolean().optional(),
+	isInference: z.boolean().optional(),
+	createdAt: z.string(),
+	updatedAt: z.string(),
+	sourceCount: z.number().optional(),
+	documentIds: z.array(z.string()).optional(),
+	history: z.array(memoryEntryHistorySchema).optional(),
+})
+
+export type MemoryEntry = z.infer<typeof memoryEntrySchema>
+
+export const memoriesListSchema = z.object({
+	memoryEntries: z.array(memoryEntrySchema),
+	pagination: paginationSchema,
+})
+
+export type MemoriesList = z.infer<typeof memoriesListSchema>
+
 // ViewMessage — discriminated union returned by app tools as `structuredContent`.
 // The widget uses an exhaustive switch on `view` to dispatch to the correct view component.
 // Adding a new view here is a compile error in App.tsx until the case is handled.


### PR DESCRIPTION
## Problem

The MCP `listMemories` tool fails with:

```
data/memoryEntries/45 must NOT have additional properties
```

## Root cause

`listMemories` parsed the `/v4/memories/list` response in the client with a **loose** `z.looseObject` schema (keeps unknown keys), then validated the result against a **separate, strict** output schema in the tool (`additionalProperties: false`). The API returns extra per-entry fields (`spaceId`, `orgId`, `metadata`, `memoryRelations`, `temporalContext`, `forgetReason`, `forgetAfter`, `parentMemoryId`, `rootMemoryId`) that passed the loose parse and then tripped the strict validator. The index (`45`) is just the first entry carrying one.

The deeper cause: **two hand-maintained copies** of the memory-entry shape (loose in the client, strict in the tool) that drifted apart.

## Fix + prevention

1. Switch the parse schemas to `z.object` (strips unknown keys on parse, without throwing) so parsed data matches the strict output contract while still tolerating new API fields.
2. **Consolidate** the entry / history / list schemas into a single source of truth in `shared/types.ts`. The client parser and the tool output schema now reference the *same* objects, so they can't diverge again.

## Audit of the other 14 tools

Checked every tool with an `outputSchema`. **Only `listMemories` was affected.** The rest are safe by one of two mechanisms:

- **Explicit field projection** (no raw spread into a strict schema): `listDocuments`, `getDocument`, `search_memory`, `listContainerTags`, `whoAmI`, `addMemory`, `saveMemory`, `setActiveTag`, `uploadFile`, `guidedSave`, `prepareFileUpload`.
- **Loose-parsed data validated against the same loose schema** (`additionalProperties` allowed on both sides): `fetchGraphData`, `memoryGraph`, `selectSpace`.

## Verification

- `tsc --noEmit` clean (main + widget configs).
- `biome check` clean on changed files.
- 17/17 unit tests pass (Vitest).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Schema consolidation and stricter parse-time stripping for one MCP tool; no auth, persistence, or API behavior changes beyond fixing validation.
> 
> **Overview**
> Fixes **`listMemories`** failing with Ajv errors (`memoryEntries/N must NOT have additional properties`) when `/v4/memories/list` returns extra per-entry fields beyond the strict MCP output contract.
> 
> **Memory-entry shapes** (`memoryEntry`, history, list) are moved to **`shared/types.ts`** as the single source of truth. The API client parser and **`listMemoriesOutputSchema`** both use **`memoriesListSchema`**, so the two definitions cannot drift again.
> 
> Parsing switches from **`z.looseObject`** (kept unknown API keys) to **`z.object`** (strips unknown keys on parse without throwing), so parsed data matches the strict tool output while still tolerating new API fields.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 966c0d259b20709873ade27941855bf642064cac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->