### PR TITLE
fix(web): scope the ?view=mcp guest exemption to /

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -41,13 +41,14 @@ export default async function proxy(request: Request) {
 		return NextResponse.next()
 	}
 
-	// MCP setup page is public — no auth required
-	if (url.searchParams.get("view") === "mcp") {
-		return NextResponse.next()
-	}
-
-	// Integrations index is public in guest mode; actions still require login.
-	if (url.pathname === "/" && url.searchParams.get("view") === "integrations") {
+	// Integrations index and MCP setup are public in guest mode; actions still
+	// require login. The ?view param is only meaningful at "/" (see
+	// lib/view-mode-context, which ignores it elsewhere), so scope it there —
+	// unscoped, ?view=mcp would let any path skip the /api/ gate below.
+	if (
+		url.pathname === "/" &&
+		["integrations", "mcp"].includes(url.searchParams.get("view") ?? "")
+	) {
 		return NextResponse.next()
 	}
 


### PR DESCRIPTION
Fixes #1540.

## Why?

The MCP-setup exemption in `apps/web/middleware.ts` was checked **before** the `/api/` session gate and was not scoped to any path:

```ts
if (url.searchParams.get("view") === "mcp") {
    return NextResponse.next()          // unscoped, runs first
}
...
if (url.pathname.startsWith("/api/")) {
    if (!sessionCookie) return 401       // never reached when view=mcp
}
```

Every other public exemption in the file is already scoped to a path (`pathname === "/" && view=integrations`, `/integrations`, `/integrations/mcp`). This one was the odd one out, so appending `?view=mcp` to any URL under the matcher skipped authentication entirely.

`apps/web/app/api/onboarding/*` is covered by the matcher — its negative lookahead excludes `/onboarding`, not `/api/onboarding` — which left two paid endpoints open to unauthenticated callers, with no rate limit and no attribution:

- `POST /api/onboarding/research?view=mcp` → xAI Grok via `generateText`
- `POST /api/onboarding/extract-content?view=mcp` → the Exa API

## What?

Scope the `?view=` exemption to `/` and fold the `integrations` and `mcp` cases into one check.

The `?view` param is only meaningful at `/` — `lib/view-mode-context.tsx` returns early for any other pathname (`if (pathname !== "/") return`) and forwards legacy `/?view=mcp` to its real path — so scoping the check there loses nothing.

The resulting guest-visible surface now matches `components/ensure-workspace.tsx`, the client-side counterpart, exactly:

```ts
// ensure-workspace.tsx — unchanged, already correct
pathname === "/integrations" ||
pathname === "/integrations/mcp" ||
(pathname === "/" && ["integrations", "mcp"].includes(searchParams.get("view") ?? ""))
```

## Testing

`apps/web` has no test runner wired up, so I verified the predicate out-of-band rather than adding vitest and a config to the app for a single guard — happy to add the harness if you'd prefer the regression pinned down in CI.

Old vs. new predicate across the relevant URLs:

```
ok   public=true  (was true ) /?view=mcp
ok   public=true  (was true ) /?view=integrations
ok   public=true  (was true ) /integrations
ok   public=true  (was true ) /integrations/mcp
ok   public=false (was true ) /api/onboarding/research?view=mcp
ok   public=false (was true ) /api/onboarding/extract-content?view=mcp
ok   public=false (was true ) /api/og?view=mcp
ok   public=false (was true ) /settings?view=mcp
ok   public=false (was true ) /brain?view=mcp
ok   public=false (was false) /api/onboarding/research
ok   public=false (was false) /settings
```

All four legitimately-public URLs stay public; the five bypass URLs become gated; already-gated paths are untouched.

`tsc --noEmit` reports no errors in `middleware.ts`. (The app has ~90 pre-existing type errors elsewhere — see #1544 — none of them in this file, and none added here.)
