### PR TITLE
fix(tools): keep the forget-memory timeout when a caller passes a signal

### DIFF
--- a/packages/tools/src/shared/forget-memory.ts
+++ b/packages/tools/src/shared/forget-memory.ts
@@ -33,7 +33,11 @@ export async function forgetMemoryRequest(
 			Authorization: `Bearer ${apiKey}`,
 		},
 		body: JSON.stringify(params),
-		signal: options?.signal ?? AbortSignal.timeout(FETCH_TIMEOUT_MS),
+		// Compose rather than choose: a caller-supplied signal must add cancellation
+		// on top of the timeout, not replace it, or the request becomes unbounded.
+		signal: options?.signal
+			? AbortSignal.any([options.signal, AbortSignal.timeout(FETCH_TIMEOUT_MS)])
+			: AbortSignal.timeout(FETCH_TIMEOUT_MS),
 	})
 
 	if (!response.ok) {

--- a/packages/tools/src/tool-operations.test.ts
+++ b/packages/tools/src/tool-operations.test.ts
@@ -112,7 +112,7 @@ describe("memoryForget", () => {
 		expect(init.signal).toBeInstanceOf(AbortSignal)
 	})
 
-	it("uses a caller-provided signal instead of creating a timeout", async () => {
+	it("cancels through a caller-provided signal", async () => {
 		const fetchMock = stubFetch()
 		const controller = new AbortController()
 
@@ -124,7 +124,39 @@ describe("memoryForget", () => {
 		)
 
 		const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
-		expect(init.signal).toBe(controller.signal)
+		// The request signal is a composite, not the caller's own, but aborting
+		// the caller still aborts the request.
+		expect(init.signal).not.toBe(controller.signal)
+		controller.abort()
+		expect(init.signal?.aborted).toBe(true)
+	})
+
+	it("keeps the timeout when a caller-provided signal is present", async () => {
+		const timeoutController = new AbortController()
+		const timeoutSpy = vi
+			.spyOn(AbortSignal, "timeout")
+			.mockReturnValue(timeoutController.signal)
+		const fetchMock = stubFetch()
+		const controller = new AbortController()
+
+		try {
+			await forgetMemoryRequest(
+				API_KEY,
+				{ containerTag: "user_1", id: "mem_1" },
+				undefined,
+				{ signal: controller.signal },
+			)
+
+			expect(timeoutSpy).toHaveBeenCalledWith(30_000)
+
+			const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
+			// Firing only the timeout leg aborts the request: a caller signal adds
+			// cancellation, it does not remove the 30s bound.
+			timeoutController.abort()
+			expect(init.signal?.aborted).toBe(true)
+		} finally {
+			timeoutSpy.mockRestore()
+		}
 	})
 
 	it("throws a descriptive error on non-2xx responses", async () => {


### PR DESCRIPTION
Fixes #1549.

## The problem

`packages/tools/src/shared/forget-memory.ts` combined the caller's signal and the 30s abort with `??`, which makes them mutually exclusive:

```ts
signal: options?.signal ?? AbortSignal.timeout(FETCH_TIMEOUT_MS),
```

Pass a cancellation signal and the request becomes unbounded again — exactly the condition #1451 set out to remove. A caller who wants both cancellation *and* a timeout had no way to express it.

Latent rather than live today: neither production call site (`ai-sdk.ts`, `openai/tools.ts`) passes `options`. It becomes a real hang the first time someone wires up cancellation.

## The fix

Compose the two signals instead of choosing between them:

```ts
signal: options?.signal
    ? AbortSignal.any([options.signal, AbortSignal.timeout(FETCH_TIMEOUT_MS)])
    : AbortSignal.timeout(FETCH_TIMEOUT_MS),
```

`AbortSignal.any` is available in Node 20.3+, Bun and workerd. Root `package.json` declares `"node": ">=20"`, so in theory 20.0–20.2 are below the floor for this API; every maintained 20.x release is well past 20.3. Happy to guard it if you'd rather not rely on that.

## Tests

The existing case — *"uses a caller-provided signal instead of creating a timeout"* — **asserted the buggy behaviour** (`expect(init.signal).toBe(controller.signal)`), so it could not survive the fix. It is replaced by two tests that pin the composed semantics:

- **`cancels through a caller-provided signal`** — the request signal is a composite rather than the caller's own, and aborting the caller still aborts the request.
- **`keeps the timeout when a caller-provided signal is present`** — `AbortSignal.timeout` is still called with `30_000`, and firing only the timeout leg aborts the request.

Both new tests fail against the previous implementation (verified by reverting the source and keeping the tests):

```
× memoryForget > cancels through a caller-provided signal
  → expected AbortSignal { aborted: false } not to be AbortSignal { aborted: false }
× memoryForget > keeps the timeout when a caller-provided signal is present
  → expected "timeout" to be called with arguments: [ 30000 ]
```

## Verification

- `vitest run src/tool-operations.test.ts` — 15/15 pass (was 14).
- Full `packages/tools` suite — 91 passed / 30 skipped. The two failing files (`src/tools.test.ts`, `test/claude-memory.test.ts`) fail identically on a clean `origin/main` checkout; they are the pre-existing collection errors tracked in #1545, untouched by this change.
- `biome check` clean on both files; `tsc --noEmit` reports nothing on either file.

## Unrelated, but noticed nearby

`apps/mcp/src/server/client/index.ts:339` (`getDocuments`) has the identical `options?.signal ?? AbortSignal.timeout(...)` shape. Out of scope here — say the word and I'll open a separate issue or PR for it.
