### PR TITLE
fix(browser-extension): run wxt prepare before type checking

### DIFF
--- a/apps/browser-extension/package.json
+++ b/apps/browser-extension/package.json
@@ -9,10 +9,9 @@
 		"dev:firefox": "wxt -b firefox",
 		"build": "wxt build",
 		"build:firefox": "wxt build -b firefox",
-		"check-types": "bun run compile",
+		"check-types": "wxt prepare && tsc --noEmit",
 		"zip": "wxt zip",
 		"zip:firefox": "wxt zip -b firefox",
-		"compile": "tsc --noEmit",
 		"postinstall": "wxt prepare"
 	},
 	"dependencies": {


### PR DESCRIPTION
Fixes #1552

## Problem
`check-types` invoked `tsc` directly, but the `PublicPath` union that types
`browser.runtime.getURL()` lives in the gitignored `.wxt/types/paths.d.ts`,
which was generated only by `postinstall`. Any change to `public/` or
`entrypoints/` left those types stale until the next reinstall, so
`tsc --noEmit` failed with errors pointing at correct source.

## Fix
Run `wxt prepare` as part of `check-types` so the task regenerates its own
prerequisites, mirroring `supermemory-mcp`, whose `check-types` already runs
its `build:widget` prerequisite. The separate `compile` script is folded in,
as it had no other callers.

## Verification
Verified against the exact lockfile toolchain (`wxt@0.20.18`, `typescript@5.8.3`):

- New `public/` asset without reinstall the reported failure now passes
- Also fixes new `public/` subdirectories, new HTML entrypoints, and newly
  auto-imported utils, which failed the same way
- Fresh clone with no `.wxt` at all now works (previously `TS5083`)
- Deleted-but-referenced assets and genuine type errors still fail correctly 
  the exit code propagates through `&&`, so nothing is masked
- `turbo run check-types` passes, and adding a `public/` file produces a cache
  miss, so `wxt prepare` genuinely re-runs rather than replaying a stale hit

CI is unaffected either way, since it installs before checking.
