### PR TITLE
fix(web): unwrap the iOS Shortcut API key from the better-auth result

### DIFF
--- a/apps/web/components/settings/integrations.tsx
+++ b/apps/web/components/settings/integrations.tsx
@@ -144,15 +144,22 @@ export default function Integrations() {
 
 	const createApiKeyMutation = useMutation({
 		mutationFn: async () => {
+			if (!org?.id) {
+				throw new Error("Organization ID is required")
+			}
+
 			const res = await authClient.apiKey.create({
 				metadata: {
-					organizationId: org?.id,
+					organizationId: org.id,
 					type: "ios-shortcut",
 				},
 				name: `ios-${generateId().slice(0, 8)}`,
-				prefix: `sm_${org?.id}_`,
+				prefix: `sm_${org.id}_`,
 			})
-			return res.key
+			if (res.error)
+				throw new Error(res.error.message ?? "Failed to create API key")
+			if (!res.data?.key) throw new Error("API key missing from response")
+			return res.data.key
 		},
 		onSuccess: (key) => {
 			setApiKey(key)


### PR DESCRIPTION
Fixes #1541.

## Why?

`authClient.apiKey.create()` resolves to `{ data, error }`, not the key object directly. The iOS Shortcut mutation in `components/settings/integrations.tsx` unwrapped it wrong:

```ts
const res = await authClient.apiKey.create({ ... })
return res.key            // always undefined
```

Because `undefined` is a perfectly good resolved value, the mutation still *succeeded*. `onSuccess` then ran `setApiKey(undefined)`, opened the modal, and called `handleCopyApiKey(undefined)` — so the user gets an empty key field and a clipboard copy that silently no-ops, with no error anywhere. A server-side failure was invisible for the same reason: nothing threw, so `onError` never fired.

A key *is* created server-side on every attempt, so retrying leaves orphaned keys on the org.

This was the last remaining call site with the bug — the other four already unwrap correctly, including the Raycast mutation 20 lines below it in the same file:

| Call site | Handling |
|---|---|
| `integrations/raycast-detail.tsx:61` | `res.data.key` |
| `integrations/shortcuts-detail.tsx:89` | `res.data.key` |
| `settings/api-keys.tsx:196` | `extractCreatedKey(res)` |
| `settings/integrations.tsx:187` (Raycast) | `res.data.key` |
| **`settings/integrations.tsx:155` (iOS Shortcut)** | **`res.key`** |

## What?

Adopt the shape the three sibling mutations already use — surface `res.error`, guard the missing key, return `res.data.key`:

```ts
if (res.error)
    throw new Error(res.error.message ?? "Failed to create API key")
if (!res.data?.key) throw new Error("API key missing from response")
return res.data.key
```

Also guard `org?.id` up front, matching that same Raycast mutation. The prefix template interpolated an undefined org id into the literal string `"sm_undefined_"` rather than failing — a second, quieter defect in the same six lines.

No behavioural change to the Raycast path, the modal, or the copy handler.

## Testing

`apps/web` has no test runner wired up, so I verified the unwrap out-of-band rather than adding vitest and a config to the app for one mutation — happy to add the harness if you'd prefer it pinned in CI.

Old vs. new against a `{ data, error }` result:

```
ok   old: success -> key      returned undefined            <-- modal gets no key
ok   new: success -> key      returned "sm_org_abc_livekey"
ok   old: failure -> silent   returned undefined            <-- onError never fires
ok   new: failure -> throws   threw "quota exceeded"
```

`tsc --noEmit` on `apps/web` goes from **84 errors to 83** — the one removed is exactly this line:

```
components/settings/integrations.tsx(155,15): error TS2339:
  Property 'key' does not exist on type 'Data<{ key: string; ... }> | Error$1<...>'
```

No new errors. (The remaining 83 are pre-existing and unrelated — see #1544.)
