### PR TITLE
fix(mcp): let getDocument read any accessible document

### DIFF
--- a/apps/mcp/src/server/tools/get-document.ts
+++ b/apps/mcp/src/server/tools/get-document.ts
@@ -7,7 +7,6 @@ import {
 } from "./output-schemas"
 import { textContent, type ToolDeps } from "./types"
 
-// An out-of-space document reports "not found" on purpose, so the id is not an existence oracle.
 export function register(deps: ToolDeps) {
 	const inputSchema = z.object({
 		documentId: z
@@ -22,24 +21,15 @@ export function register(deps: ToolDeps) {
 		{
 			title: "Get Document",
 			description:
-				"Read one stored document by ID, including its summary and available content. Use listDocuments in the intended space to discover document IDs.",
+				"Read one stored document by ID from any space you can access, including its summary and available content. Use listDocuments to discover document IDs.",
 			inputSchema,
 			outputSchema: getDocumentOutputSchema,
 			annotations: READ_ONLY_TOOL_ANNOTATIONS,
 		},
 		async (args) => {
 			try {
-				const effectiveTag = await deps.resolveContainerTag()
 				const client = deps.getClient()
 				const document = await client.getDocument(args.documentId)
-				const docTags = document.containerTags
-				if (
-					Array.isArray(docTags) &&
-					docTags.length > 0 &&
-					!docTags.includes(effectiveTag)
-				) {
-					throw new Error("Document not found")
-				}
 				const { content, truncated } = getDocumentContent(document)
 				const structuredContent: GetDocumentOutput = {
 					document: {


### PR DESCRIPTION
getDocument filtered on the caller's active space, so an ID from listDocuments in any other space returned "Document not found". With activeSpace unset the fallback is sm_project_default, which broke most cross-space reads.

The API already scopes document reads to the caller's org, so the extra filter added no protection. Verified locally against the mono API: own-space and cross-space IDs now resolve, foreign-org IDs still 404.