### PR TITLE
fix(browser-extension): make the save-memory keyboard shortcut fire

### DIFF
--- a/apps/browser-extension/entrypoints/content/shared.ts
+++ b/apps/browser-extension/entrypoints/content/shared.ts
@@ -97,7 +97,8 @@ export function setupGlobalKeyboardShortcut() {
 		if (
 			(event.ctrlKey || event.metaKey) &&
 			event.shiftKey &&
-			event.key === "m"
+			// with Shift held, event.key is "M", never "m"
+			event.key.toLowerCase() === "m"
 		) {
 			event.preventDefault()
 			await saveMemory("keyboard_shortcut")


### PR DESCRIPTION
Small one: the global save shortcut in the content script checks `event.shiftKey && event.key === "m"`, but with Shift held the key value is uppercase "M", so the condition can never be true and Ctrl/Cmd+Shift+M does nothing on any page (about the only way to trigger it was Shift with Caps Lock on). Compare the key case-insensitively.

No test - the extension has no test setup and it's a one-liner. The `!event.shiftKey` checks in the per-site content scripts (chatgpt/claude/gemini/t3) are Enter handlers and unaffected.