### PR TITLE
fix(tools): export the promptTemplate types from @supermemory/tools/ai-sdk

### DIFF
--- a/packages/tools/src/ai-sdk-exports.test.ts
+++ b/packages/tools/src/ai-sdk-exports.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from "vitest"
+import {
+	type MemoryPromptData,
+	type PromptTemplate,
+	type WithSupermemoryOptions,
+	withSupermemory,
+} from "./ai-sdk"
+
+// The documented custom prompt-template example (packages/tools/README.md and
+// apps/docs/integrations/ai-sdk.mdx) imports these types from this entry point.
+// `./vercel` is not listed in the package's `exports` map, so there is nowhere
+// else a consumer can reach them from: dropping the re-export again breaks
+// every documented `promptTemplate` snippet at compile time. Importing and
+// using them here makes `check-types` fail if that happens.
+describe("@supermemory/tools/ai-sdk public surface", () => {
+	it("re-exports the middleware wrapper", () => {
+		expect(typeof withSupermemory).toBe("function")
+	})
+
+	it("types the documented promptTemplate example", () => {
+		const claudePrompt: PromptTemplate = (data: MemoryPromptData) =>
+			`<context><user_profile>${data.userMemories}</user_profile><relevant_memories>${data.generalSearchMemories}</relevant_memories></context>`
+
+		const options: WithSupermemoryOptions = {
+			containerTag: "user-123",
+			customId: "conv-1",
+			mode: "full",
+			promptTemplate: claudePrompt,
+		}
+
+		expect(
+			options.promptTemplate?.({
+				userMemories: "- Prefers TypeScript",
+				generalSearchMemories: "- Asked about zod",
+				searchResults: [{ memory: "Prefers TypeScript" }],
+			}),
+		).toBe(
+			"<context><user_profile>- Prefers TypeScript</user_profile><relevant_memories>- Asked about zod</relevant_memories></context>",
+		)
+	})
+})

--- a/packages/tools/src/ai-sdk.ts
+++ b/packages/tools/src/ai-sdk.ts
@@ -372,4 +372,12 @@ export function supermemoryTools(
 	}
 }
 
-export { withSupermemory } from "./vercel"
+// `./vercel` is not a published subpath, so this entry point is the only way
+// consumers can reach the middleware types — including the `promptTemplate`
+// data shape used by the documented custom-template example.
+export {
+	withSupermemory,
+	type WithSupermemoryOptions,
+	type PromptTemplate,
+	type MemoryPromptData,
+} from "./vercel"


### PR DESCRIPTION
## Problem

The documented custom prompt-template example for the AI SDK integration does not compile:

```ts
import { withSupermemory, type MemoryPromptData } from "@supermemory/tools/ai-sdk"
// TS2305: Module '"@supermemory/tools/ai-sdk"' has no exported member 'MemoryPromptData'.
```

`packages/tools/src/ai-sdk.ts` re-exported only `withSupermemory` from `./vercel`, dropping the three types that entry point's own options object is built from:

- `MemoryPromptData` — TS2305
- `PromptTemplate` — TS2305
- `WithSupermemoryOptions` — TS2724

`./vercel` is not listed in the package's `exports` map, so there is nowhere else a consumer can reach them from. Every `promptTemplate` snippet that documents this entry point fails to typecheck as written:

- `packages/tools/README.md:232`
- `apps/docs/integrations/ai-sdk.mdx:97`
- `packages/docs-test/tests/integrations/ai-sdk.ts:9`

The sibling entry points already export these — `@supermemory/tools/mastra` ([`src/mastra/index.ts`](https://github.com/supermemoryai/supermemory/blob/main/packages/tools/src/mastra/index.ts)) and `@supermemory/tools/voltagent` both list `PromptTemplate` and `MemoryPromptData`. The AI SDK entry point was the only one that did not. `promptTemplate` has been documented for it since #660, and the type has never been reachable from it.

## Fix

Widen the existing re-export to cover the middleware's public types:

```ts
export {
	withSupermemory,
	type WithSupermemoryOptions,
	type PromptTemplate,
	type MemoryPromptData,
} from "./vercel"
```

Type-only addition — no runtime change, no new API surface (all three are already exported from `./vercel`).

## Regression test

`packages/tools/src/ai-sdk-exports.test.ts` imports the three types and exercises the documented template, so the re-export cannot be dropped again without `check-types` failing.

## Testing

- **`tsc --noEmit` in `packages/tools`** — before: 151 errors, 3 of them the ones a user hits when copying the documented example:
  ```
  src/ai-sdk-exports.test.ts(3,7): error TS2305: Module '"./ai-sdk"' has no exported member 'MemoryPromptData'.
  src/ai-sdk-exports.test.ts(4,7): error TS2305: Module '"./ai-sdk"' has no exported member 'PromptTemplate'.
  src/ai-sdk-exports.test.ts(5,7): error TS2724: '"./ai-sdk"' has no exported member named 'WithSupermemoryOptions'.
  ```
  After: 148 errors, none from the touched files. The remaining 148 are pre-existing and unrelated (zod v3/v4 resolution plus `test/`, tracked in #1544 / #1545).
- **`vitest run`** over the pure unit suites in `packages/tools/src` — 36/36 pass (`ai-sdk-exports`, `tools-shared`, `tool-operations`, `shared/memory-client`, `claude-memory`). `src/tools.test.ts` is excluded because it requires live `SUPERMEMORY_API_KEY` / `OPENAI_API_KEY`.
- **`tsdown` build** — emitted `dist/ai-sdk.d.ts` now carries the types:
  ```
  export { type MemoryPromptData, type PromptTemplate, type WrapVercelLanguageModelOptions as WithSupermemoryOptions, ... }
  ```
- **Biome** — clean on both files.

## Note

CI's type-check job currently filters to `@supermemory/ai-sdk` and `@supermemory/memory-graph`, so this guard won't run in CI until `@supermemory/tools` is included there (#1436 moves in that direction). It does run under the package's own `bun run check-types`.