### PR TITLE
fix(tools): support multi-part and array message content in OpenAI middleware

### DIFF
--- a/packages/tools/src/openai-middleware.test.ts
+++ b/packages/tools/src/openai-middleware.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest"
+import {
+	extractMessageText,
+	getLastUserMessage,
+	getConversationContent,
+} from "./openai/middleware"
+
+describe("OpenAI middleware message extraction", () => {
+	it("extracts text from simple string content", () => {
+		const messages = [
+			{ role: "system" as const, content: "System prompt" },
+			{ role: "user" as const, content: "Hello world" },
+		]
+		expect(getLastUserMessage(messages)).toBe("Hello world")
+	})
+
+	it("extracts text from multi-part array content", () => {
+		const messages = [
+			{
+				role: "user" as const,
+				content: [
+					{ type: "text" as const, text: "What is my favorite language?" },
+					{
+						type: "image_url" as const,
+						image_url: { url: "https://example.com/image.png" },
+					},
+				],
+			},
+		]
+		expect(getLastUserMessage(messages)).toBe("What is my favorite language?")
+	})
+
+	it("extracts and joins multiple text parts within array content", () => {
+		const messages = [
+			{
+				role: "user" as const,
+				content: [
+					{ type: "text" as const, text: "Part 1" },
+					{ type: "text" as const, text: "Part 2" },
+				],
+			},
+		]
+		expect(getLastUserMessage(messages)).toBe("Part 1 Part 2")
+	})
+
+	it("returns empty string when no user message exists", () => {
+		const messages = [
+			{ role: "system" as const, content: "System prompt" },
+			{ role: "assistant" as const, content: "Hello" },
+		]
+		expect(getLastUserMessage(messages)).toBe("")
+	})
+
+	it("formats conversation content with multi-part array messages", () => {
+		const messages = [
+			{
+				role: "user" as const,
+				content: [
+					{ type: "text" as const, text: "Hello" },
+					{
+						type: "image_url" as const,
+						image_url: { url: "https://example.com/image.png" },
+					},
+				],
+			},
+			{ role: "assistant" as const, content: "Hi there!" },
+		]
+		const formatted = getConversationContent(messages)
+		expect(formatted).toBe("User: Hello\n\nAssistant: Hi there!")
+	})
+
+	it("extractMessageText handles string, array, and invalid inputs gracefully", () => {
+		expect(extractMessageText("plain text")).toBe("plain text")
+		expect(extractMessageText([{ type: "text", text: "extracted text" }])).toBe(
+			"extracted text",
+		)
+		expect(extractMessageText([{ type: "other_type" }])).toBe("")
+		expect(extractMessageText(null)).toBe("")
+		expect(extractMessageText(undefined)).toBe("")
+	})
+})

--- a/packages/tools/src/openai/middleware.ts
+++ b/packages/tools/src/openai/middleware.ts
@@ -56,17 +56,49 @@ interface SupermemoryProfileSearch {
  * // Returns: "What's the weather like?"
  * ```
  */
-const getLastUserMessage = (
+/**
+ * Extracts text content from a message's content, supporting both strings and
+ * multi-part / multimodal content arrays.
+ */
+export const extractMessageText = (content: unknown): string => {
+	if (typeof content === "string") {
+		return content
+	}
+	if (Array.isArray(content)) {
+		return content
+			.map((part) => {
+				if (typeof part === "string") return part
+				if (typeof part === "object" && part !== null) {
+					if ("text" in part && typeof (part as { text?: unknown }).text === "string") {
+						return (part as { text: string }).text
+					}
+				}
+				return ""
+			})
+			.filter(Boolean)
+			.join(" ")
+	}
+	return ""
+}
+
+/**
+ * Extracts the last user message from an array of chat completion messages.
+ *
+ * Searches through the messages array in reverse order to find the most recent
+ * message with role "user" and returns its content as a string.
+ *
+ * @param messages - Array of chat completion message parameters
+ * @returns The content of the last user message, or empty string if none found
+ */
+export const getLastUserMessage = (
 	messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[],
-) => {
+): string => {
 	const lastUserMessage = messages
 		.slice()
 		.reverse()
 		.find((msg) => msg.role === "user")
 
-	return typeof lastUserMessage?.content === "string"
-		? lastUserMessage.content
-		: ""
+	return lastUserMessage ? extractMessageText(lastUserMessage.content) : ""
 }
 
 /**
@@ -279,13 +311,13 @@ const addSystemPrompt = async (
  * // Returns: "User: Hello!\n\nAssistant: Hi there!\n\nUser: How are you?"
  * ```
  */
-const getConversationContent = (
+export const getConversationContent = (
 	messages: OpenAI.Chat.Completions.ChatCompletionMessageParam[],
-) => {
+): string => {
 	return messages
 		.map((msg) => {
 			const role = msg.role === "user" ? "User" : "Assistant"
-			const content = typeof msg.content === "string" ? msg.content : ""
+			const content = extractMessageText(msg.content)
 			return `${role}: ${content}`
 		})
 		.join("\n\n")


### PR DESCRIPTION
## Problem

In `packages/tools/src/openai/middleware.ts`, `getLastUserMessage` and `getConversationContent` previously assumed message `content` was strictly a `string`.

When callers use modern OpenAI multimodal or multi-part messages where `content` is an array of content parts (`[{ type: "text", text: "..." }, ...]`), `typeof content === "string"` evaluated to `false`, causing `getLastUserMessage` to return `""`.

In `createWithMemory`, `!userMessage` evaluated to `true`, which caused the middleware to:
1. Silently skip semantic memory retrieval.
2. Skip saving the conversation context to memory.
3. Pass through the completion request without injecting any Supermemory context.

## Solution

1. Added `extractMessageText` in `openai/middleware.ts` to cleanly extract and join text parts from both string content and array content parts (`ChatCompletionContentPartText`).
2. Updated `getLastUserMessage` and `getConversationContent` to use `extractMessageText`.
3. Added unit tests under `packages/tools/src/openai-middleware.test.ts` covering string, multi-part, and multimodal inputs.

## Verification

Ran `bun test packages/tools/src/openai-middleware.test.ts` (all 6 tests passed).
