### PR TITLE
docs: warn about CWD-relative SUPERMEMORY_DATA_DIR default (#1420)

### DIFF
--- a/apps/docs/self-hosting/configuration.mdx
+++ b/apps/docs/self-hosting/configuration.mdx
@@ -16,6 +16,14 @@ The installer writes API keys to `~/.supermemory/env`, which is loaded on every 
 | `PORT` (or `SUPERMEMORY_PORT`) | HTTP listen port | `6767` |
 | `SUPERMEMORY_DATA_DIR` | Where the graph engine's data, auth secret, and model cache live | `./.supermemory` |
 
+<Warning>
+**Always set a stable `SUPERMEMORY_DATA_DIR` (e.g., `~/.supermemory`)**
+
+If `SUPERMEMORY_DATA_DIR` is left unset, it defaults to `./.supermemory` (relative to your current working directory). Running the server from different directories will silently create a new empty database store and generate a new API key in that folder. 
+
+To prevent this, it is highly recommended to explicitly define `SUPERMEMORY_DATA_DIR=~/.supermemory` (or another stable folder) in your process manager, systemd unit file, or shell rc.
+</Warning>
+
 ## LLM providers
 
 In production, Supermemory uses its own proprietary models tuned for long-horizon data understanding. Self-hosted, you bring your own LLM for the intelligent steps — summaries, contextual chunking, and memory extraction. Embeddings default to a local model (no API key) and can optionally use OpenAI, Gemini, or Ollama — see [Embeddings](/self-hosting/embeddings). Configure **at least one** LLM provider:


### PR DESCRIPTION
Resolves #1420.

### Description
Adds a warning block to the self-hosted configuration documentation, advising users to always set `SUPERMEMORY_DATA_DIR` to a stable directory path (e.g. `~/.supermemory`) to prevent the creation of accidental empty stores.

### Root Cause
When `SUPERMEMORY_DATA_DIR` is left unset, it defaults to `./.supermemory` relative to the current working directory ($CWD). If the server is started from different directories (e.g. while cd-ing between repo checkouts or system folders), it silently scaffolds and boots a brand-new, empty store (along with a new API key, auth secret, and downloading models/runtimes again). Nothing in the console output distinguishes a fresh creation from an existing store opening, which leads to confusion and wasted disk space.

### Changes
Added a clear Warning block under the configuration parameters table recommending explicit configuration of `SUPERMEMORY_DATA_DIR`.
