### PR TITLE
fix(lib): drop global $fetch retry on non-idempotent methods

### DIFF
--- a/packages/lib/api.ts
+++ b/packages/lib/api.ts
@@ -452,11 +452,6 @@ export const $fetch = createFetch({
 			context.headers.set("X-App-Source", "nova")
 		}
 	},
-	retry: {
-		attempts: 3,
-		delay: 100,
-		type: "linear",
-	},
 	schema: apiSchema,
 })
 


### PR DESCRIPTION
The $fetch client retried every endpoint 3x on non-OK responses, including @post/documents (create) and @delete/documents/:id. If a POST timed out or returned 5xx after the server processed it, the retry created a duplicate memory; a retried DELETE could double-process. better-fetch's shouldRetry only receives the Response (not the method or URL), so the global config can't safely distinguish idempotent from non-idempotent calls. Remove the global retry — read paths already refetch via React Query's own retry/refetch logic, and no $fetch call relies on a per-call retry override.