### PR TITLE
fix(mcp): handle transient session endpoint failures without invalidating token

### DIFF
--- a/apps/mcp/src/server/auth/index.test.ts
+++ b/apps/mcp/src/server/auth/index.test.ts
@@ -172,6 +172,30 @@ describe("MCP authentication", () => {
 		).resolves.toBeNull()
 	})
 
+	it("rejects an API key when the session endpoint returns 403", async () => {
+		vi.spyOn(console, "error").mockImplementation(() => {})
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(new Response(null, { status: 403 })),
+		)
+
+		await expect(
+			validateApiKey("sm_forbidden_key_0123456789abcdef", API_URL),
+		).resolves.toBeNull()
+	})
+
+	it("propagates transient session endpoint failures (500/network errors)", async () => {
+		vi.spyOn(console, "error").mockImplementation(() => {})
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(new Response(null, { status: 500 })),
+		)
+
+		await expect(
+			validateApiKey("sm_transient_key_0123456789abcdef", API_URL),
+		).rejects.toMatchObject({ status: 500 })
+	})
+
 	it("rejects malformed API keys without an API request", async () => {
 		const fetchSpy = vi.fn()
 		vi.stubGlobal("fetch", fetchSpy)

--- a/apps/mcp/src/server/auth/index.ts
+++ b/apps/mcp/src/server/auth/index.ts
@@ -92,8 +92,17 @@ export async function validateApiKey(
 		})
 		return user
 	} catch (error) {
-		console.error("API key validation error:", error)
-		return null
+		if (
+			typeof error === "object" &&
+			error !== null &&
+			"status" in error &&
+			(error.status === 401 || error.status === 403)
+		) {
+			console.error("API key validation error:", error)
+			return null
+		}
+		console.error("API key validation transient error:", error)
+		throw error
 	}
 }
 

--- a/apps/mcp/src/server/index.ts
+++ b/apps/mcp/src/server/index.ts
@@ -128,6 +128,26 @@ function authInfoFor(
 	}
 }
 
+function authUnavailableResponse(): Response {
+	return Response.json(
+		{
+			jsonrpc: "2.0",
+			error: {
+				code: -32000,
+				message: "Authentication service unavailable",
+			},
+			id: null,
+		},
+		{
+			status: 503,
+			headers: {
+				"Access-Control-Expose-Headers": "WWW-Authenticate",
+				"Access-Control-Allow-Origin": "*",
+			},
+		},
+	)
+}
+
 function unauthorizedResponse(
 	resourceMetadataUrl: string,
 	invalidToken = false,
@@ -181,9 +201,15 @@ async function handleMcpRequest(
 
 	if (!token) return unauthorizedResponse(resourceMetadataUrl)
 
-	const authUser = isApiKey(token)
-		? await validateApiKey(token, apiUrl)
-		: await validateOAuthToken(token, apiUrl, mcpResource)
+	const authUser = await (isApiKey(token)
+		? validateApiKey(token, apiUrl)
+		: validateOAuthToken(token, apiUrl, mcpResource)
+	).catch((error) => {
+		console.error("Authentication service unavailable:", error)
+		return undefined
+	})
+
+	if (authUser === undefined) return authUnavailableResponse()
 	if (!authUser) return unauthorizedResponse(resourceMetadataUrl, true)
 
 	const actor: ActorContext = {


### PR DESCRIPTION
## Description
Fixes #1551

Previously, `validateApiKey` collapsed all errors from `fetchSession` into `null`, which caused `handleMcpRequest` to return `401 Unauthorized` with `WWW-Authenticate: Bearer error="invalid_token"`. This misled MCP clients into discarding valid API keys during transient backend errors (e.g. 500s, Hyperdrive blips, or timeouts) and forcing users through a browser re-auth flow.

### Changes
1. **`apps/mcp/src/server/auth/index.ts`**:
   - Only return `null` when the session endpoint returns an explicit rejection (`401` or `403`).
   - Propagate transient errors (5xx, timeouts, network issues).
2. **`apps/mcp/src/server/index.ts`**:
   - Added `authUnavailableResponse()` returning `503 Service Unavailable` with JSON-RPC error code `-32000` and message `"Authentication service unavailable"` (without `error="invalid_token"`).
   - Caught transient authentication failures in `handleMcpRequest` and returned the 503 response so MCP clients know to retry instead of clearing credentials.
3. **`apps/mcp/src/server/auth/index.test.ts`**:
   - Added unit test cases verifying 403 status returns `null` and 500 status propagates the error.

## Verification
- Ran `bun run test:unit` in `apps/mcp` (all 23 tests passing).
- Ran `bun run check-types` (clean, no type errors).
- Ran `bunx biome check apps/mcp` (clean, no formatting or lint errors).