### PR TITLE
docs(mcp): fix Cursor install link on MCP setup page

### DIFF
--- a/apps/docs/supermemory-mcp/setup.mdx
+++ b/apps/docs/supermemory-mcp/setup.mdx
@@ -57,7 +57,7 @@ Add the server to `~/.cursor/mcp.json`:
 }
 ```
 
-You can also use the install option in [app.supermemory.ai](https://app.supermemory.ai).
+You can also use the one-click Cursor install on the [MCP setup page](https://app.supermemory.ai/integrations/mcp).
 
 ### Other MCP clients
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

On the [MCP Setup and Usage page](https://supermemory.ai/docs/supermemory-mcp/setup), the **Cursor** section's "install option" pointed at the bare `https://app.supermemory.ai` root instead of the actual MCP install surface. This updates it to link directly to the MCP setup page where Cursor's one-click install lives:

```
- You can also use the install option in [app.supermemory.ai](https://app.supermemory.ai).
+ You can also use the one-click Cursor install on the [MCP setup page](https://app.supermemory.ai/integrations/mcp).
```

## Why

Unauth QA flagged that the doc still tells people to do the Cursor install "in app.supermemory.ai", raising the question of whether it should point to the console / current auth surface instead.

I verified the actual flow in the codebase:

- `apps/web` is the consumer app served at **app.supermemory.ai**; it links to `console.supermemory.ai` only as the separate "Developer console" for API keys/usage.
- The one-click Cursor MCP install genuinely lives in this app's MCP view (`MCP_CLIENTS` → `cursor` → "One-click MCP install in Cursor" in `integrations-view.tsx`). The canonical route is `/integrations/mcp`, which is guest-accessible per `apps/web/middleware.ts`.
- MCP OAuth's allowed origin hostnames include `app.supermemory.ai` (`apps/mcp/src/server/index.ts`), and MCP uses OAuth — no API key, so the console isn't involved.

So the **app.supermemory.ai flow is still the real one** — it should not change to console. The only real defect was the imprecise link (root instead of the MCP install page). This is the minimal correct fix.

## Scope

- One-line link change in `apps/docs/supermemory-mcp/setup.mdx`. No rewrite of the MCP docs, no other copy touched.

Nothing ships until merge + deploy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f2417205-c011-4fdb-a3e4-60471e4a067c?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f2417205-c011-4fdb-a3e4-60471e4a067c&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

