### PR TITLE
fix: agent-framework drops profile search memories

### DIFF
--- a/packages/agent-framework-python/src/supermemory_agent_framework/utils.py
+++ b/packages/agent-framework-python/src/supermemory_agent_framework/utils.py
@@ -92,14 +92,24 @@ def deduplicate_memories(
     def extract_memory_text(item: Any) -> Optional[str]:
         if item is None:
             return None
-        if isinstance(item, dict):
-            memory = item.get("memory")
-            if isinstance(memory, str):
-                trimmed = memory.strip()
-                return trimmed if trimmed else None
-            return None
         if isinstance(item, str):
             trimmed = item.strip()
+            return trimmed if trimmed else None
+        if isinstance(item, dict):
+            memory = item.get("memory")
+        else:
+            # The Supermemory SDK returns search results as Pydantic model
+            # objects, not dicts. Without this branch they matched neither
+            # dict nor str and were silently dropped, so query/full mode
+            # injected no search memories. Read "memory" from a model_dump
+            # (falling back to attribute access).
+            model_dump = getattr(item, "model_dump", None)
+            if callable(model_dump):
+                memory = model_dump(by_alias=True).get("memory")
+            else:
+                memory = getattr(item, "memory", None)
+        if isinstance(memory, str):
+            trimmed = memory.strip()
             return trimmed if trimmed else None
         return None
 

--- a/packages/agent-framework-python/tests/test_search_result_models.py
+++ b/packages/agent-framework-python/tests/test_search_result_models.py
@@ -1,0 +1,51 @@
+"""Regression tests: search results arrive as SDK model objects.
+
+middleware.py and context_provider.py pass ``response.search_results.results``
+into ``deduplicate_memories``. The Supermemory SDK returns those as Pydantic
+model objects, not dicts. ``extract_memory_text`` previously only handled dict
+and str, so models fell through to ``None`` and were silently dropped -- in
+query/full mode no search memories were injected. These tests feed dict-less
+model stand-ins through the dedup path.
+"""
+
+from supermemory_agent_framework.utils import deduplicate_memories
+
+
+class _FakeSearchResult:
+    """Mimics a Supermemory SDK search result: attribute access and
+    ``model_dump()`` but no dict ``.get()``."""
+
+    def __init__(self, memory):
+        self.memory = memory
+
+    def model_dump(self, by_alias=False):
+        return {"memory": self.memory}
+
+
+class _AttrOnlyResult:
+    """A model-like object without model_dump(), to exercise the attribute
+    fallback."""
+
+    def __init__(self, memory):
+        self.memory = memory
+
+
+def test_model_results_are_extracted_and_deduped():
+    result = deduplicate_memories(
+        search_results=[
+            _FakeSearchResult("likes python"),
+            _FakeSearchResult("likes python"),  # duplicate, dropped
+            _FakeSearchResult("prefers async"),
+        ]
+    )
+    assert result.search_results == ["likes python", "prefers async"]
+
+
+def test_model_without_model_dump_falls_back_to_attribute():
+    result = deduplicate_memories(search_results=[_AttrOnlyResult("via attr")])
+    assert result.search_results == ["via attr"]
+
+
+def test_dict_results_still_supported():
+    result = deduplicate_memories(search_results=[{"memory": "from dict"}])
+    assert result.search_results == ["from dict"]


### PR DESCRIPTION
## What & why

In the Agent Framework integration, `middleware.py` and `context_provider.py` both pass `list(response.search_results.results)` into `deduplicate_memories()`, which routes each item through `extract_memory_text()`:

```python
def extract_memory_text(item):
    if isinstance(item, dict):
        memory = item.get("memory")
        ...
    if isinstance(item, str):
        ...
    return None   # <- SDK models land here
```

But the Supermemory SDK returns `response.search_results.results` as **Pydantic model objects, not dicts or strings**. A model matches neither branch, so `extract_memory_text` returns `None` and the memory is **silently dropped** — in `query`/`full` mode, no search memories get injected into the context. Unlike the Cartesia/Pipecat path this doesn't crash; it just quietly loses retrieved context, which is harder to notice.

Why existing tests didn't catch it: the current fixtures pass dicts (`{"memory": "..."}`), a shape production never sends. (The sibling `openai-sdk-python` package already `model_dump()`s the same results, confirming the model shape.)

## The fix

Add a model branch to `extract_memory_text` — read `"memory"` from `model_dump(by_alias=True)`, falling back to attribute access — while leaving the existing `dict` and `str` handling untouched:

```python
if isinstance(item, str):
    ...
if isinstance(item, dict):
    memory = item.get("memory")
else:
    model_dump = getattr(item, "model_dump", None)
    if callable(model_dump):
        memory = model_dump(by_alias=True).get("memory")
    else:
        memory = getattr(item, "memory", None)
```

## Tests

Added `tests/test_search_result_models.py` feeding dict-less model stand-ins through the dedup path — asserts models are extracted and deduped, the attribute fallback works for models without `model_dump`, and dict inputs still work.

> Note: the repo's PR CI runs only TypeScript type-checks + Biome, not the Python suites, so these tests won't run in CI here — I verified them locally.

## Compatibility

Backward compatible — dict and str inputs behave exactly as before. No API or behavior change for callers already passing dicts.