### PR TITLE
docs(mcp): fix grammar in ChatGPT web plugin description

### DIFF
--- a/apps/docs/supermemory-mcp/chatgpt-web.mdx
+++ b/apps/docs/supermemory-mcp/chatgpt-web.mdx
@@ -113,7 +113,7 @@ On the Plugins page, select the **plus icon** in the upper-right corner.
 Complete the **New Plugin** form:
 
 - In **Name**, enter `Supermemory MCP`.
-- In **Description**, enter `Memory/context for you ai agents`.
+- In **Description**, enter `Memory/context for your AI agents`.
 - Under **Connection**, select **Server URL** instead of **Tunnel**.
 - In the URL field, paste `https://mcp.supermemory.ai/mcp`.
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Part of the unauth QA pass on supermemory docs/marketing. This PR fixes the one issue whose source lives in this monorepo. The other three issues live in the separate marketing-website repo (`supermemory.ai` root) and cannot be changed from here — details and exact fixes are documented below so they can be applied there.

## Fixed here (issue 4)

**ChatGPT MCP docs grammar** — `apps/docs/supermemory-mcp/chatgpt-web.mdx`

- Before: ``Memory/context for you ai agents``
- After: ``Memory/context for your AI agents``

("you" → "your", "ai" → "AI".)

## Not in this repo — belongs to the marketing website (`supermemory.ai`)

I verified the whole checkout: there is no marketing app, and none of the affected copy exists here (no `llms.txt` content, no pricing plan copy / "Most picked", no marketing homepage). This monorepo only contains `apps/docs` (docs.supermemory.ai) and `apps/web` (app.supermemory.ai console). So issues 1, 2, and the homepage side of 3 must be fixed in the marketing repo. Precise, verified fixes for whoever owns it:

**1. `llms.txt`** (`supermemory.ai/llms.txt`)
- REST link 404s: `…/docs/api-reference/manage-documents/add-document` → use the live path `…/docs/api-reference/ingest/add-document`.
- Stale method/path: `POST https://api.supermemory.ai/v3/add` → `POST https://api.supermemory.ai/v3/documents`. (Confirmed against `apps/docs/docs.json`: the add endpoint is `POST /v3/documents` under the **Ingest** group; the docs contain no `/v3/add` references.)

**2. Pricing "Most picked" badge**
- Both Pro and Max carry the badge; only one plan should. Recommend keeping it on **Pro** and removing it from **Max**. I could not confirm the intended plan from this repo (pricing copy isn't here); the owner should confirm against the pricing page copy / analytics before shipping.

**3. Homepage Slack vs connectors overview**
- Codebase reality (verified): Slack is a real product integration, but as a **Company Brain messaging** integration (`/brain/slack/*` OAuth, rendered via `SlackCard`/`ConnectorCard` in `apps/web/components/settings/company-brain-connections.tsx`). It is **not** a document-sync connector — it is absent from `ConnectionProviderEnum` in `packages/validation/schemas.ts`, there is no `/v3/connections/slack`, and no `apps/docs/connectors/slack.mdx`.
- The docs connectors overview (`apps/docs/connectors/overview.mdx`) is scoped to document-sync connectors (Drive, Gmail, Notion, OneDrive, GitHub, Granola, Web Crawler), so Slack should **not** be added there. The inconsistency is on the marketing **homepage**, which advertises Slack as a connector; that copy should be reconciled there (drop/recategorize it as a Company Brain integration).
- I intentionally did not add Slack to the docs connectors overview, since that would misrepresent it as a data-source connector.

## Testing

Docs-only copy change; no build/behavior impact.

Nothing here is claimed as shipped/deployed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-273e4800-79d7-47f8-92ce-ce37365105ae?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-273e4800-79d7-47f8-92ce-ce37365105ae&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

