### PR TITLE
fix(validation): remove unreachable limit refine branches in search schemas

### DIFF
--- a/packages/validation/api.test.ts
+++ b/packages/validation/api.test.ts
@@ -18,6 +18,41 @@ describe("search threshold schemas", () => {
 
 		expect(searchSchemas).not.toContain(".transform(Number)")
 		expect(searchSchemas).not.toContain("v === undefined || (v >= 0 && v <= 1)")
+		expect(searchSchemas).not.toContain(
+			"v === undefined || (v > 0 && v <= 100)",
+		)
+	})
+
+	it.each([
+		1, 50, 100,
+	])("accepts in-range limit value %p on search schemas", (limit) => {
+		expect(SearchRequestSchema.parse({ q: "memory", limit }).limit).toBe(limit)
+		expect(Searchv4RequestSchema.parse({ q: "memory", limit }).limit).toBe(
+			limit,
+		)
+	})
+
+	it("preserves the limit default of 10 on search schemas", () => {
+		expect(SearchRequestSchema.parse({ q: "memory" }).limit).toBe(10)
+		expect(Searchv4RequestSchema.parse({ q: "memory" }).limit).toBe(10)
+	})
+
+	it("still rejects a limit above 100 on search schemas", () => {
+		expect(
+			SearchRequestSchema.safeParse({ q: "memory", limit: 101 }).success,
+		).toBe(false)
+		expect(
+			Searchv4RequestSchema.safeParse({ q: "memory", limit: 101 }).success,
+		).toBe(false)
+	})
+
+	it("still rejects a non-positive limit on search schemas", () => {
+		expect(
+			SearchRequestSchema.safeParse({ q: "memory", limit: 0 }).success,
+		).toBe(false)
+		expect(
+			Searchv4RequestSchema.safeParse({ q: "memory", limit: -1 }).success,
+		).toBe(false)
 	})
 
 	it("preserves threshold defaults", () => {

--- a/packages/validation/api.ts
+++ b/packages/validation/api.ts
@@ -432,7 +432,7 @@ export const SearchRequestSchema = z.object({
 		.positive()
 		.optional()
 		.default(10)
-		.refine((v) => v === undefined || (v > 0 && v <= 100), {
+		.refine((v) => v <= 100, {
 			message: "limit must be between 1 and 100",
 			params: {
 				max: 100,
@@ -527,7 +527,7 @@ export const Searchv4RequestSchema = z.object({
 		.positive()
 		.optional()
 		.default(10)
-		.refine((v) => v === undefined || (v > 0 && v <= 100), {
+		.refine((v) => v <= 100, {
 			message: "limit must be between 1 and 100",
 			params: {
 				max: 100,


### PR DESCRIPTION
SearchRequestSchema and Searchv4RequestSchema both chain `.positive().optional().default(10)` before their `limit` refine, so by the time the refine runs the value can never be `undefined` (`default()` substitutes 10) and can never be `<= 0` (`positive()` already rejects it). The `v === undefined || (v > 0 && ...)` guard was therefore dead code — only the upper bound (`v <= 100`) check had any effect.

Simplified both to just the meaningful check, and extended the existing source-level dead-code test (which already covered the threshold fields) plus added tests for the limit default, accepted range, and both still-rejected boundaries (0 and 101).

No behavior change — same values accepted/rejected before and after, confirmed by tests.

Refs #1205