### PR TITLE
fix(web): resolve CHROME_EXTENSION_URL via the mapped @lib alias

### DIFF
--- a/apps/web/components/integrations/chrome-detail.tsx
+++ b/apps/web/components/integrations/chrome-detail.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { CHROME_EXTENSION_URL } from "@repo/lib/constants"
+import { CHROME_EXTENSION_URL } from "@lib/constants"
 import { cn } from "@lib/utils"
 import { dmSans125ClassName } from "@/lib/fonts"
 import { ChromeIcon } from "@/components/integration-icons"

--- a/apps/web/components/nova/nova-empty-state.tsx
+++ b/apps/web/components/nova/nova-empty-state.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { CHROME_EXTENSION_URL } from "@repo/lib/constants"
+import { CHROME_EXTENSION_URL } from "@lib/constants"
 import type { IntegrationParamValue } from "@/lib/search-params"
 import { cn } from "@lib/utils"
 import { dmSansClassName } from "@/lib/fonts"

--- a/apps/web/components/onboarding/x-bookmarks-detail-view.tsx
+++ b/apps/web/components/onboarding/x-bookmarks-detail-view.tsx
@@ -4,7 +4,7 @@ import { Button } from "@ui/components/button"
 import { cn } from "@lib/utils"
 import { dmSansClassName } from "@/lib/fonts"
 import Image from "next/image"
-import { CHROME_EXTENSION_URL } from "@repo/lib/constants"
+import { CHROME_EXTENSION_URL } from "@lib/constants"
 
 interface XBookmarksDetailViewProps {
 	onBack: () => void


### PR DESCRIPTION
Closes #1548

## Problem

Three web components import the Chrome extension URL through an alias that nothing maps:

```ts
import { CHROME_EXTENSION_URL } from "@repo/lib/constants"
```

```
error TS2307: Cannot find module '@repo/lib/constants'
  or its corresponding type declarations.
```

`apps/web/tsconfig.json` maps `@repo/ui/*`, `@ui/*`, `@lib/*` and `@hooks/*` — but not `@repo/lib/*`. Resolution therefore falls through to the package's own exports map, `{"./*": "./*"}`, which points at the extensionless `packages/lib/constants`. TypeScript's `bundler` resolution does not append extensions after an exports-map substitution, so the import fails to type-check.

Webpack/Turbopack apply extension resolution more permissively, so these still bundle at runtime — but the imports are unsound and contribute to the red `check-types` run (#1544).

## Fix

Switch the three imports to `@lib/constants`, matching every other consumer in the app:

- `apps/web/components/integrations/chrome-detail.tsx`
- `apps/web/components/nova/nova-empty-state.tsx`
- `apps/web/components/onboarding/x-bookmarks-detail-view.tsx`

## Verification

- Isolated a `tsc` probe importing both alias forms against `apps/web/tsconfig.json`: only the `@repo/` form raises TS2307; `@lib/constants` resolves cleanly.
- `@repo/lib/` now has **0** remaining occurrences repo-wide; `@lib/` is already used in 233 places.
- `biome check` passes on all three files.
- No overlap with #1571, which touches a disjoint set of files.

## Scope

This clears 3 of the errors tracked in #1544 — it does not by itself make `check-types` green.
