### PR TITLE
fix(openai-sdk-python): run the requests fallback off the event loop

### DIFF
--- a/packages/openai-sdk-python/src/supermemory_openai/middleware.py
+++ b/packages/openai-sdk-python/src/supermemory_openai/middleware.py
@@ -227,10 +227,12 @@ async def supermemory_profile_search(
                 return SupermemoryProfileSearch(data)
 
     except ImportError:
-        # Fallback to requests if aiohttp not available
+        # Fallback to requests if aiohttp not available. requests blocks, so it
+        # runs on a worker thread to keep the caller's event loop free.
         import requests
 
-        response = requests.post(
+        response = await asyncio.to_thread(
+            requests.post,
             profile_url,
             headers={
                 "Content-Type": "application/json",

--- a/packages/openai-sdk-python/tests/test_middleware.py
+++ b/packages/openai-sdk-python/tests/test_middleware.py
@@ -1,8 +1,11 @@
 """Tests for middleware module."""
 
 import os
+import sys
 import pytest
+import requests
 import asyncio
+import threading
 from unittest.mock import AsyncMock, Mock, patch, MagicMock
 from typing import Dict, Any
 
@@ -26,6 +29,7 @@ except ImportError:
         SupermemoryOpenAIWrapper,
     )
 
+from supermemory_openai.middleware import supermemory_profile_search
 from openai import OpenAI, AsyncOpenAI
 from openai.types.chat import ChatCompletion, ChatCompletionMessage
 from openai.types import CompletionUsage
@@ -812,3 +816,37 @@ class TestBackgroundTaskManagement:
                         )
 
                     # Should complete without error
+
+
+class TestProfileSearchFallback:
+    """Test the requests fallback used when aiohttp is not installed."""
+
+    @pytest.mark.asyncio
+    async def test_requests_fallback_does_not_block_event_loop(self):
+        """requests.post must run off the event loop so other tasks keep running."""
+        released = threading.Event()
+
+        def slow_post(*args, **kwargs):
+            # The test sets the event from the event loop, which it can only do
+            # while this call is running somewhere else.
+            if not released.wait(timeout=2):
+                raise AssertionError("requests.post blocked the event loop")
+            response = Mock(status_code=200)
+            response.json.return_value = {
+                "profile": {"static": ["Prefers vegetarian food"], "dynamic": []},
+                "searchResults": {"results": []},
+            }
+            return response
+
+        with patch.dict(sys.modules, {"aiohttp": None}):
+            with patch.object(requests, "post", side_effect=slow_post):
+                search = asyncio.create_task(
+                    supermemory_profile_search(
+                        "user-123", "", "test-key", "https://api.supermemory.ai"
+                    )
+                )
+                await asyncio.sleep(0)
+                released.set()
+                result = await search
+
+        assert result.profile["static"] == ["Prefers vegetarian food"]


### PR DESCRIPTION
supermemory_profile_search is async, but without aiohttp it falls back to requests.post, which holds the event loop for the whole request. aiohttp is only in the `async` extra and requests is a hard dependency, so a plain `pip install supermemory-openai-sdk` always lands on the fallback.

**numbers**

Local server that takes 2s to answer the profile search, with a ticker on the same loop that should fire every 50ms. Longest gap between ticks:

| | default install | with aiohttp |
|---|---|---|
| calling supermemory_profile_search on main | 2.10s | |
| same call with this change | 0.09s | |
| AsyncOpenAI with #1503's dispatch fix | 2.14s | 0.08s |
| AsyncOpenAI with #1503's dispatch fix and this change | 0.14s | |

#1503 fixes which path AsyncOpenAI takes and this fixes the path it lands on, so a default install needs both. #1503's branch is behind main, so I applied its dispatch check to main for those two rows.

**fix**

`await asyncio.to_thread(requests.post, ...)`. to_thread is 3.9+, which matches requires-python.

**test**

test_requests_fallback_does_not_block_event_loop in tests/test_middleware.py forces the fallback by setting aiohttp to None in sys.modules, and makes requests.post wait on an event that only the loop can set. It fails on main with "requests.post blocked the event loop" and passes here. The rest of the package suite is unchanged, 32 passed and 11 skipped.
