### PR TITLE
fix(tools): accept zero-argument OpenAI tool calls and reject non-object args

### DIFF
--- a/packages/tools/src/openai/tools.ts
+++ b/packages/tools/src/openai/tools.ts
@@ -553,8 +553,21 @@ export function getToolDefinitions(): OpenAI.Chat.Completions.ChatCompletionTool
 }
 
 function parseToolArguments(argumentsJson: string) {
+	// getProfile, documentList and memoryForget all declare `required: []`, so a model
+	// may legitimately call them with no arguments. OpenAI serialises that as `""`,
+	// which is "no arguments" rather than malformed JSON — parse it as `{}`.
+	const source = argumentsJson?.trim() || "{}"
+
 	try {
-		return { success: true as const, value: JSON.parse(argumentsJson) }
+		const value = JSON.parse(source)
+
+		// `"null"`, `"5"` and `"[]"` parse cleanly, then throw in the destructuring
+		// parameter of every tool function — the throw this gate exists to contain.
+		if (typeof value !== "object" || value === null || Array.isArray(value)) {
+			return { success: false as const }
+		}
+
+		return { success: true as const, value }
 	} catch {
 		return { success: false as const }
 	}

--- a/packages/tools/src/tool-operations.test.ts
+++ b/packages/tools/src/tool-operations.test.ts
@@ -6,12 +6,14 @@ const documentsDelete = vi.fn()
 const documentsList = vi.fn()
 const searchExecute = vi.fn()
 const clientAdd = vi.fn()
+const clientProfile = vi.fn()
 
 vi.mock("supermemory", () => {
 	return {
 		default: class MockSupermemory {
 			search = { execute: searchExecute }
 			add = clientAdd
+			profile = clientProfile
 			documents = {
 				delete: documentsDelete,
 				list: documentsList,
@@ -42,6 +44,10 @@ beforeEach(() => {
 	})
 	searchExecute.mockReset()
 	clientAdd.mockReset().mockResolvedValue({ id: "doc_new" })
+	clientProfile.mockReset().mockResolvedValue({
+		profile: { static: ["likes tea"], dynamic: [] },
+		searchResults: undefined,
+	})
 	vi.unstubAllGlobals()
 })
 
@@ -171,6 +177,87 @@ describe("memoryForget", () => {
 
 		expect(result.success).toBe(false)
 		expect(fetchMock).not.toHaveBeenCalled()
+	})
+})
+
+describe("openai executeToolCall argument parsing", () => {
+	type ExecutorToolCall = Parameters<
+		ReturnType<typeof openAi.createToolCallExecutor>
+	>[0]
+
+	function toolCall(name: string, args: string) {
+		return {
+			id: "call_1",
+			type: "function",
+			function: { name, arguments: args },
+		} as ExecutorToolCall
+	}
+
+	// getProfile, documentList and memoryForget declare `required: []`, so the model
+	// is allowed to call them with no arguments. OpenAI serialises that as "".
+	it.each([
+		"",
+		"   ",
+	])("runs a zero-argument tool when arguments are %p", async (args) => {
+		const execute = openAi.createToolCallExecutor(API_KEY, {
+			containerTags: ["user_1"],
+		})
+
+		const result = JSON.parse(await execute(toolCall("getProfile", args)))
+
+		expect(result.success).toBe(true)
+		expect(clientProfile).toHaveBeenCalledTimes(1)
+		expect(clientProfile).toHaveBeenCalledWith({ containerTag: "user_1" })
+	})
+
+	// These parse cleanly, so the JSON guard lets them through to a destructuring
+	// parameter that rejects — the throw the guard exists to contain.
+	it.each([
+		"null",
+		"5",
+		"[]",
+		'"text"',
+	])("rejects non-object arguments %p as a tool result rather than throwing", async (args) => {
+		const execute = openAi.createToolCallExecutor(API_KEY)
+
+		const result = JSON.parse(await execute(toolCall("getProfile", args)))
+
+		expect(result.success).toBe(false)
+		expect(result.error).toMatch(/Invalid JSON arguments for getProfile/)
+		expect(clientProfile).not.toHaveBeenCalled()
+	})
+
+	it("still reports malformed JSON as a tool error", async () => {
+		const execute = openAi.createToolCallExecutor(API_KEY)
+
+		const result = JSON.parse(
+			await execute(toolCall("searchMemories", "{not json")),
+		)
+
+		expect(result.success).toBe(false)
+		expect(result.error).toMatch(/Invalid JSON arguments for searchMemories/)
+		expect(searchExecute).not.toHaveBeenCalled()
+	})
+
+	it("still passes well-formed arguments through", async () => {
+		searchExecute.mockResolvedValue({ results: [{ id: "mem_1" }] })
+		const execute = openAi.createToolCallExecutor(API_KEY, {
+			containerTags: ["user_1"],
+		})
+
+		const result = JSON.parse(
+			await execute(
+				toolCall(
+					"searchMemories",
+					JSON.stringify({ informationToGet: "tea", limit: 3 }),
+				),
+			),
+		)
+
+		expect(result.success).toBe(true)
+		expect(searchExecute).toHaveBeenCalledWith(
+			expect.objectContaining({ q: "tea", limit: 3 }),
+		)
 	})
 })
 


### PR DESCRIPTION
## Summary

- treat `arguments: ""` as "no arguments" so the three `required: []` tools are callable
- reject non-object JSON at the gate instead of letting it throw out of `executeToolCall`
- eight regression tests, six of which fail against `main`

## Why

`getProfile`, `documentList` and `memoryForget` all declare `required: []` in `memoryToolSchemas`, so a model may call them with no arguments. The OpenAI API serialises that as `arguments: ""`, and `parseToolArguments` (added in #1594, cherry-picking #1488) hands the empty string straight to `JSON.parse`:

```json
{"success":false,"error":"Invalid JSON arguments for getProfile"}
```

So those three tools never work in their documented no-argument form — the model gets a hard error back and no call is made.

The same gate also lets non-object JSON through, which is the case #1488 was meant to close. `"null"` parses cleanly, then rejects in the destructuring parameter of every tool function:

```
TypeError: Cannot destructure property 'containerTag' of 'object null' as it is null.
```

`executeToolCall` has no `catch`, so that rejection escapes and fails the whole request — exactly the throw the gate exists to contain. `"5"` and `"\"text\""` are quieter but worse: they destructure to `undefined` and call the API with no container tag.

## Change

`packages/tools/src/openai/tools.ts` — blank arguments parse as `{}`, and the parsed value must be a non-null, non-array object. Malformed JSON still returns the tool error #1488 introduced.

## Validation

- `vitest run src/` in `packages/tools` — 42 passed; `src/tools.test.ts` still fails on a missing `SUPERMEMORY_API_KEY`, which is pre-existing on `main` and unrelated
- reverted `openai/tools.ts` to the `main` version and re-ran: **6 of the 8 new tests fail**, one with the raw `TypeError` above. The two guard tests — malformed JSON, and an ordinary well-formed call — pass both before and after, so #1488's behaviour is pinned rather than changed
- `tsc --noEmit` on `packages/tools`: identical to the `main` baseline (the three pre-existing `openai/tools.ts` errors at 329/336/369 remain, tracked in #1545; no new ones)
- `biome check` clean on `openai/tools.ts`