### PR TITLE
fix(tools): keep the forget-memory timeout when a caller passes a signal

### DIFF
--- a/packages/tools/src/shared/forget-memory.ts
+++ b/packages/tools/src/shared/forget-memory.ts
@@ -26,6 +26,7 @@ export async function forgetMemoryRequest(
 	baseUrl: string = DEFAULT_BASE_URL,
 	options?: ForgetMemoryRequestOptions,
 ): Promise<void> {
+	const timeoutSignal = AbortSignal.timeout(FETCH_TIMEOUT_MS)
 	const response = await fetch(`${baseUrl}/v4/memories`, {
 		method: "DELETE",
 		headers: {
@@ -33,7 +34,9 @@ export async function forgetMemoryRequest(
 			Authorization: `Bearer ${apiKey}`,
 		},
 		body: JSON.stringify(params),
-		signal: options?.signal ?? AbortSignal.timeout(FETCH_TIMEOUT_MS),
+		signal: options?.signal
+			? AbortSignal.any([options.signal, timeoutSignal])
+			: timeoutSignal,
 	})
 
 	if (!response.ok) {

--- a/packages/tools/src/tool-operations.test.ts
+++ b/packages/tools/src/tool-operations.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { beforeEach, describe, expect, it, onTestFinished, vi } from "vitest"
 
 // Mock the Supermemory SDK (same pattern as claude-memory.test.ts) so tool
 // executions can be verified deterministically without network access.
@@ -88,6 +88,20 @@ describe("memoryForget", () => {
 		return fetchMock
 	}
 
+	function forget(options?: { signal?: AbortSignal }) {
+		return forgetMemoryRequest(
+			API_KEY,
+			{ containerTag: "user_1", id: "mem_1" },
+			undefined,
+			options,
+		)
+	}
+
+	function signalOf(fetchMock: ReturnType<typeof stubFetch>) {
+		const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+		return init.signal as AbortSignal
+	}
+
 	it("issues DELETE /v4/memories with the forget payload", async () => {
 		const fetchMock = stubFetch()
 
@@ -112,27 +126,78 @@ describe("memoryForget", () => {
 		expect(init.signal).toBeInstanceOf(AbortSignal)
 	})
 
-	it("uses a caller-provided signal instead of creating a timeout", async () => {
+	it("composes a caller-provided signal with the timeout", async () => {
 		const fetchMock = stubFetch()
 		const controller = new AbortController()
 
-		await forgetMemoryRequest(
-			API_KEY,
-			{ containerTag: "user_1", id: "mem_1" },
-			undefined,
-			{ signal: controller.signal },
+		await forget({ signal: controller.signal })
+
+		const signal = signalOf(fetchMock)
+		expect(signal).not.toBe(controller.signal)
+		expect(signal.aborted).toBe(false)
+
+		const reason = new Error("caller cancelled")
+		controller.abort(reason)
+		expect(signal.aborted).toBe(true)
+		expect(signal.reason).toBe(reason)
+	})
+
+	it("still times out while a caller-provided signal stays open", async () => {
+		const realTimeout = AbortSignal.timeout.bind(AbortSignal)
+		const timeout = vi
+			.spyOn(AbortSignal, "timeout")
+			.mockImplementation(() => realTimeout(5))
+		onTestFinished(() => timeout.mockRestore())
+		const fetchMock = stubFetch()
+		const controller = new AbortController()
+
+		await forget({ signal: controller.signal })
+
+		expect(timeout).toHaveBeenCalledWith(30_000)
+		const signal = signalOf(fetchMock)
+		await vi.waitFor(() => expect(signal.aborted).toBe(true))
+		expect((signal.reason as Error).name).toBe("TimeoutError")
+		expect(controller.signal.aborted).toBe(false)
+	})
+
+	it("forwards an already-aborted caller signal", async () => {
+		const fetchMock = stubFetch()
+		const reason = new Error("cancelled before dispatch")
+
+		await forget({ signal: AbortSignal.abort(reason) })
+
+		expect(signalOf(fetchMock).aborted).toBe(true)
+		expect(signalOf(fetchMock).reason).toBe(reason)
+	})
+
+	it("uses the bare timeout when options carry no signal", async () => {
+		const timeout = vi.spyOn(AbortSignal, "timeout")
+		onTestFinished(() => timeout.mockRestore())
+		const fetchMock = stubFetch()
+
+		await forget({})
+
+		expect(timeout).toHaveBeenCalledWith(30_000)
+		expect(signalOf(fetchMock)).toBe(timeout.mock.results[0]?.value)
+	})
+
+	it("surfaces an aborted request to the caller", async () => {
+		vi.stubGlobal(
+			"fetch",
+			vi
+				.fn()
+				.mockRejectedValue(
+					new DOMException("The operation timed out", "TimeoutError"),
+				),
 		)
 
-		const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
-		expect(init.signal).toBe(controller.signal)
+		await expect(forget()).rejects.toThrow("The operation timed out")
 	})
 
 	it("throws a descriptive error on non-2xx responses", async () => {
 		stubFetch(new Response("nope", { status: 401, statusText: "Unauthorized" }))
 
-		await expect(
-			forgetMemoryRequest(API_KEY, { containerTag: "user_1", id: "mem_1" }),
-		).rejects.toThrow(/401/)
+		await expect(forget()).rejects.toThrow(/401/)
 	})
 
 	it("ai-sdk tool forgets by content through the endpoint", async () => {


### PR DESCRIPTION
Closes #1549

### Problem

#1451 bounded `DELETE /v4/memories` with a 30-second abort, but the caller
signal and the timeout were selected between with `??`:

    signal: options?.signal ?? AbortSignal.timeout(FETCH_TIMEOUT_MS)

They were mutually exclusive. Passing a cancellation signal silently dropped
the timeout and the request became unbounded again - the exact hang #1451 set
out to remove - with no way to ask for both through the API. Latent today
(`ai-sdk.ts:332` and `openai/tools.ts:490` both omit `options`), live the
moment anyone wires up cancellation.

### Fix

Compose the two with `AbortSignal.any`, building the timeout signal once so
the bare path reuses it. `AbortSignal.any` is available in Node 20+ (the
repo's engines floor), Bun, and workerd.

### Test

`tool-operations.test.ts` replaces the case that asserted the old select-one
behaviour with five:

- the caller signal is composed rather than substituted, and its abort reason
  reaches the request
- the timeout still fires while the caller signal stays open
- an already-aborted caller signal is forwarded with its reason
- the bare path still receives the 30s timeout signal itself, not a composition
- an aborted `fetch` surfaces to the caller rather than being swallowed

18 tests in the file pass. The timeout case spies on `AbortSignal.timeout`
(shortened to 5ms) while asserting the code still requested `30_000` - Node
captures its internal timer at module load, so fake timers cannot intercept
`AbortSignal.timeout`.

Each case was checked against mutants of the fix, so the suite fails for a
wrong-but-plausible fix and not only for a full revert:

| mutant | result |
|---|---|
| `AbortSignal.any([options.signal])` - timeout leg dropped | 1 case fails |
| composed with a signal that never fires | 1 case fails |
| revert to `options?.signal ?? ...` | 2 cases fail |
| timeout shortened to 300ms | 2 cases fail |
| the fix as submitted | 18/18 pass |

### Verification against a real socket

Against a server that accepts the connection and never responds:

| scenario | before | after |
|---|---|---|
| caller signal present, never aborts | hangs indefinitely | `TimeoutError` at the deadline |
| no caller signal | `TimeoutError` | `TimeoutError` |
| caller aborts early | `AbortError` | `AbortError` |
| already-aborted caller signal | immediate `AbortError` | immediate `AbortError` |
| 200 response with a caller signal | resolves | resolves |

### Note (not in this PR)

`apps/mcp/src/server/client/index.ts:370` (`getDocuments`) has the identical
`??` pattern and is equally latent - no caller there passes `options` either.
Left out to keep this diff scoped to the issue and to avoid colliding with
#1564, which already touches that file.
