### PR TITLE
fix(pipecat): keep memory text literal when replacing the injected block

### DIFF
--- a/packages/pipecat-sdk-python/src/supermemory_pipecat/service.py
+++ b/packages/pipecat-sdk-python/src/supermemory_pipecat/service.py
@@ -415,8 +415,13 @@ class SupermemoryPipecatService(FrameProcessor):
             if system_idx is not None:
                 existing_content = messages[system_idx].get("content", "")
                 if MEMORY_TAG_PATTERN.search(existing_content):
+                    # A callable replacement keeps the memory text literal. As a
+                    # plain string, re.sub reads backslash escapes in it as group
+                    # references and raises on real memories such as a Windows
+                    # path ("bad escape \\U") or a regex fact ("invalid group
+                    # reference 1").
                     messages[system_idx]["content"] = MEMORY_TAG_PATTERN.sub(
-                        tagged_memory, existing_content
+                        lambda _match: tagged_memory, existing_content
                     )
                 else:
                     messages[system_idx]["content"] = f"{existing_content}\n\n{tagged_memory}"

--- a/packages/pipecat-sdk-python/tests/test_empty_profile.py
+++ b/packages/pipecat-sdk-python/tests/test_empty_profile.py
@@ -154,3 +154,52 @@ class TestSupermemoryPipecatNullProfile(unittest.IsolatedAsyncioTestCase):
         self.assertTrue(
             any(fact in message.get("content", "") for message in context.messages)
         )
+
+    def test_system_injection_replaces_stale_block_with_backslash_memory(self) -> None:
+        """A memory containing backslashes must not be read as a regex template.
+
+        re.sub() expands escapes in a *string* replacement, so a Windows path or
+        a group-reference-looking fact used to raise re.error and abort the turn.
+        """
+        backslash = chr(92)
+        fact = "User's repo is at C:" + backslash + "Users" + backslash + "alice"
+        service = SupermemoryPipecatService(
+            api_key="mock_key",
+            user_id="user-123",
+            session_id="conversation-456",
+            params=SupermemoryPipecatService.InputParams(inject_mode="system"),
+        )
+        newline = chr(10)
+        stale = newline.join(["<user_memories>", "Stale fact", "</user_memories>"])
+
+        class Context:
+            def __init__(self):
+                self.messages = [
+                    {
+                        "role": "system",
+                        "content": "You are helpful." + newline + newline + stale,
+                    },
+                    {"role": "user", "content": "Where is my repo?"},
+                ]
+
+            def get_messages(self):
+                return self.messages
+
+            def add_message(self, message):
+                self.messages.append(message)
+
+        context = Context()
+        service._enhance_context_with_memories(
+            context,
+            "Where is my repo?",
+            {
+                "profile": {"static": [fact], "dynamic": []},
+                "search_results": [],
+            },
+        )
+
+        system_content = context.messages[0]["content"]
+        self.assertIn(fact, system_content)
+        self.assertNotIn("Stale fact", system_content)
+        self.assertIn("You are helpful.", system_content)
+        self.assertEqual(system_content.count("<user_memories>"), 1)


### PR DESCRIPTION
## Problem

`_enhance_context_with_memories` refreshes the `<user_memories>` block in the system message like this:

```python
if MEMORY_TAG_PATTERN.search(existing_content):
    messages[system_idx]["content"] = MEMORY_TAG_PATTERN.sub(
        tagged_memory, existing_content
    )
```

`re.sub()` parses a **string** replacement as a template. Backslash sequences in `tagged_memory` are therefore expanded as group references rather than inserted, and `MEMORY_TAG_PATTERN` has no groups at all — so ordinary memory content raises:

```
"User's repo is at C:\Users\alice"     -> re.error: bad escape \U
"User writes \1 for a capture group"   -> re.error: invalid group reference 1
```

The exception propagates out of context enhancement and aborts the turn. It only fires from the **second turn onward**, once a block exists to replace — the exact path this method's docstring describes:

> Uses XML tags `<user_memories>...</user_memories>` to wrap memories, allowing replacement on each turn instead of accumulation.

A memory holding a Windows path is enough to trigger it, and memory text is arbitrary user content.

`escape_memory_delimiters` does not help here: it neutralizes `<user_memories>` tags, not backslashes.

## Fix

Use a callable replacement, which `re.sub()` inserts verbatim and never parses as a template:

```python
messages[system_idx]["content"] = MEMORY_TAG_PATTERN.sub(
    lambda _match: tagged_memory, existing_content
)
```

This is the only dynamic-replacement `re.sub()` in the repo — every other call site in the Python SDKs already passes a callable or a literal `""`, so this brings the last one in line.

## Tests

Adds `test_system_injection_replaces_stale_block_with_backslash_memory` to the existing pipecat suite: a stale block plus a memory containing a Windows path, asserting the new fact lands, the stale one is gone, the caller's own system text survives, and exactly one block remains.

On `main` it fails with the production error (`re.PatternError: bad escape \U`); with the fix the suite is 3/3. `ci-python.yml` runs the pipecat suite on any PR touching `packages/pipecat-sdk-python/**`, so this is covered on both the 3.10 and 3.12 lanes.

## Scope

One functional line plus a regression test. No API surface change, no new dependencies, no behaviour change for memories without backslashes.
