### PR TITLE
docs: fixed typo in graph-memory.mdx

### DIFF
--- a/apps/docs/concepts/graph-memory.mdx
+++ b/apps/docs/concepts/graph-memory.mdx
@@ -56,7 +56,7 @@ Uploading a long PDF does more than store bytes: Supermemory derives many memori
 ## Properties and rules of memories
 
 1. Memories are atomic - Each memory has enough information and context about one particular topic
-2. They always build on top of each other - with `updates`, the model knows the history, a memory `extends` from other memories, and new facts are derived (`derives` relation) from existing knowledg.e
+2. They always build on top of each other - with `updates`, the model knows the history, a memory `extends` from other memories, and new facts are derived (`derives` relation) from existing knowledge.
 
 ## Memory relationships
 


### PR DESCRIPTION
Fixes a typo in the documentation