### PR TITLE
fix(browser-extension): guard project name against null textContent

### DIFF
--- a/apps/browser-extension/utils/ui-components.ts
+++ b/apps/browser-extension/utils/ui-components.ts
@@ -605,7 +605,7 @@ export function createProjectSelectionModal(
 		if (selectedOption.value) {
 			const selectedProject = {
 				id: selectedOption.value,
-				name: selectedOption.textContent,
+				name: selectedOption.textContent || "",
 				containerTag: selectedOption.dataset.containerTag || "",
 			}
 			onImport(selectedProject)


### PR DESCRIPTION
Fixes #1561

## Problem
`createProjectSelectionModal` declares its `onImport` callback with a
non-nullable `name` (utils/ui-components.ts:405-411), but the call site passed
`Node.textContent`, which is typed `string | null`. WXT's generated tsconfig
sets `strict: true`, so `check-types` failed on the pinned TypeScript 5.8.3:

utils/ui-components.ts(611,13): error TS2345:
Argument of type '{ id: string; name: string | null; containerTag: string; }'
is not assignable to parameter of type '{ id: string; name: string; containerTag: string; }'.

CONTRIBUTING.md instructs contributors to run `bun run check-types`, so anyone
following the documented workflow hit this.

## Fix
Fall back to an empty string. This matches the `containerTag` line directly
below it and every other `.textContent` read in the extension all 34 of them
already guard with `|| ""` or `?.`; this was the only unguarded site.

`selectedOption.text` was considered instead, since it is typed non-nullable,
but rejected: per spec it strips and collapses whitespace, which would silently
trim project names.

## Verification
Against the exact lockfile toolchain (`wxt@0.20.18`, `typescript@5.8.3`):

- Reproduced the error on current `main`, confirmed it was the only error in
  the package, and confirmed `bun run check-types` exits 0 after the fix
- Also clean under TypeScript 5.9.3, whose DOM lib does not widen this access
- Runtime behaviour unchanged, verified with 53 assertions over real `<option>`
  elements: `textContent` is never null for these nodes, the old and new
  expressions are identical across empty, whitespace-only, padded, emoji,
  newline and 5000-character names, and whitespace is preserved
- The placeholder guard is unaffected: `selectedIndex` is never -1 and the
  `if (selectedOption.value)` check short-circuits before `name` is read
- Biome clean; all 12 existing extension unit tests pass

Runtime behaviour is unchanged this is a type-safety fix.