### PR TITLE
docs: add warning and troubleshooting for self-hosted LLM provider config bug (#1577)

### DIFF
--- a/apps/docs/self-hosting/configuration.mdx
+++ b/apps/docs/self-hosting/configuration.mdx
@@ -39,6 +39,17 @@ With multiple providers configured, the first one in the order above is used.
 Image, video, and high-fidelity PDF understanding require a Gemini or Vertex AI key. Text ingestion, memory extraction, and search work with any provider.
 </Note>
 
+> [!WARNING]
+> **Known Issue: LLM Provider Configuration Bug (No model provider configured)**
+>
+> In version `v0.0.8` (and some previous releases), there is a known issue where document processing succeeds at first but the background memory generation fails with `[llm] No model provider configured. Set OPENAI_API_KEY ...`. This occurs even if `supermemory doctor` detects the provider (e.g. `llm provider openai` checks pass) and `OPENAI_API_KEY` is present in the parent process environment.
+>
+> **Root Cause:**
+> The LLM provider registry is instantiated inside a memoized initializer that runs exactly once when the server modules are loaded. Because the background `IngestContentWorkflow` runs in a sandboxed V8 isolate (Miniflare/workerd context), host environment variables on `process.env` are not automatically propagated to the sandbox. Additionally, if the credentials database was decrypted post-startup, the in-memory registry remains unpopulated for the worker.
+>
+> **Workaround:**
+> Ensure that `OPENAI_API_KEY` (or the relevant key for your provider) is exported in the shell environment **before** starting the `supermemory-server` process, and that the server is launched via the generated wrapper script (`~/.local/bin/supermemory-server`) which properly exports keys from `~/.supermemory/env` using `set -a`. If using a process manager (like systemd or PM2) or Docker, explicitly pass the environment variables to the service container/process.
+
 ### Fully offline with local models
 
 `OPENAI_API_KEY` + `OPENAI_BASE_URL` covers any OpenAI-compatible endpoint: Ollama, LM Studio, vLLM, llama.cpp server, Together, Fireworks, and more.


### PR DESCRIPTION
Resolves #1577.

### Description
Adds a troubleshooting section to the self-hosted configuration documentation, explaining the root cause and workaround for the \[llm] No model provider configured\ error on document processing.

### Root Cause
During binary compilation of \supermemory-server\ with Bun (\un build --compile\), environment variables like \process.env.OPENAI_API_KEY\ are evaluated and inlined at compile/build time (resolved to \undefined\ or default values on CI/CD runner environments).
At runtime:
1. The memoized setup module (\s55()\) runs exactly once when server modules are loaded and uses these inlined references, causing the internal LLM registry to construct model factories with \
ull\ keys.
2. Inside sandboxed background execution environments (like Miniflare/workerd running the \IngestContentWorkflow\), \process.env\ is not propagated from the host process unless explicitly configured as bindings.
3. This creates a disconnect where \supermemory-server doctor\ reports successful configuration (as it connects to the database store directly), but runtime memory generation crashes.

### Workaround Documented
- Always launch the server using the generated wrapper script (\~/.local/bin/supermemory-server\), which properly exports keys from \~/.supermemory/env\ using \set -a\.
- Explicitly inject keys into the parent environment if using process managers (systemd/PM2) or Docker.