### PR TITLE
fix(tools): compose caller abort signal with the forget-memory timeout

### DIFF
--- a/packages/tools/src/shared/forget-memory.test.ts
+++ b/packages/tools/src/shared/forget-memory.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { forgetMemoryRequest } from "./forget-memory"
+
+const originalFetch = globalThis.fetch
+
+afterEach(() => {
+	globalThis.fetch = originalFetch
+	vi.restoreAllMocks()
+})
+
+describe("forgetMemoryRequest signal composition", () => {
+	it("aborts via the caller's signal even though the 30s timeout is also armed", async () => {
+		// Simulate a server that never answers, honoring the signal like real
+		// fetch: rejection on abort proves the composed signal is wired
+		// through to the request.
+		const fetchMock = vi.fn().mockImplementation(
+			(_url: unknown, init?: RequestInit) =>
+				new Promise<Response>((_resolve, reject) => {
+					const signal = init?.signal as AbortSignal | undefined
+					signal?.addEventListener("abort", () => {
+						reject(new Error("aborted"))
+					})
+				}),
+		)
+		globalThis.fetch = fetchMock as unknown as typeof fetch
+
+		const controller = new AbortController()
+		const promise = forgetMemoryRequest(
+			"sm_key",
+			{ containerTag: "c" },
+			"https://api.example.com",
+			{
+				signal: controller.signal,
+			},
+		)
+
+		controller.abort()
+		await expect(promise).rejects.toThrow()
+		expect(fetchMock.mock.calls.length).toBe(1)
+	})
+
+	it("applies the 30s deadline when no caller signal is provided", async () => {
+		const fetchMock = vi.fn().mockImplementation((_url, init) => {
+			const signal = (init as RequestInit).signal as AbortSignal
+			// The timeout must be armed even without a caller signal.
+			expect(signal).toBeTruthy()
+			return Promise.resolve(new Response(null, { status: 200 }))
+		})
+		globalThis.fetch = fetchMock as unknown as typeof fetch
+
+		await expect(
+			forgetMemoryRequest(
+				"sm_key",
+				{ containerTag: "c" },
+				"https://api.example.com",
+			),
+		).resolves.toBeUndefined()
+	})
+})

--- a/packages/tools/src/shared/forget-memory.ts
+++ b/packages/tools/src/shared/forget-memory.ts
@@ -33,7 +33,13 @@ export async function forgetMemoryRequest(
 			Authorization: `Bearer ${apiKey}`,
 		},
 		body: JSON.stringify(params),
-		signal: options?.signal ?? AbortSignal.timeout(FETCH_TIMEOUT_MS),
+		// Compose, don't choose: `??` let a caller-supplied signal silently
+		// drop the 30s safety timeout (and vice versa). Any signal firing —
+		// caller abort or the deadline — must abort the request.
+		signal: AbortSignal.any([
+			...(options?.signal ? [options.signal] : []),
+			AbortSignal.timeout(FETCH_TIMEOUT_MS),
+		]),
 	})
 
 	if (!response.ok) {


### PR DESCRIPTION
Fixes #1549.

Hi supermemory team 👋 Thanks for building such a great product! While running a security & quality audit of the repo we hit this issue and put together a small, tested fix — details below.

## Problem

`forgetMemoryRequest` selected between signals with `??`:

```ts
signal: options?.signal ?? AbortSignal.timeout(FETCH_TIMEOUT_MS)
```

Passing a caller-supplied `AbortSignal` therefore silently **disarmed** the 30-second safety timeout added in #1451 — a hung request would wait forever instead of failing at the deadline.

## Solution

Compose instead of choose: `AbortSignal.any([callerSignal?, timeout])` arms both, so whichever fires first (caller abort or the 30s deadline) aborts the request.

## Changes

- `packages/tools/src/shared/forget-memory.ts` → composed signal
- `packages/tools/src/shared/forget-memory.test.ts` (**new**) → 2 tests: caller-abort honored while the timeout is armed; timeout armed when no caller signal is passed

## Verification

Fresh from the committed branch: `bunx vitest run src/shared/forget-memory.test.ts` → **2/2 pass**; Biome clean on both touched files.

---
Happy to iterate on any of this — feedback and reworks very welcome! 🙏

## Environment

- macOS 26.1 (arm64) · bun 1.4.0 · node v26.7.0
- vitest 3.2.4 (workspace-pinned) · Biome lint clean
- Branch `fix/forget-memory-signal-compose` — all gates re-run fresh at commit `9f0c86a0790b`
