### PR TITLE
fix(web): import Chrome extension URL through the mapped @lib alias

### DIFF
--- a/apps/web/components/integrations/chrome-detail.tsx
+++ b/apps/web/components/integrations/chrome-detail.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { CHROME_EXTENSION_URL } from "@repo/lib/constants"
+import { CHROME_EXTENSION_URL } from "@lib/constants"
 import { cn } from "@lib/utils"
 import { dmSans125ClassName } from "@/lib/fonts"
 import { ChromeIcon } from "@/components/integration-icons"

--- a/apps/web/components/nova/nova-empty-state.tsx
+++ b/apps/web/components/nova/nova-empty-state.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { CHROME_EXTENSION_URL } from "@repo/lib/constants"
+import { CHROME_EXTENSION_URL } from "@lib/constants"
 import type { IntegrationParamValue } from "@/lib/search-params"
 import { cn } from "@lib/utils"
 import { dmSansClassName } from "@/lib/fonts"

--- a/apps/web/components/onboarding/x-bookmarks-detail-view.tsx
+++ b/apps/web/components/onboarding/x-bookmarks-detail-view.tsx
@@ -4,7 +4,7 @@ import { Button } from "@ui/components/button"
 import { cn } from "@lib/utils"
 import { dmSansClassName } from "@/lib/fonts"
 import Image from "next/image"
-import { CHROME_EXTENSION_URL } from "@repo/lib/constants"
+import { CHROME_EXTENSION_URL } from "@lib/constants"
 
 interface XBookmarksDetailViewProps {
 	onBack: () => void


### PR DESCRIPTION
Fixes #1548

## Problem

Three components import the Chrome extension URL through an alias nothing can resolve:

```ts
import { CHROME_EXTENSION_URL } from "@repo/lib/constants"
```

`apps/web/tsconfig.json` maps `@/*`, `@ui/*`, `@repo/ui/*`, `@lib/*` and `@hooks/*` — but not `@repo/lib/*`. Resolution falls through to the package's own exports map (`{"./*": "./*"}`), which points at the extensionless `packages/lib/constants`; the file is `constants.ts`, and `bundler` resolution does not append extensions after an exports-map substitution.

Webpack/Turbopack are more permissive, so this still bundles at runtime — but `tsc --noEmit` reports TS2307 on all three, part of what keeps `check-types` red (#1544).

## Fix

Switch the three imports to `@lib/constants`, the alias every other consumer already uses (`app/(app)/brain/page.tsx`, `components/app-experience.tsx`, `components/dashboard-view.tsx`, …). Adding a fourth `@repo/lib/*` mapping for the same package would work too, but matching the existing convention is the smaller change.

Files:
- `apps/web/components/integrations/chrome-detail.tsx`
- `apps/web/components/nova/nova-empty-state.tsx`
- `apps/web/components/onboarding/x-bookmarks-detail-view.tsx`

## Verification

`tsc --noEmit` on `apps/web` before and after: the three TS2307 errors are gone and nothing new appears — the remaining errors are identical to `main`. `biome ci --changed` exits 0.
