### PR TITLE
fix(web): surface connection-delete server errors

### DIFF
--- a/apps/web/components/add-document/connections.tsx
+++ b/apps/web/components/add-document/connections.tsx
@@ -486,9 +486,14 @@ export function ConnectContent({ selectedProject }: ConnectContentProps) {
 			connectionId: string
 			deleteDocuments: boolean
 		}) => {
-			await $fetch(`@delete/connections/${connectionId}`, {
+			const response = await $fetch(`@delete/connections/${connectionId}`, {
 				query: { deleteDocuments },
 			})
+			if (response.error) {
+				throw new Error(
+					response.error?.message || "Failed to remove connection",
+				)
+			}
 			return { deleteDocuments }
 		},
 		onSuccess: (_data, variables) => {

--- a/apps/web/components/settings/connections-mcp.tsx
+++ b/apps/web/components/settings/connections-mcp.tsx
@@ -527,9 +527,14 @@ export default function ConnectionsMCP() {
 			connectionId: string
 			deleteDocuments: boolean
 		}) => {
-			await $fetch(`@delete/connections/${connectionId}`, {
+			const response = await $fetch(`@delete/connections/${connectionId}`, {
 				query: { deleteDocuments },
 			})
+			if (response.error) {
+				throw new Error(
+					response.error?.message || "Failed to remove connection",
+				)
+			}
 			return { deleteDocuments }
 		},
 		onSuccess: (_data, variables) => {


### PR DESCRIPTION
The deleteConnection mutations awaited $fetch without checking response.error. better-fetch does not throw on HTTP errors, so a 403/500 resolved successfully, onSuccess fired, and the user saw 'Connection removed. Your memories have been kept.' even though nothing was deleted — the connection stayed live and kept syncing. Check response.error and throw so onError runs and the user is informed.