### PR TITLE
fix(pipecat): export InputParams from the package root

### DIFF
--- a/apps/docs/integrations/pipecat.mdx
+++ b/apps/docs/integrations/pipecat.mdx
@@ -28,8 +28,7 @@ You can obtain an API key from [console.supermemory.ai](https://console.supermem
 Supermemory integration is provided through the `SupermemoryPipecatService` class in Pipecat:
 
 ```python
-from supermemory_pipecat import SupermemoryPipecatService
-from supermemory_pipecat.service import InputParams
+from supermemory_pipecat import InputParams, SupermemoryPipecatService
 
 memory = SupermemoryPipecatService(
     api_key=os.getenv("SUPERMEMORY_API_KEY"),
@@ -157,8 +156,7 @@ from pipecat.transports.websocket.fastapi import (
     FastAPIWebsocketTransport,
 )
 
-from supermemory_pipecat import SupermemoryPipecatService
-from supermemory_pipecat.service import InputParams
+from supermemory_pipecat import InputParams, SupermemoryPipecatService
 
 app = FastAPI()
 

--- a/packages/pipecat-sdk-python/src/supermemory_pipecat/__init__.py
+++ b/packages/pipecat-sdk-python/src/supermemory_pipecat/__init__.py
@@ -40,11 +40,17 @@ from .utils import (
     get_last_user_message,
 )
 
+# Exported as a top-level name for convenience, mirroring
+# supermemory_cartesia.MemoryConfig. The canonical definition stays nested on
+# the service, matching Pipecat's own `Service.InputParams` convention.
+InputParams = SupermemoryPipecatService.InputParams
+
 __version__ = "0.1.1"
 
 __all__ = [
     # Main service
     "SupermemoryPipecatService",
+    "InputParams",
     # Exceptions
     "SupermemoryPipecatError",
     "ConfigurationError",

--- a/packages/pipecat-sdk-python/tests/test_public_exports.py
+++ b/packages/pipecat-sdk-python/tests/test_public_exports.py
@@ -1,0 +1,39 @@
+"""The package's documented public names must be importable from its root.
+
+apps/docs/integrations/pipecat.mdx tells users to configure the service with
+`InputParams(...)`. `InputParams` is defined as a nested class on
+`SupermemoryPipecatService` (matching Pipecat's own `Service.InputParams`
+convention), so it is only reachable from the package root through the alias in
+`__init__.py` -- the same alias `supermemory_cartesia` provides for
+`MemoryConfig`. Without it the documented quickstart fails on its import line.
+"""
+
+from __future__ import annotations
+
+import unittest
+
+from .test_empty_profile import _install_test_stubs
+
+_install_test_stubs()
+
+import supermemory_pipecat
+from supermemory_pipecat import InputParams, SupermemoryPipecatService
+
+
+class TestPublicExports(unittest.TestCase):
+    def test_input_params_is_exported_from_the_package_root(self) -> None:
+        self.assertIn("InputParams", supermemory_pipecat.__all__)
+        self.assertIs(InputParams, SupermemoryPipecatService.InputParams)
+
+    def test_documented_configuration_example_constructs(self) -> None:
+        params = InputParams(
+            mode="full",
+            search_limit=10,
+            search_threshold=0.1,
+            system_prompt="Based on previous conversations:\n\n",
+        )
+
+        self.assertEqual(params.mode, "full")
+        self.assertEqual(params.search_limit, 10)
+        self.assertEqual(params.search_threshold, 0.1)
+        self.assertEqual(params.system_prompt, "Based on previous conversations:\n\n")


### PR DESCRIPTION
## Problem

The Pipecat quickstart in the docs fails on its second line:

```python
from supermemory_pipecat import SupermemoryPipecatService
from supermemory_pipecat.service import InputParams
# ImportError: cannot import name 'InputParams' from 'supermemory_pipecat.service'
```

`InputParams` is a nested class on `SupermemoryPipecatService` ([`service.py:54`](https://github.com/supermemoryai/supermemory/blob/main/packages/pipecat-sdk-python/src/supermemory_pipecat/service.py#L54)) — which is correct, it matches Pipecat's own `Service.InputParams` convention. But that means it is not a module-level name in `.service`, and nothing in the package exposed it either. Anyone copying the config example from docs.supermemory.ai hits an `ImportError` before reaching a single Supermemory call.

Both occurrences are affected: `apps/docs/integrations/pipecat.mdx` lines 32 and 161 (the Configuration snippet and the full FastAPI voice-bot example).

## Why the alias, not just a docs edit

`supermemory_cartesia` — the sibling SDK with the identical nested-config shape — already solves exactly this, explicitly:

```python
# packages/cartesia-sdk-python/src/supermemory_cartesia/__init__.py
# Export MemoryConfig as a top-level class for convenience
MemoryConfig = SupermemoryCartesiaAgent.MemoryConfig
```

Pipecat was the only one of the two missing it, and its docs were written as if it had it. So this restores parity rather than papering over the gap. Happy to reduce this to a docs-only change (`params=SupermemoryPipecatService.InputParams(...)`) if you'd rather not widen the export surface — just say so.

## Changes

1. `supermemory_pipecat/__init__.py` — add `InputParams = SupermemoryPipecatService.InputParams` and the `__all__` entry, mirroring cartesia.
2. `apps/docs/integrations/pipecat.mdx` — point both imports at the package root: `from supermemory_pipecat import InputParams, SupermemoryPipecatService`.
3. `tests/test_public_exports.py` — regression test.

The nested `SupermemoryPipecatService.InputParams` form used by the package's own README and `Agents.md` keeps working unchanged. No behavioural change — it's the same class object, asserted with `assertIs`.

## Testing

Run with the existing suite's dependency stubs (`_install_test_stubs`), so no `pipecat-ai` install needed:

```
$ cd packages/pipecat-sdk-python && PYTHONPATH=src python3 -m unittest discover -s . -p "test_*.py" -v
test_retrieve_memories_handles_null_profile ... ok
test_documented_configuration_example_constructs ... ok
test_input_params_is_exported_from_the_package_root ... ok
Ran 3 tests in 0.022s
OK
```

Reverting only the `__init__.py` alias reproduces the original failure, confirming the test guards the right thing:

```
ImportError: cannot import name 'InputParams' from 'supermemory_pipecat'
Ran 2 tests in 0.020s
FAILED (errors=1)
```

I also swept every `from supermemory_* import ...` line across `apps/docs/**` against each package's actual exports — this was the only broken one. (`supermemory_bash` in the SMFS pages resolves to a separately published package, not this repo.) The same sweep over documented constructor kwargs found no mismatches.


