### PR TITLE
fix(validation): cap documents-with-memories limit and bulk-delete containerTags

### DIFF
--- a/packages/validation/api.test.ts
+++ b/packages/validation/api.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "bun:test"
 import { readFileSync } from "node:fs"
 import {
+	BulkDeleteMemoriesSchema,
 	DocumentsWithMemoriesQuerySchema,
 	ListMemoriesQuerySchema,
 	SearchRequestSchema,
@@ -150,5 +151,23 @@ describe("pagination query schemas", () => {
 		})
 		expect(parsed.page).toBe(2)
 		expect(parsed.limit).toBe(50)
+	})
+
+	it("DocumentsWithMemoriesQuerySchema caps limit at 100", () => {
+		expect(DocumentsWithMemoriesQuerySchema.safeParse({ limit: 101 }).success)
+			.toBe(false)
+	})
+
+	it("BulkDeleteMemoriesSchema caps containerTags at 100 entries of bounded length", () => {
+		const tooMany = {
+			containerTags: Array.from({ length: 101 }, (_, i) => `tag_${i}`),
+		}
+		expect(BulkDeleteMemoriesSchema.safeParse(tooMany).success).toBe(false)
+
+		const tagTooLong = { containerTags: ["x".repeat(257)] }
+		expect(BulkDeleteMemoriesSchema.safeParse(tagTooLong).success).toBe(false)
+
+		const ok = { containerTags: ["tag_a", "tag_b"] }
+		expect(BulkDeleteMemoriesSchema.safeParse(ok).success).toBe(true)
 	})
 })

--- a/packages/validation/api.ts
+++ b/packages/validation/api.ts
@@ -1102,8 +1102,11 @@ export const DocumentsWithMemoriesQuerySchema = z
 			description: "Page number to fetch",
 			example: 1,
 		}),
-		limit: z.number().int().min(1).default(10).openapi({
-			description: "Number of items per page",
+		// Capped like every sibling list schema (SearchRequest <= 100,
+		// ListMemories <= 1100): each row expands joined memoryEntries, so an
+		// unbounded limit here is a memory/CPU/cost amplifier.
+		limit: z.number().int().min(1).max(100).default(10).openapi({
+			description: "Number of items per page (max 100)",
 			example: 10,
 		}),
 		sort: z.enum(["createdAt", "updatedAt"]).default("createdAt").openapi({
@@ -1408,13 +1411,17 @@ export const BulkDeleteMemoriesSchema = z
 				description: "Array of memory IDs to delete (max 100 at once)",
 				example: ["acxV5LHMEsG2hMSNb4umbn", "bxcV5LHMEsG2hMSNb4umbn"],
 			}),
+		// Bounded like the ids array above: this is the most destructive
+		// operation in the schema ("delete ALL memories in these containers"),
+		// so the tag list must not be an unbounded fan-out vector.
 		containerTags: z
-			.array(z.string())
+			.array(z.string().max(256))
 			.min(1)
+			.max(100)
 			.optional()
 			.openapi({
 				description:
-					"Array of container tags - all memories in these containers will be deleted",
+					"Array of container tags - all memories in these containers will be deleted (max 100 at once)",
 				example: ["user_123", "project_123"],
 			}),
 	})


### PR DESCRIPTION
Hi supermemory team 👋 Thanks for building such a great product! While running a security & quality audit of the repo we hit this issue and put together a small, tested fix — details below.

## Problem

Two schemas in `packages/validation` missed bounds their whole schema family applies:

1. `DocumentsWithMemoriesQuerySchema.limit` had **no** `.max()` while sibling query schemas cap at 100 → unbounded row-join amplification on documents-with-memories queries.
2. `BulkDeleteMemoriesSchema.containerTags` accepted unlimited entries of unlimited length while the parallel `ids` field was capped `.max(100)` → destructive fan-out asymmetry.

Part of #1578 (finding M9).

## Solution

Align with the family's existing convention (`.max(100)`) rather than inventing new limits — minimal diff, consistent developer experience.

## Changes

- `packages/validation/src/api.ts` → `DocumentsWithMemoriesQuerySchema.limit` gains `.max(100)`
- same file → `BulkDeleteMemoriesSchema.containerTags` gains `.max(100)` items, each ≤256 chars

## Verification

Fresh from the committed branch: `bun test api.test.ts` → **29 pass**; `bunx tsc --noEmit` → exit 0; Biome clean.

---
Happy to iterate on any of this — feedback and reworks very welcome! 🙏

## Environment

- macOS 26.1 (arm64) · bun 1.4.0 · node v26.7.0
- vitest 3.2.4 (workspace-pinned) · Biome lint clean
- Branch `fix/validation-limit-caps` — all gates re-run fresh at commit `f13df7a14530`
