### PR TITLE
fix(browser-extension): guard project name against null textContent

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Detect SDK and playground changes
+      - name: Detect SDK, playground and browser extension changes
         id: sdk-changes
         run: |
           if git diff --quiet "${{ github.event.pull_request.base.sha }}" HEAD -- packages/tools; then
@@ -45,6 +45,12 @@ jobs:
             echo "sdk_playground=false" >> "$GITHUB_OUTPUT"
           else
             echo "sdk_playground=true" >> "$GITHUB_OUTPUT"
+          fi
+
+          if git diff --quiet "${{ github.event.pull_request.base.sha }}" HEAD -- apps/browser-extension; then
+            echo "browser_extension=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "browser_extension=true" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Setup Python for SDK Playground
@@ -97,6 +103,10 @@ jobs:
       - name: Build SDK Playground
         if: steps.sdk-changes.outputs.sdk_playground == 'true'
         run: bun run --cwd apps/sdk-playground build:app
+
+      - name: Run Browser Extension type checking
+        if: steps.sdk-changes.outputs.browser_extension == 'true'
+        run: bun run --cwd apps/browser-extension check-types
 
       - name: Run Memory Graph type checking
         run: bun run --cwd packages/memory-graph check-types

--- a/apps/browser-extension/utils/ui-components.ts
+++ b/apps/browser-extension/utils/ui-components.ts
@@ -605,7 +605,7 @@ export function createProjectSelectionModal(
 		if (selectedOption.value) {
 			const selectedProject = {
 				id: selectedOption.value,
-				name: selectedOption.textContent,
+				name: selectedOption.textContent ?? "",
 				containerTag: selectedOption.dataset.containerTag || "",
 			}
 			onImport(selectedProject)


### PR DESCRIPTION
Fixes #1561

## Problem

`createProjectSelectionModal` declares its `onImport` callback with a non-nullable `name` (`utils/ui-components.ts:405-411`), but the call site passes `Node.textContent`, typed `string | null`:

```
utils/ui-components.ts(611,13): error TS2345:
Argument of type '{ id: string; name: string | null; containerTag: string; }'
is not assignable to parameter of type '{ id: string; name: string; containerTag: string; }'.
```

## Fix

Fall back to an empty string. This matches the `containerTag` line directly below it and every other `.textContent` read in the extension — this was the only unguarded site.

`selectedOption.text` was considered instead (it is typed non-nullable), but rejected: per spec it strips and collapses whitespace, which would silently alter project names.

**Runtime behaviour is unchanged.** Options are built with `option.textContent = project.name` (`ui-components.ts:516-518`), so the value is always a string, and the disabled placeholder carries `value = ""`, so the existing `if (selectedOption.value)` guard already excludes it. This is a type-safety fix only.

## One correction to the issue report

The issue states the lockfile pins TypeScript 5.8.3 as a single entry that this workspace dedupes onto. That is not what the current lockfile resolves: `bun install --frozen-lockfile` gives `apps/browser-extension` its **own nested `typescript@5.9.3`** (the root copy is 5.8.3, but the extension does not use it).

TS 5.9's DOM lib types `textContent` as non-nullable on `Element`, so **`check-types` currently passes on `main` as CI would install it** — the error only appears under 5.8.x, which the package's own `^5.8.3` range still permits.

So this is a latent defect rather than a red build today. Verified both ways:

| | `main` | with this PR |
|---|---|---|
| TS 5.9.3 (lockfile resolution) | passes | passes |
| TS 5.8.3 | `TS2345`, the package's only error | passes |

## Preventing recurrence

`apps/browser-extension` is not type-checked in CI, which is why this sat on `main`. This PR adds a change-gated `check-types` step following the existing SDK/playground detection pattern, so it runs only when `apps/browser-extension` changes.

Happy to drop the CI half if you'd rather keep this PR to the one-line fix.

## Verification

- `bun run --cwd apps/browser-extension check-types` exits 0 under both TypeScript versions above; the `TS2345` was the only error reported under 5.8.3
- `bun test` in `apps/browser-extension`: 12 pass, 0 fail
- `biome check` on the changed line is clean (the file reports a pre-existing CRLF diff on a Windows checkout only, identical before and after this change; the repo stores LF)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017QSriDRoFLVze1BZGrAJHV
