### PR TITLE
docs: clarify customer content is never used to train models on any plan

### DIFF
--- a/apps/docs/overview/security.mdx
+++ b/apps/docs/overview/security.mdx
@@ -36,7 +36,7 @@ A malicious or buggy client with a correctly scoped key cannot read another cont
 
 ### Data use
 
-Supermemory is infrastructure for *your* agents. Paid production usage is not treated as free training corpus for unrelated public models. For contractual wording (DPA, subprocessors, training policies), request the latest legal pack from support.
+Supermemory is infrastructure for *your* agents. Your customer content is never used to train models — this applies to every plan, free or paid, with no difference between them. For contractual wording (DPA, subprocessors, training policies), request the latest legal pack from support.
 
 ### Data residency and deployment options
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Fixes misleading wording on the Security & compliance docs page (`apps/docs/overview/security.mdx`, published at `supermemory.ai/docs/overview/security`).

## Why

Customer Lars (Plain T-1682) flagged a real inconsistency. The "Data use" section read:

> Supermemory is infrastructure for *your* agents. Paid production usage is not treated as free training corpus for unrelated public models.

Singling out "paid production usage" implied free-tier data might be treated differently for training. Per official company policy (confirmed by Dhravya Shah, 2026-08-28), customer data is **never** used to train models — on any plan, free or paid, with no difference between plans.

## Change

The "Data use" section now states plainly:

> Supermemory is infrastructure for *your* agents. Your customer content is never used to train models — this applies to every plan, free or paid, with no difference between them. For contractual wording (DPA, subprocessors, training policies), request the latest legal pack from support.

## Scope notes

- Only the one incorrect sentence was changed. No other compliance text (SOC 2, GDPR, HIPAA/BAA, DPA references) was touched, and no new legal claims were introduced.
- Existing tone and the pointer to the legal pack were preserved.
- Other repo matches for "train"/"corpus" are unrelated (embedding-model training, RAG corpus, post-trained model marketing copy) and were left alone.
- This repo contains the docs/trust copy under `apps/docs`. If the formal Terms of Service / legal pack lives in a separate repo or system, that is out of scope for this change and not present here — only the in-repo docs copy was corrected.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-92e800f7-135d-4c15-903a-bc98c06b0495?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-92e800f7-135d-4c15-903a-bc98c06b0495&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

