### PR TITLE
fix(mcp): resolve security access check bypass in getDocument tool

### DIFF
--- a/apps/mcp/src/server/tools/get-document.ts
+++ b/apps/mcp/src/server/tools/get-document.ts
@@ -32,9 +32,12 @@ export function register(deps: ToolDeps) {
 				const effectiveTag = await deps.resolveContainerTag()
 				const client = deps.getClient()
 				const document = await client.getDocument(args.documentId)
-				const docTags = document.containerTags
+				const docTags = Array.isArray(document.memoryEntries)
+					? document.memoryEntries
+							.map((entry: any) => entry.spaceContainerTag)
+							.filter(Boolean)
+					: []
 				if (
-					Array.isArray(docTags) &&
 					docTags.length > 0 &&
 					!docTags.includes(effectiveTag)
 				) {


### PR DESCRIPTION
This PR fixes a security check bypass in the getDocument MCP tool. Since document.containerTags is undefined on the returned schema, the container tag access validation was being skipped. This fix maps spaceContainerTag from document.memoryEntries to properly validate space boundaries.