### PR TITLE
fix(web): keep personal connector action visible

### DIFF
--- a/apps/web/components/settings/company-brain-connections.tsx
+++ b/apps/web/components/settings/company-brain-connections.tsx
@@ -984,9 +984,16 @@ export default function CompanyBrainConnections() {
 												>
 													Disconnect
 												</DropdownMenuItem>
+											) : orgConnected ? (
+												<DropdownMenuItem
+													className={menuItemClass}
+													onClick={() => connect(entry, false)}
+												>
+													Connect my account
+												</DropdownMenuItem>
 											) : (
 												<DropdownMenuItem disabled className={menuItemClass}>
-													Managed by workspace admins
+													Not connected
 												</DropdownMenuItem>
 											)}
 										</InstalledTile>


### PR DESCRIPTION
<!-- VORFLUX_AGENT_PR_BODY_BEGIN -->
Restores the personal connector action in the compact Installed tile for non-admin users whose workspace already has the connector installed.

## Changes

- Show **Connect my account** when the workspace connection is active but the current user has not connected personally.
- Keep workspace administration controls restricted to admins.
- Retain the personal disconnect action when the current user is already connected.

## Testing

- `bunx biome check apps/web/components/settings/company-brain-connections.tsx`
- `git diff --check origin/main...HEAD`
- Reviewed the installed-tile state branches for admin, personal-only, and workspace-only connection states.
- Repository-wide `apps/web` TypeScript checking remains blocked by existing unrelated errors; none reference the touched component.

This is a follow-up to the review on merged PR https://github.com/supermemoryai/supermemory/pull/1461.

<!-- VORFLUX_AGENT_PR_BODY_END -->

---
**Session Details**
- Session: [View Session](https://supermemory.us1.vorflux.com/agent-sessions/1cd0aab9-2a45-4818-aa13-f9bfe032ddba)
- Requested by: Dhravya Shah (dhravya@supermemory.com)
- Address comments on this PR. Add `(aside)` to your comment to have me ignore it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small settings-menu UX fix for existing connect/disconnect flows; no auth, API, or permission-model changes.
> 
> **Overview**
> Non-admin users can now connect a **personal** account from the compact Installed tile when the workspace already has that connector.
> 
> Previously that state showed a disabled “Managed by workspace admins” item. It now offers **Connect my account**. Personal disconnect stays when the user is already connected; the leftover empty state is labeled **Not connected**. Admin workspace controls are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69d95ab2d960f77dfa3776615a8673cf88f49fec. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->