### PR TITLE
fix(tools): keep the forget-request timeout when a caller passes a signal

### DIFF
--- a/packages/tools/src/shared/forget-memory.ts
+++ b/packages/tools/src/shared/forget-memory.ts
@@ -33,7 +33,12 @@ export async function forgetMemoryRequest(
 			Authorization: `Bearer ${apiKey}`,
 		},
 		body: JSON.stringify(params),
-		signal: options?.signal ?? AbortSignal.timeout(FETCH_TIMEOUT_MS),
+		// compose the caller's signal with the timeout instead of choosing
+		// between them: `??` dropped the 30s bound whenever a signal was passed,
+		// which reopened the unbounded-request hang that #1451 closed.
+		signal: options?.signal
+			? AbortSignal.any([options.signal, AbortSignal.timeout(FETCH_TIMEOUT_MS)])
+			: AbortSignal.timeout(FETCH_TIMEOUT_MS),
 	})
 
 	if (!response.ok) {

--- a/packages/tools/src/tool-operations.test.ts
+++ b/packages/tools/src/tool-operations.test.ts
@@ -112,7 +112,7 @@ describe("memoryForget", () => {
 		expect(init.signal).toBeInstanceOf(AbortSignal)
 	})
 
-	it("uses a caller-provided signal instead of creating a timeout", async () => {
+	it("composes the caller signal with the timeout so both still bound the request", async () => {
 		const fetchMock = stubFetch()
 		const controller = new AbortController()
 
@@ -124,7 +124,15 @@ describe("memoryForget", () => {
 		)
 
 		const [, init] = fetchMock.mock.calls[0] as [string, RequestInit]
-		expect(init.signal).toBe(controller.signal)
+		const signal = init.signal as AbortSignal
+		// #1549: a composed signal, not the raw caller signal. the 30s timeout
+		// must not be dropped just because a caller passes their own signal.
+		expect(signal).toBeInstanceOf(AbortSignal)
+		expect(signal).not.toBe(controller.signal)
+		expect(signal.aborted).toBe(false)
+		// the caller's signal still aborts the request through the composite
+		controller.abort()
+		expect(signal.aborted).toBe(true)
 	})
 
 	it("throws a descriptive error on non-2xx responses", async () => {


### PR DESCRIPTION
Fixes #1549

`forgetMemoryRequest` combined the caller's abort signal and the 30s fetch timeout with `??`, so the two were mutually exclusive. Passing a cancellation signal dropped the timeout and made the DELETE /v4/memories request unbounded again, undoing the bound #1451 added. A caller that wanted both cancellation and a timeout had no way to ask for it.

It is latent today, since no production call site passes options (ai-sdk.ts:332 and openai/tools.ts:490 both omit it). It becomes a real hang the first time someone wires up cancellation.

Changes:
- compose the caller signal and the timeout with AbortSignal.any instead of choosing between them, so the request aborts on whichever fires first
- fall back to the plain timeout when no caller signal is passed
- rewrite the existing signal test, which asserted the dropped-timeout behaviour, to assert the composed signal aborts on the caller and still carries the timeout

AbortSignal.any is available on the repo's Node 20 engines floor, Bun, and workerd.

Tested:
vitest run src/tool-operations.test.ts (14 passed)