### PR TITLE
docs: document self-hosted v0.0.5 model mixing bug and v0.0.7 resolution (#1450)

### DIFF
--- a/apps/docs/self-hosting/embeddings.mdx
+++ b/apps/docs/self-hosting/embeddings.mdx
@@ -129,6 +129,14 @@ Use the dimension published for your chosen model. A mismatch with vectors alrea
 
 **Changing embeddings later:** Not supported in place. Start from a fresh data directory or re-ingest all content so vectors stay comparable.
 
+> [!IMPORTANT]
+> **Model Mixing Bug in v0.0.5 (Exact match returns nothing)**
+>
+> In version `v0.0.5`, there was a bug where the server could mix different embedding models between write and read paths (e.g., document ingestion using OpenAI but memory queries using local default embeddings). In multilingual contexts like Japanese (which lacks space tokenization for fallback lexical FTS matching), this caused exact-text memory searches through `/v4/search` and `/v4/profile` to silently return `{"results":[],"total":0}`.
+>
+> **Resolution:**
+> This was fully resolved in `v0.0.7` by locking the embedding plan uniformly across all document and query embedding paths (enforced via a locked plan in the database store). If you are running `v0.0.5` and experiencing this issue, you should upgrade to `v0.0.7` or later.
+
 ## Related
 
 - [Configuration](/self-hosting/configuration) — LLM providers, storage, ingestion limits


### PR DESCRIPTION
Resolves #1450.

### Description
Documents the self-hosted `v0.0.5` embedding model mixing bug in the embeddings documentation, explaining the root cause of why Japanese memories query and profile retrieval returned empty results, and notes that upgrading to `v0.0.7` resolves the issue by enforcing a locked embedding plan.

### Root Cause
In version `v0.0.5`, the embedding configuration was not locked. The server could mix different embedding models between document write paths (e.g. OpenAI `text-embedding-3-small` with 1536 dimensions) and memory query paths (e.g. local English default `bge-base-en-v1.5`), causing vector search cosine similarities to drop to near-zero.
- **English Memories:** Succeeded because full-text search (FTS) tokenized words based on spaces, allowing the hybrid search engine to fall back on lexical match.
- **Japanese Memories:** Failed completely because Japanese lacks space-separated words, causing SQLite FTS5 simple tokenizer to treat sentences as single tokens. The queries returned `{"results":[],"total":0}` because both the vector path (due to model mixing) and the lexical path (due to tokenization mismatch) failed.

### Resolution
This was resolved in `v0.0.7` by locking the embedding plan uniformly across all write and query paths.
