### PR TITLE
feat(web): drop the Web research row from Company Brain models

### DIFF
--- a/apps/web/components/settings/company-brain-models.tsx
+++ b/apps/web/components/settings/company-brain-models.tsx
@@ -90,13 +90,6 @@ const ROWS: {
 		effortHelp:
 			"Deeper thinking routes messages more carefully but takes longer.",
 	},
-	{
-		role: "research",
-		effortKey: "researchEffort",
-		title: "Web research",
-		help: "Looks things up on the web when researching your company.",
-		effortHelp: "Deeper research per web search, at the cost of speed.",
-	},
 ]
 
 type FullConfig = Required<BrainModelConfig>
@@ -132,10 +125,8 @@ const PRESETS: PresetDef[] = [
 				? "grok-4-fast"
 				: defaults.main,
 			triage: defaults.triage,
-			research: defaults.research,
 			mainEffort: pickEffort(choices.mainEffort, "low", "low"),
 			triageEffort: pickEffort(choices.triageEffort, "low", "low"),
-			researchEffort: pickEffort(choices.researchEffort, "low", "low"),
 		}),
 	},
 	{
@@ -145,35 +136,24 @@ const PRESETS: PresetDef[] = [
 		build: (defaults) => ({
 			main: defaults.main,
 			triage: defaults.triage,
-			research: defaults.research,
 			mainEffort: defaults.mainEffort ?? "high",
 			triageEffort: defaults.triageEffort ?? "low",
-			researchEffort: defaults.researchEffort ?? "high",
 		}),
 	},
 	{
 		id: "thorough",
 		label: "Most thorough",
-		description: "Deepest answers and research. Slower, uses more credits.",
+		description: "Deepest answers. Slower, uses more credits.",
 		build: (defaults, choices) => ({
 			main: defaults.main,
 			triage: defaults.triage,
-			research: defaults.research,
 			mainEffort: pickEffort(choices.mainEffort, "xhigh", "high"),
 			triageEffort: pickEffort(choices.triageEffort, "medium", "low"),
-			researchEffort: pickEffort(choices.researchEffort, "xhigh", "high"),
 		}),
 	},
 ]
 
-const CONFIG_KEYS = [
-	"main",
-	"triage",
-	"research",
-	"mainEffort",
-	"triageEffort",
-	"researchEffort",
-] as const
+const CONFIG_KEYS = ["main", "triage", "mainEffort", "triageEffort"] as const
 
 const extraHighIsBounded = (model: string): boolean =>
 	model.startsWith("grok-") || model.startsWith("gpt-")

--- a/apps/web/hooks/use-brain-models.ts
+++ b/apps/web/hooks/use-brain-models.ts
@@ -6,9 +6,9 @@ const BACKEND =
 	process.env.NEXT_PUBLIC_BACKEND_URL ?? "https://api.supermemory.ai"
 const BASE = `${BACKEND}/brain/models`
 
-export type BrainModelRole = "main" | "triage" | "research"
+export type BrainModelRole = "main" | "triage"
 export type BrainReasoningEffort = "auto" | "low" | "medium" | "high" | "xhigh"
-export type BrainReasoningKey = "mainEffort" | "triageEffort" | "researchEffort"
+export type BrainReasoningKey = "mainEffort" | "triageEffort"
 
 export type BrainModelConfig = Record<BrainModelRole, string> &
 	Partial<Record<BrainReasoningKey, BrainReasoningEffort>>


### PR DESCRIPTION
The `research` / `researchEffort` model role no longer exists on the API,
so remove its card, its preset entries, and its types.