### PR TITLE
fix(tools): keep the forget timeout when a caller passes a signal

### DIFF
--- a/packages/tools/src/shared/forget-memory.ts
+++ b/packages/tools/src/shared/forget-memory.ts
@@ -33,7 +33,12 @@ export async function forgetMemoryRequest(
 			Authorization: `Bearer ${apiKey}`,
 		},
 		body: JSON.stringify(params),
-		signal: options?.signal ?? AbortSignal.timeout(FETCH_TIMEOUT_MS),
+		signal: options?.signal
+			? AbortSignal.any([
+					options.signal,
+					AbortSignal.timeout(FETCH_TIMEOUT_MS),
+				])
+			: AbortSignal.timeout(FETCH_TIMEOUT_MS),
 	})
 
 	if (!response.ok) {

--- a/packages/tools/src/shared/forget-memory.ts
+++ b/packages/tools/src/shared/forget-memory.ts
@@ -34,10 +34,7 @@ export async function forgetMemoryRequest(
 		},
 		body: JSON.stringify(params),
 		signal: options?.signal
-			? AbortSignal.any([
-					options.signal,
-					AbortSignal.timeout(FETCH_TIMEOUT_MS),
-				])
+			? AbortSignal.any([options.signal, AbortSignal.timeout(FETCH_TIMEOUT_MS)])
 			: AbortSignal.timeout(FETCH_TIMEOUT_MS),
 	})
 

--- a/packages/tools/src/tool-operations.test.ts
+++ b/packages/tools/src/tool-operations.test.ts
@@ -112,7 +112,7 @@ describe("memoryForget", () => {
 		expect(init.signal).toBeInstanceOf(AbortSignal)
 	})
 
-	it("uses a caller-provided signal instead of creating a timeout", async () => {
+	it("keeps the timeout when the caller provides a signal", async () => {
 		const fetchMock = stubFetch()
 		const controller = new AbortController()
 
@@ -124,7 +124,10 @@ describe("memoryForget", () => {
 		)
 
 		const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
-		expect(init.signal).toBe(controller.signal)
+		// A composed signal, not the caller's — so the 30s timeout still applies.
+		expect(init.signal).not.toBe(controller.signal)
+		controller.abort()
+		expect(init.signal?.aborted).toBe(true)
 	})
 
 	it("throws a descriptive error on non-2xx responses", async () => {


### PR DESCRIPTION
Fixes #1549

## Problem

`forgetMemoryRequest` picked between the caller's signal and the 30s abort with `??`:

```ts
signal: options?.signal ?? AbortSignal.timeout(FETCH_TIMEOUT_MS),
```

The two are mutually exclusive that way, so passing a cancellation signal silently drops the timeout and a hung `DELETE /v4/memories` can wedge the tool call again — the condition #1451 added the timeout to remove. There was also no way for a caller to ask for both.

Latent today: no production call site passes `options` (`ai-sdk.ts:332` and `openai/tools.ts:490` both omit it). It becomes a real hang the first time cancellation gets wired up.

## Fix

Compose the signals with `AbortSignal.any` instead of choosing between them, so cancellation and the timeout are both live. Available in Node 20+ (the repo's `engines` floor), Bun, and workerd.

## Test

Updated the existing signal case in `packages/tools/src/tool-operations.test.ts` to assert the composed behaviour: the signal handed to `fetch` is no longer the caller's (so the timeout is still attached), and aborting the caller's controller still aborts the request. All 14 tests in the file pass.

## Note (not in this PR)

`apps/mcp/src/server/client/index.ts:369` (`getDocuments`) has the identical `??` pattern. No caller there passes `options` either, so it's the same latent bug in a separate package — left out to keep this diff scoped to the issue; happy to fold it in if you'd prefer one PR.
