### PR TITLE
fix(mcp): report transient session-endpoint failures as 503, not invalid token

### DIFF
--- a/apps/mcp/src/server/auth/index.test.ts
+++ b/apps/mcp/src/server/auth/index.test.ts
@@ -1,6 +1,11 @@
 import { createLocalJWKSet, exportJWK, generateKeyPair, SignJWT } from "jose"
 import { afterEach, beforeAll, describe, expect, it, vi } from "vitest"
-import { fetchSession, validateApiKey, validateOAuthToken } from "./index"
+import {
+	fetchSession,
+	TransientAuthError,
+	validateApiKey,
+	validateOAuthToken,
+} from "./index"
 
 const API_URL = "https://api.example.com"
 const ISSUER = `${API_URL}/api/auth`
@@ -179,5 +184,35 @@ describe("MCP authentication", () => {
 		await expect(validateApiKey("sm_short", API_URL)).resolves.toBeNull()
 		await expect(validateApiKey("not_a_key", API_URL)).resolves.toBeNull()
 		expect(fetchSpy).not.toHaveBeenCalled()
+	})
+
+	it("surfaces a 500 from the session endpoint as TransientAuthError, not invalid token", async () => {
+		vi.spyOn(console, "error").mockImplementation(() => {})
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue(new Response(null, { status: 500 })),
+		)
+
+		// fetchSession attaches the upstream status; validateApiKey must
+		// rethrow it as transient instead of collapsing to null (#1551).
+		await expect(
+			validateApiKey("sm_outage_key_0123456789abcdef", API_URL),
+		).rejects.toThrow(TransientAuthError)
+	})
+
+	it("surfaces a session-endpoint timeout as TransientAuthError", async () => {
+		vi.spyOn(console, "error").mockImplementation(() => {})
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockRejectedValue(
+				Object.assign(new Error("The operation was aborted"), {
+					name: "TimeoutError",
+				}),
+			),
+		)
+
+		await expect(
+			validateApiKey("sm_timeout_key_0123456789abcd", API_URL),
+		).rejects.toThrow(TransientAuthError)
 	})
 })

--- a/apps/mcp/src/server/auth/index.ts
+++ b/apps/mcp/src/server/auth/index.ts
@@ -65,6 +65,23 @@ export function isApiKey(token: string): boolean {
 	return API_KEY_PATTERN.test(token)
 }
 
+/**
+ * API-key validation failed for a reason that is NOT an invalid key:
+ * network errors, timeouts, or a 5xx from the session endpoint. Callers must
+ * surface this as a temporary upstream failure instead of reporting
+ * "invalid token" (which makes MCP clients discard perfectly valid keys and
+ * push users through re-authentication during outages).
+ */
+export class TransientAuthError extends Error {
+	readonly status?: number
+
+	constructor(message: string, status?: number) {
+		super(message)
+		this.name = "TransientAuthError"
+		this.status = status
+	}
+}
+
 export async function validateApiKey(
 	token: string,
 	apiUrl: string,
@@ -93,6 +110,23 @@ export async function validateApiKey(
 		return user
 	} catch (error) {
 		console.error("API key validation error:", error)
+		// Distinguish "bad key" from "session endpoint unavailable": only the
+		// former should collapse to null (-> 401 invalid_token). fetchSession
+		// attaches the upstream status to its errors; timeouts surface as
+		// AbortError/TimeoutError.
+		const status = (error as { status?: unknown } | null)?.status
+		if (typeof status === "number" && status !== 401 && status !== 403) {
+			throw new TransientAuthError(
+				`Session endpoint returned ${status}`,
+				status,
+			)
+		}
+		if (
+			error instanceof Error &&
+			(error.name === "AbortError" || error.name === "TimeoutError")
+		) {
+			throw new TransientAuthError("Session request timed out")
+		}
 		return null
 	}
 }

--- a/apps/mcp/src/server/index.ts
+++ b/apps/mcp/src/server/index.ts
@@ -129,6 +129,33 @@ function authInfoFor(
 	}
 }
 
+type AuthResolution =
+	| { ok: true; user: AuthUser }
+	| { ok: false; reason: "invalid" }
+	| { ok: false; reason: "transient" }
+
+/**
+ * Resolve the request's bearer token to an AuthUser, keeping a transient
+ * upstream failure distinct from an invalid token (#1551).
+ */
+async function resolveAuthUser(
+	token: string,
+	apiUrl: string,
+	mcpResource: string,
+): Promise<AuthResolution> {
+	try {
+		const user = isApiKey(token)
+			? await validateApiKey(token, apiUrl)
+			: await validateOAuthToken(token, apiUrl, mcpResource)
+		return user ? { ok: true, user } : { ok: false, reason: "invalid" }
+	} catch (error) {
+		if (error instanceof TransientAuthError) {
+			return { ok: false, reason: "transient" }
+		}
+		throw error
+	}
+}
+
 function unauthorizedResponse(
 	resourceMetadataUrl: string,
 	invalidToken = false,
@@ -182,32 +209,26 @@ async function handleMcpRequest(
 
 	if (!token) return unauthorizedResponse(resourceMetadataUrl)
 
-	let authUser: AuthUser | null
-	try {
-		authUser = isApiKey(token)
-			? await validateApiKey(token, apiUrl)
-			: await validateOAuthToken(token, apiUrl, mcpResource)
-	} catch (error) {
+	const resolved = await resolveAuthUser(token, apiUrl, mcpResource)
+	if (!resolved.ok && resolved.reason === "transient") {
 		// A transient session-endpoint outage must not be reported as an
 		// invalid token — that makes clients discard valid sm_ keys and
 		// re-authenticate. Tell them to retry instead.
-		if (error instanceof TransientAuthError) {
-			return Response.json(
-				{
-					jsonrpc: "2.0",
-					error: {
-						code: -32001,
-						message:
-							"Authentication backend temporarily unavailable, please retry",
-					},
-					id: null,
+		return Response.json(
+			{
+				jsonrpc: "2.0",
+				error: {
+					code: -32001,
+					message:
+						"Authentication backend temporarily unavailable, please retry",
 				},
-				{ status: 503, headers: { "Retry-After": "5" } },
-			)
-		}
-		throw error
+				id: null,
+			},
+			{ status: 503, headers: { "Retry-After": "5" } },
+		)
 	}
-	if (!authUser) return unauthorizedResponse(resourceMetadataUrl, true)
+	if (!resolved.ok) return unauthorizedResponse(resourceMetadataUrl, true)
+	const authUser = resolved.user
 
 	const actor: ActorContext = {
 		userId: authUser.userId,

--- a/apps/mcp/src/server/index.ts
+++ b/apps/mcp/src/server/index.ts
@@ -4,6 +4,7 @@ import { Hono, type Context } from "hono"
 import { cors } from "hono/cors"
 import {
 	isApiKey,
+	TransientAuthError,
 	validateApiKey,
 	validateOAuthToken,
 	type AuthUser,
@@ -181,9 +182,31 @@ async function handleMcpRequest(
 
 	if (!token) return unauthorizedResponse(resourceMetadataUrl)
 
-	const authUser = isApiKey(token)
-		? await validateApiKey(token, apiUrl)
-		: await validateOAuthToken(token, apiUrl, mcpResource)
+	let authUser: AuthUser | null
+	try {
+		authUser = isApiKey(token)
+			? await validateApiKey(token, apiUrl)
+			: await validateOAuthToken(token, apiUrl, mcpResource)
+	} catch (error) {
+		// A transient session-endpoint outage must not be reported as an
+		// invalid token — that makes clients discard valid sm_ keys and
+		// re-authenticate. Tell them to retry instead.
+		if (error instanceof TransientAuthError) {
+			return Response.json(
+				{
+					jsonrpc: "2.0",
+					error: {
+						code: -32001,
+						message:
+							"Authentication backend temporarily unavailable, please retry",
+					},
+					id: null,
+				},
+				{ status: 503, headers: { "Retry-After": "5" } },
+			)
+		}
+		throw error
+	}
 	if (!authUser) return unauthorizedResponse(resourceMetadataUrl, true)
 
 	const actor: ActorContext = {


### PR DESCRIPTION
Fixes #1551.

Hi supermemory team 👋 Thanks for building such a great product! While running a security & quality audit of the repo we hit this issue and put together a small, tested fix — details below.

## Problem

`validateApiKey` collapsed **every** `fetchSession` failure — network errors, timeouts, any non-OK status — into `null`, which the transport maps to JSON-RPC `-32000 "Invalid or expired token"`. During an api.supermemory.ai/Hyperdrive outage this made MCP clients discard perfectly valid `sm_` keys and forced users through browser re-authentication at exactly the wrong moment, amplifying incidents into support load.

## Solution

Classify failures instead of collapsing them. A new `TransientAuthError` is thrown for timeouts (`AbortError`/`TimeoutError`) and upstream statuses other than 401/403; the transport maps it to a **503** JSON-RPC response with `Retry-After: 5`. Genuine rejections (401/403/schema failures/missing org) still resolve `null` → unchanged `invalid_token` behavior. Success-path caching untouched.

## Changes

- `apps/mcp/src/server/auth/index.ts` → `TransientAuthError` class + typed catch in `validateApiKey`
- `apps/mcp/src/server/index.ts` → try/catch around token validation → 503 response with `Retry-After`
- `apps/mcp/src/server/auth/index.test.ts` → +2 tests (500 → TransientAuthError; timeout → TransientAuthError)
- applied review feedback: auth resolution extracted into `resolveAuthUser()` returning a typed `AuthResolution` union — call site is all-`const`, behavior unchanged

## Verification

Fresh from the committed branch: `bunx vitest run src/server/auth` → **15/15 pass**, including the pre-existing revoked-key → `null` case proving rejection behavior is unchanged; `tsc` adds zero new errors vs baseline; Biome clean.

---
Happy to iterate on any of this — feedback and reworks very welcome! 🙏

## Environment

- macOS 26.1 (arm64) · bun 1.4.0 · node v26.7.0
- vitest 3.2.4 (workspace-pinned) · Biome lint clean
- Branch `fix/mcp-transient-session-errors` — all gates re-run fresh at commit `b561e12a27c5`
