### PR TITLE
fix(web): deprecate app.supermemory.ai / and /login + add clickjacking headers

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -37,8 +37,41 @@ const nextConfig: NextConfig = {
 		]
 	},
 	skipTrailingSlashRedirect: true,
+	async headers() {
+		// app.supermemory.ai is being deprecated in favour of the console.
+		// Anything that still serves HTML must not be framable, matching the
+		// console's clickjacking protection.
+		return [
+			{
+				source: "/:path*",
+				headers: [
+					{ key: "X-Frame-Options", value: "DENY" },
+					{
+						key: "Content-Security-Policy",
+						value: "frame-ancestors 'none'",
+					},
+				],
+			},
+		]
+	},
 	async redirects() {
 		return [
+			// The old app surface is dying: send its entry points to the console.
+			{
+				source: "/",
+				destination: "https://console.supermemory.ai",
+				permanent: false,
+			},
+			{
+				source: "/login",
+				destination: "https://console.supermemory.ai",
+				permanent: false,
+			},
+			{
+				source: "/login/:path*",
+				destination: "https://console.supermemory.ai",
+				permanent: false,
+			},
 			{
 				source: "/new",
 				destination: "/",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Unauth QA found that `app.supermemory.ai` (the old consumer app, being deprecated in favour of the console) still serves a live product surface and is missing clickjacking protection:

- `GET /` → 307 to `/login` (unauth gate)
- `GET /login` → **200 `text/html`** with **no** `Content-Security-Policy` / `X-Frame-Options`, so it is framable.

Meanwhile `console.supermemory.ai` already returns `Content-Security-Policy: frame-ancestors 'none'` and `X-Frame-Options: DENY`.

## Hunch check (worker/CF vs app code)

Verified this is **app code**, not Cloudflare/worker config: there is no `_headers` file and no header/redirect rules in `apps/web/wrangler.jsonc`. `app.supermemory.ai` is served by the OpenNext worker, which honours `next.config` `redirects()`/`headers()`. Console's headers are set by its own (separate) deployment, not this repo.

## Change

Small, config-only edit in `apps/web/next.config.ts`:

1. **Redirect the dying entry points to the console.** `/`, `/login`, and `/login/*` now `307` to `https://console.supermemory.ai`. `next.config` redirects run *before* middleware, so the login gate never renders. Temporary (307) instead of permanent so it stays reversible.
2. **Clickjacking headers on everything.** `X-Frame-Options: DENY` + `Content-Security-Policy: frame-ancestors 'none'` on `/:path*`, matching console, so any remaining HTML surface cannot be framed.

No app rewrite, no new tests, no extra comments.

## Verification (local `next build` + `next start`)

- `GET /` → `307` → `https://console.supermemory.ai/`
- `GET /login` → `307` → `https://console.supermemory.ai/`
- `GET /login/new` → `307` → `https://console.supermemory.ai/`
- `GET /integrations` (still-live HTML) → `200` with both `X-Frame-Options: DENY` and `Content-Security-Policy: frame-ancestors 'none'`
- Other routes (`/settings`, `/brain`, `/oauth/consent`) carry the headers on their responses too.

Production build passed with the new config.

> Not shipped — needs review and deploy. Draft.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-98df9b91-b9e2-4508-b0d4-c63016b42abd?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-98df9b91-b9e2-4508-b0d4-c63016b42abd&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

