### PR TITLE
fix(extension): open X History for bookmark import

### DIFF
--- a/apps/browser-extension/entrypoints/content/twitter.ts
+++ b/apps/browser-extension/entrypoints/content/twitter.ts
@@ -1,10 +1,10 @@
 import {
 	DOMAINS,
 	ELEMENT_IDS,
-	isTwitterBookmarksPage,
 	MESSAGE_TYPES,
 	POSTHOG_EVENT_KEY,
 	STORAGE_KEYS,
+	TWITTER_BOOKMARKS_PATH,
 	UI_CONFIG,
 } from "../../utils/constants"
 import { trackEvent } from "../../utils/posthog"
@@ -87,9 +87,9 @@ export async function initializeTwitter() {
 		return
 	}
 
-	if (isTwitterBookmarksPage(window.location.pathname)) {
+	if (window.location.pathname === TWITTER_BOOKMARKS_PATH) {
 		setTimeout(async () => {
-			if (isTwitterBookmarksPage(window.location.pathname)) {
+			if (window.location.pathname === TWITTER_BOOKMARKS_PATH) {
 				await handleBookmarksPageLoad()
 			}
 		}, 2000)
@@ -103,7 +103,7 @@ export async function initializeTwitter() {
  * Handle what to show when user lands on bookmarks page
  */
 async function handleBookmarksPageLoad() {
-	if (!isTwitterBookmarksPage(window.location.pathname)) {
+	if (window.location.pathname !== TWITTER_BOOKMARKS_PATH) {
 		return
 	}
 
@@ -590,7 +590,7 @@ export async function handleTwitterNavigation() {
 		return
 	}
 
-	if (isTwitterBookmarksPage(window.location.pathname)) {
+	if (window.location.pathname === TWITTER_BOOKMARKS_PATH) {
 		addTwitterImportButtonForFolders()
 		await handleBookmarksPageLoad()
 	} else {
@@ -602,7 +602,7 @@ export async function handleTwitterNavigation() {
  * Adds import buttons to bookmark folders
  */
 function addTwitterImportButtonForFolders() {
-	if (!isTwitterBookmarksPage(window.location.pathname)) {
+	if (window.location.pathname !== TWITTER_BOOKMARKS_PATH) {
 		return
 	}
 

--- a/apps/browser-extension/entrypoints/content/twitter.ts
+++ b/apps/browser-extension/entrypoints/content/twitter.ts
@@ -1,6 +1,7 @@
 import {
 	DOMAINS,
 	ELEMENT_IDS,
+	isTwitterBookmarksPage,
 	MESSAGE_TYPES,
 	POSTHOG_EVENT_KEY,
 	STORAGE_KEYS,
@@ -86,9 +87,9 @@ export async function initializeTwitter() {
 		return
 	}
 
-	if (window.location.pathname === "/i/bookmarks") {
+	if (isTwitterBookmarksPage(window.location.pathname)) {
 		setTimeout(async () => {
-			if (window.location.pathname === "/i/bookmarks") {
+			if (isTwitterBookmarksPage(window.location.pathname)) {
 				await handleBookmarksPageLoad()
 			}
 		}, 2000)
@@ -102,7 +103,7 @@ export async function initializeTwitter() {
  * Handle what to show when user lands on bookmarks page
  */
 async function handleBookmarksPageLoad() {
-	if (window.location.pathname !== "/i/bookmarks") {
+	if (!isTwitterBookmarksPage(window.location.pathname)) {
 		return
 	}
 
@@ -589,7 +590,7 @@ export async function handleTwitterNavigation() {
 		return
 	}
 
-	if (window.location.pathname === "/i/bookmarks") {
+	if (isTwitterBookmarksPage(window.location.pathname)) {
 		addTwitterImportButtonForFolders()
 		await handleBookmarksPageLoad()
 	} else {
@@ -601,7 +602,7 @@ export async function handleTwitterNavigation() {
  * Adds import buttons to bookmark folders
  */
 function addTwitterImportButtonForFolders() {
-	if (window.location.pathname !== "/i/bookmarks") {
+	if (!isTwitterBookmarksPage(window.location.pathname)) {
 		return
 	}
 

--- a/apps/browser-extension/entrypoints/popup/App.tsx
+++ b/apps/browser-extension/entrypoints/popup/App.tsx
@@ -4,9 +4,9 @@ import "./App.css"
 import { validateAuthToken } from "../../utils/api"
 import {
 	getSupermemoryLoginUrl,
-	isTwitterBookmarksPage,
 	MESSAGE_TYPES,
 	STORAGE_KEYS,
+	TWITTER_BOOKMARKS_PATH,
 	TWITTER_BOOKMARKS_PAGE_URL,
 	UI_CONFIG,
 } from "../../utils/constants"
@@ -494,7 +494,10 @@ function App() {
 				currentWindow: true,
 			})
 
-			const isOnBookmarksPage = !!activeTab?.url && isTwitterBookmarksPage(activeTab.url)
+			const activePathname = activeTab?.url
+				? new URL(activeTab.url).pathname
+				: ""
+			const isOnBookmarksPage = activePathname === TWITTER_BOOKMARKS_PATH
 
 			if (isOnBookmarksPage && activeTab?.id) {
 				try {

--- a/apps/browser-extension/entrypoints/popup/App.tsx
+++ b/apps/browser-extension/entrypoints/popup/App.tsx
@@ -4,8 +4,10 @@ import "./App.css"
 import { validateAuthToken } from "../../utils/api"
 import {
 	getSupermemoryLoginUrl,
+	isTwitterBookmarksPage,
 	MESSAGE_TYPES,
 	STORAGE_KEYS,
+	TWITTER_BOOKMARKS_PAGE_URL,
 	UI_CONFIG,
 } from "../../utils/constants"
 import {
@@ -484,7 +486,7 @@ function App() {
 	}
 
 	const handleTwitterBookmarksImport = async () => {
-		const targetUrl = "https://x.com/i/bookmarks"
+		const targetUrl = TWITTER_BOOKMARKS_PAGE_URL
 
 		try {
 			const [activeTab] = await chrome.tabs.query({
@@ -492,9 +494,7 @@ function App() {
 				currentWindow: true,
 			})
 
-			const isOnBookmarksPage =
-				activeTab?.url?.includes("x.com/i/bookmarks") ||
-				activeTab?.url?.includes("twitter.com/i/bookmarks")
+			const isOnBookmarksPage = !!activeTab?.url && isTwitterBookmarksPage(activeTab.url)
 
 			if (isOnBookmarksPage && activeTab?.id) {
 				try {

--- a/apps/browser-extension/utils/constants.ts
+++ b/apps/browser-extension/utils/constants.ts
@@ -76,6 +76,30 @@ export const DOMAINS = {
 	SUPERMEMORY: ["localhost", "supermemory.ai", "app.supermemory.ai"],
 } as const
 
+/** X moved bookmarks from /i/bookmarks into the History hub. */
+export const TWITTER_BOOKMARKS_PAGE_URL = "https://x.com/i/history"
+
+/**
+ * True for the current History page and the old Bookmarks URL, so import still
+ * works during the rollout and if X redirects /i/bookmarks → /i/history.
+ */
+export function isTwitterBookmarksPage(urlOrPath: string): boolean {
+	let pathname = urlOrPath
+	try {
+		if (/^https?:\/\//i.test(urlOrPath)) {
+			pathname = new URL(urlOrPath).pathname
+		}
+	} catch {
+		return urlOrPath.includes("/i/history") || urlOrPath.includes("/i/bookmarks")
+	}
+
+	return (
+		pathname === "/i/bookmarks" ||
+		pathname === "/i/history" ||
+		pathname.startsWith("/i/history/")
+	)
+}
+
 /**
  * Container Tags
  */

--- a/apps/browser-extension/utils/constants.ts
+++ b/apps/browser-extension/utils/constants.ts
@@ -76,29 +76,8 @@ export const DOMAINS = {
 	SUPERMEMORY: ["localhost", "supermemory.ai", "app.supermemory.ai"],
 } as const
 
-/** X moved bookmarks from /i/bookmarks into the History hub. */
-export const TWITTER_BOOKMARKS_PAGE_URL = "https://x.com/i/history"
-
-/**
- * True for the current History page and the old Bookmarks URL, so import still
- * works during the rollout and if X redirects /i/bookmarks → /i/history.
- */
-export function isTwitterBookmarksPage(urlOrPath: string): boolean {
-	let pathname = urlOrPath
-	try {
-		if (/^https?:\/\//i.test(urlOrPath)) {
-			pathname = new URL(urlOrPath).pathname
-		}
-	} catch {
-		return urlOrPath.includes("/i/history") || urlOrPath.includes("/i/bookmarks")
-	}
-
-	return (
-		pathname === "/i/bookmarks" ||
-		pathname === "/i/history" ||
-		pathname.startsWith("/i/history/")
-	)
-}
+export const TWITTER_BOOKMARKS_PATH = "/i/history"
+export const TWITTER_BOOKMARKS_PAGE_URL = `https://x.com${TWITTER_BOOKMARKS_PATH}`
 
 /**
  * Container Tags


### PR DESCRIPTION
## What changed

X moved Bookmarks from `/i/bookmarks` to `/i/history`. The extension still opened and checked the old route, so the import dialog did not start on the new page.

This change updates the popup and content script to use `/i/history`. The GraphQL bookmark import code is unchanged.

## Testing

- [x] Ran `pnpm check-types`
- [x] Ran `pnpm build`
- [x] Loaded the production build as an unpacked Chrome extension
- [x] Confirmed that bookmark import opens `https://x.com/i/history`
- [x] Complete a full import with logged-in X and Supermemory accounts