### PR TITLE
fix(mcp): fail closed on empty scoped-key tag sets and missing accessType

### DIFF
--- a/apps/mcp/src/server/auth/rbac.test.ts
+++ b/apps/mcp/src/server/auth/rbac.test.ts
@@ -46,4 +46,38 @@ describe("effectiveContainerTagAccess", () => {
 			{ containerTag: "one", permission: "read" },
 		])
 	})
+
+	it("grants a scoped write key write on its listed tags only", () => {
+		const session: SessionInfo = {
+			...baseSession,
+			scope: {
+				type: "scoped",
+				permission: "write",
+				tags: ["one"],
+			},
+		}
+
+		expect(effectiveContainerTagAccess(["one", "two"], session)).toEqual([
+			{ containerTag: "one", permission: "write" },
+			{ containerTag: "two", permission: "read" },
+		])
+	})
+
+	it("denies everything for a scoped session with an empty tag set", () => {
+		const emptyTagsSession: SessionInfo = {
+			...baseSession,
+			scope: { type: "scoped", permission: "write", tags: [] },
+		}
+		const missingTagSession: SessionInfo = {
+			...baseSession,
+			scope: { type: "scoped", permission: "write" },
+		}
+
+		expect(effectiveContainerTagAccess(["one", "two"], emptyTagsSession)).toEqual(
+			[],
+		)
+		expect(effectiveContainerTagAccess(["one", "two"], missingTagSession)).toEqual(
+			[],
+		)
+	})
 })

--- a/apps/mcp/src/server/auth/rbac.ts
+++ b/apps/mcp/src/server/auth/rbac.ts
@@ -14,6 +14,13 @@ export function effectiveContainerTagAccess(
 		session.scope?.tags ?? (session.scope?.tag ? [session.scope.tag] : []),
 	)
 
+	// A scoped session whose tag set resolves empty must grant NOTHING:
+	// treating the empty set as "no restriction" upgraded it to org-wide
+	// write, defeating the key's purpose. Fail closed instead.
+	if (session.scope?.type === "scoped" && scopedTags.size === 0) {
+		return []
+	}
+
 	return containerTags.map((containerTag) => {
 		let permission: ContainerTagAccess["permission"] = "write"
 

--- a/apps/mcp/src/shared/types.test.ts
+++ b/apps/mcp/src/shared/types.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from "vitest"
+import { sessionInfoSchema } from "./types"
+
+describe("sessionInfoSchema", () => {
+	it("accepts a session with accessType", () => {
+		const parsed = sessionInfoSchema.safeParse({
+			user: { id: "user_test" },
+			accessType: "full",
+		})
+		expect(parsed.success).toBe(true)
+	})
+
+	it("rejects sessions without accessType (fail closed)", () => {
+		const parsed = sessionInfoSchema.safeParse({
+			user: { id: "user_test" },
+		})
+		expect(parsed.success).toBe(false)
+	})
+})

--- a/apps/mcp/src/shared/types.ts
+++ b/apps/mcp/src/shared/types.ts
@@ -29,7 +29,11 @@ export const sessionInfoSchema = z.looseObject({
 	}),
 	org: z.looseObject({ id: z.string().min(1) }).optional(),
 	role: z.string().optional(),
-	accessType: z.enum(["full", "restricted"]).optional(),
+	// Required on purpose: an absent accessType previously fell through to the
+	// "write" default in server/auth/rbac.ts, silently upgrading sessions to
+	// org-wide write. A missing field now fails session parsing (-> 401)
+	// instead of failing open.
+	accessType: z.enum(["full", "restricted"]),
 	containerTags: z.array(containerTagAccessSchema).nullable().optional(),
 	scope: sessionScopeSchema.optional(),
 })


### PR DESCRIPTION
Hi supermemory team 👋 Thanks for building such a great product! While running a security & quality audit of the repo we hit this issue and put together a small, tested fix — details below.

## Problem

MCP RBAC failed **open**:

1. `effectiveContainerTagAccess()` treated a scoped session whose scoped-tag set resolves **empty** as unrestricted → every container tag came back `"write"`.
2. `sessionInfoSchema` marked `accessType` optional, so a session missing it skipped the restricted branch entirely and inherited the `"write"` default.

Net effect: a "scoped, read-only" API key had org-wide **write** access through MCP. Part of #1578 (finding M4, high severity).

## Solution

Default-deny semantics: an empty allowlist allows nothing, and a session that doesn't declare its access type is rejected at parse time rather than silently escalated.

## Changes

- `apps/mcp/src/server/auth/rbac.ts` → early-return `[]` when `scope.type === "scoped" && scopedTags.size === 0`
- `apps/mcp/src/shared/types.ts` → `accessType` now required (with comment explaining why)
- `rbac.test.ts` → +2 cases (scoped-empty denies writes; scoped key lists only its tags)
- `shared/types.test.ts` (**new**) → 2 schema cases incl. missing `accessType` rejected

## Verification

Fresh from the committed branch: `bunx vitest run src/server/auth src/shared` → **17/17 pass**, including pre-existing fixtures proving real sessions always send `accessType` (no compatibility break observed); `tsc` adds zero new errors vs baseline; Biome clean.

---
Happy to iterate on any of this — feedback and reworks very welcome! 🙏

## Environment

- macOS 26.1 (arm64) · bun 1.4.0 · node v26.7.0
- vitest 3.2.4 (workspace-pinned) · Biome lint clean
- Branch `fix/mcp-rbac-fail-closed` — all gates re-run fresh at commit `629ec2e59cb9`
