### PR TITLE
fix(tools): stop forcing empty instructions on Responses requests

### DIFF
--- a/packages/tools/src/openai/middleware.ts
+++ b/packages/tools/src/openai/middleware.ts
@@ -970,13 +970,22 @@ export function createOpenAIMiddleware(
 					: ""
 		}
 
+		// Sending `instructions` at all tells the Responses API to drop whatever a
+		// `previous_response_id` turn carried over, so an empty result must leave
+		// the caller's own field untouched rather than blank it. Matches the
+		// no-input early return above.
+		const instructionsOverride =
+			enhancedInstructions || typeof params.instructions === "string"
+				? { instructions: enhancedInstructions }
+				: {}
+
 		return {
 			request: originalResponsesCreate.call(
 				openaiClient.responses,
 				{
 					...params,
 					input: cleanedInput,
-					instructions: enhancedInstructions,
+					...instructionsOverride,
 				},
 				requestOptions,
 			),

--- a/packages/tools/test/openai-middleware.unit.test.ts
+++ b/packages/tools/test/openai-middleware.unit.test.ts
@@ -63,3 +63,101 @@ describe("OpenAI middleware memory context", () => {
 		).toHaveLength(1)
 	})
 })
+
+describe("OpenAI Responses middleware instructions", () => {
+	const originalApiKey = process.env.SUPERMEMORY_API_KEY
+
+	beforeEach(() => {
+		process.env.SUPERMEMORY_API_KEY = "sm_test_key"
+	})
+
+	afterEach(() => {
+		if (originalApiKey === undefined) delete process.env.SUPERMEMORY_API_KEY
+		else process.env.SUPERMEMORY_API_KEY = originalApiKey
+		vi.unstubAllGlobals()
+	})
+
+	const stubMemoryFetch = (staticMemories: string[]) => {
+		vi.stubGlobal(
+			"fetch",
+			vi.fn().mockResolvedValue({
+				ok: true,
+				json: async () => ({
+					profile: {
+						static: staticMemories.map((memory) => ({ memory })),
+						dynamic: [],
+					},
+					searchResults: { results: [] },
+				}),
+			}),
+		)
+	}
+
+	const wrapResponsesClient = () => {
+		const originalCreate = vi.fn(() =>
+			Object.assign(Promise.resolve({ output: [] }), {
+				asResponse: async () => new Response(),
+			}),
+		)
+		const client = {
+			chat: { completions: { create: vi.fn() } },
+			responses: { create: originalCreate },
+		} as unknown as OpenAI
+		const wrapped = withSupermemory(client, {
+			containerTag: "user-a",
+			customId: "conversation-a",
+			mode: "profile",
+			addMemory: "never",
+		})
+		return { originalCreate, wrapped }
+	}
+
+	it("leaves instructions absent when the caller sent none and there is nothing to inject", async () => {
+		stubMemoryFetch([])
+		const { originalCreate, wrapped } = wrapResponsesClient()
+
+		await wrapped.responses.create({
+			model: "gpt-4o-mini",
+			input: "What do you remember?",
+			previous_response_id: "resp_123",
+		})
+
+		// An empty `instructions` still counts as present, and the Responses API
+		// drops the previous turn's instructions whenever the field is sent.
+		const forwarded = originalCreate.mock.calls[0]?.[0]
+		expect("instructions" in forwarded).toBe(false)
+		expect(forwarded.previous_response_id).toBe("resp_123")
+	})
+
+	it("still injects memories as instructions when the caller sent none", async () => {
+		stubMemoryFetch(["Fresh profile fact"])
+		const { originalCreate, wrapped } = wrapResponsesClient()
+
+		await wrapped.responses.create({
+			model: "gpt-4o-mini",
+			input: "What do you remember?",
+		})
+
+		const forwarded = originalCreate.mock.calls[0]?.[0]
+		expect(String(forwarded.instructions)).toContain("Fresh profile fact")
+	})
+
+	it("keeps caller instructions and strips stale context when there is nothing to inject", async () => {
+		stubMemoryFetch([])
+		const { originalCreate, wrapped } = wrapResponsesClient()
+
+		await wrapped.responses.create({
+			model: "gpt-4o-mini",
+			input: "What do you remember?",
+			instructions: [
+				"Be helpful.",
+				'<supermemory context="user-memories" readonly>',
+				"Stale profile fact",
+				"</supermemory>",
+			].join("\n"),
+		})
+
+		const forwarded = originalCreate.mock.calls[0]?.[0]
+		expect(String(forwarded.instructions)).toBe("Be helpful.")
+	})
+})


### PR DESCRIPTION
## Problem

`prepareResponsesWithMemory` sets `instructions` on every forwarded request:

```ts
return {
  request: originalResponsesCreate.call(openaiClient.responses, {
    ...params,
    input: cleanedInput,
    instructions: enhancedInstructions,   // always present
  }, requestOptions),
}
```

When the caller passed no `instructions` and there are no memories to inject, `replaceMemoryContext("", "")` returns `""` — so the request goes out with `instructions: ""` where the caller sent nothing.

Per the Responses API contract, supplying `instructions` at all discards the instructions carried over from a `previous_response_id` turn. An empty string therefore doesn't just add noise: it silently wipes the caller's system prompt partway through a multi-turn chain.

The no-input early return in the same function already handles this correctly:

```ts
...(typeof params.instructions === "string"
  ? { instructions: stripMemoryContext(params.instructions) }
  : {}),
```

so the two paths in one function disagree about the same field.

## Fix

Apply the early return's rule to the main path — spread `instructions` only when there is something to send or the caller supplied a string:

```ts
const instructionsOverride =
  enhancedInstructions || typeof params.instructions === "string"
    ? { instructions: enhancedInstructions }
    : {}
```

Behaviour by case:

| caller `instructions` | memories | before | after |
| --- | --- | --- | --- |
| absent | none | `""` (wipes carried-over prompt) | **field absent** |
| absent | present | memory block | memory block (unchanged) |
| string | none | stale context stripped | stale context stripped (unchanged) |
| string | present | context replaced | context replaced (unchanged) |
| `null` | none | `""` | `null` preserved via `...params` |

Only the first row changes. The `catch` branch is covered by the same guard, so a failed memory search no longer blanks the field either.

## Tests

Three cases added to `test/openai-middleware.unit.test.ts`, the suite CI already runs when `packages/tools` changes:

- caller sent no instructions and nothing to inject → field absent, `previous_response_id` untouched
- caller sent no instructions but memories exist → memories still injected
- caller sent instructions → preserved, stale `<supermemory>` block stripped

Verified the first test fails on `main` and passes with the fix; the other two pass either way and are there to catch over-correction. Full file: 4/4 passing.

## Scope

One file changed plus tests. No API surface change, no new dependencies, no behaviour change for callers that already pass `instructions`.
